### PR TITLE
ci(automerge): override bash -e default

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -22,6 +22,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           MIN_AGE_HOURS: 0
+        # Override the default `bash -e` so per-PR failures don't kill the loop.
+        shell: bash --noprofile --norc {0}
         run: |
           set -uo pipefail
 


### PR DESCRIPTION
Fixes the auto-merge workflow: GitHub Actions injects `bash -e` which made our `set -uo pipefail` ineffective, so the first per-PR error killed the loop. Use `bash --noprofile --norc {0}` to drop -e cleanly.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>