### PR TITLE
chore(dependabot): document semantics + trigger rescan

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,7 @@
 version: 2
+# Weekly scans on Monday; major bumps open individual PRs (not grouped).
+# Closed major-bump PRs remain dismissed until a newer version appears
+# or the config is re-validated — touching this file forces a rescan.
 updates:
   - package-ecosystem: npm
     directory: /mcp-server


### PR DESCRIPTION
Tiny edit to .github/dependabot.yml so Dependabot revalidates the config and runs a fresh scan — pulling back the major-bump PRs that were closed earlier without waiting for Monday's weekly cron.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>