### PR TITLE
chore(deps): @hono/node-server 1.x → 2.x

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -43,12 +43,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.2.tgz",
+      "integrity": "sha512-tXlTi1h/4V7sDe7i97IVP+9re9ZU7wXZZggnR5ucCRclf1+AX6YhGStrR5w8bLj+3Mlyl0pKfBh9gqTqqnGKfQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -46,6 +46,6 @@
     "fast-uri": "^3.1.2",
     "hono": "^4.12.18",
     "ip-address": "^10.2.0",
-    "@hono/node-server": "^1.19.14"
+    "@hono/node-server": "^2.0.2"
   }
 }


### PR DESCRIPTION
Major-bump of the transitively-used HTTP server. Not imported directly; the smoke test exercises the MCP Streamable HTTP path end-to-end, which is the layer that would break if v2 broke anything we rely on.

- v2 peerDep `hono ^4` ✅ (we pin ^4.12.18)
- engines node >= 20 ✅
- 0 npm-audit findings after regen

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>