### PR TITLE
ci: release via PR instead of direct main push

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,5 +1,11 @@
 name: Auto-release (weekly)
 
+# Opens a "chore(release): vX.Y.Z" PR instead of pushing to main directly,
+# so the change goes through the same required-status-checks (smoke,
+# unit-tests, npm-audit, trivy, analyze) as any other commit. The tag
+# and downstream release/publish workflows fire from tag-on-release.yml
+# once the PR merges.
+
 on:
   schedule:
     - cron: '0 23 * * 0'
@@ -7,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:
@@ -15,7 +22,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Check for new commits since last tag
         id: check
@@ -43,26 +49,32 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Run unit tests
+      - name: Bump patch version
         if: steps.check.outputs.skip != 'true'
+        id: bump
         working-directory: ./mcp-server
         run: |
-          npm ci
-          npx tsx --test src/analysis/*.test.ts src/config/*.test.ts
-
-      - name: Bump patch version and tag
-        if: steps.check.outputs.skip != 'true'
-        run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          cd mcp-server
           new_version=$(npm version patch --no-git-tag-version)
-          cd ..
+          echo "new_version=${new_version}" >> "$GITHUB_OUTPUT"
+          echo "bumped to ${new_version}"
 
-          git add mcp-server/package.json mcp-server/package-lock.json
-          git commit -m "chore(release): ${new_version}"
-          git tag "${new_version}"
-          git push origin main
-          git push origin "${new_version}"
+      - name: Open release PR
+        if: steps.check.outputs.skip != 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          commit-message: "chore(release): ${{ steps.bump.outputs.new_version }}"
+          title: "chore(release): ${{ steps.bump.outputs.new_version }}"
+          body: |
+            Automated weekly release.
+
+            - Bumps `mcp-server/package.json` to `${{ steps.bump.outputs.new_version }}`
+            - Previous tag: `${{ steps.check.outputs.last_tag }}`
+            - Merging this PR triggers `tag-on-release.yml`, which pushes the tag and fans out to `release.yml`, `docker-publish.yml`, and `npm-publish.yml`.
+          branch: release/${{ steps.bump.outputs.new_version }}
+          delete-branch: true
+          add-paths: |
+            mcp-server/package.json
+            mcp-server/package-lock.json
+          labels: release,automated

--- a/.github/workflows/tag-on-release.yml
+++ b/.github/workflows/tag-on-release.yml
@@ -1,0 +1,54 @@
+name: Tag on release merge
+
+# When a "chore(release): vX.Y.Z" commit lands on main (typically via the
+# PR opened by auto-release.yml), create and push the matching tag. The
+# tag push then triggers release.yml, docker-publish.yml, and
+# npm-publish.yml. Tag refs are not blocked by branch protection on main.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - mcp-server/package.json
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Check commit message and create tag
+        run: |
+          set -euo pipefail
+          msg=$(git log -1 --pretty=%s)
+          echo "head subject: $msg"
+          if ! [[ "$msg" =~ ^chore\(release\):[[:space:]]+v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "not a release commit, skipping"
+            exit 0
+          fi
+          version="v${BASH_REMATCH[1]}"
+
+          # Sanity: the package.json must agree with the commit subject.
+          pkg_version=$(node -p "require('./mcp-server/package.json').version")
+          if [ "v$pkg_version" != "$version" ]; then
+            echo "commit subject ($version) does not match package.json (v$pkg_version)"
+            exit 1
+          fi
+
+          # Don't re-tag if it already exists.
+          if git rev-parse "$version" >/dev/null 2>&1; then
+            echo "tag $version already exists, skipping"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$version" -m "Release $version"
+          git push origin "$version"
+          echo "pushed tag $version"


### PR DESCRIPTION
## Summary
- \`auto-release.yml\` opens a \`chore(release): vX.Y.Z\` PR instead of pushing directly. Required: needed because main is now branch-protected.
- New \`tag-on-release.yml\`: watches main for release-commit subjects and pushes the tag, which fans out to \`release.yml\` / \`docker-publish.yml\` / \`npm-publish.yml\`.

## Why
With required status checks on main, a direct \`git push origin main\` from a GitHub-Actions token fails. The weekly Sunday 23:00 UTC release was going to silently break. Routing through a PR makes the release go through the same gate as any other change (smoke + audit + unit-tests + trivy + analyze).

## Test plan
- [ ] After merge, trigger \`auto-release.yml\` via \`workflow_dispatch\` to verify it opens a PR
- [ ] Merge that PR and verify \`tag-on-release.yml\` pushes the tag
- [ ] Confirm \`release.yml\`, \`docker-publish.yml\`, \`npm-publish.yml\` fire from the tag