### PR TITLE
security: fix CodeQL findings (LogQL escape, log injection, test tmpdirs)

### DIFF
--- a/mcp-server/src/config/loader.test.ts
+++ b/mcp-server/src/config/loader.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { writeFileSync, mkdirSync, rmSync, existsSync } from "node:fs";
+import { writeFileSync, mkdtempSync, rmSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { substituteEnv } from "./loader.js";
@@ -8,11 +8,11 @@ import { substituteEnv } from "./loader.js";
 // We test the helper functions by importing the module fresh with different env vars.
 // Since the config path is resolved at import time, we use dynamic imports.
 
-const TMP_DIR = join(tmpdir(), "observability-mcp-test-" + Date.now());
+let TMP_DIR: string;
 
 describe("config/loader", () => {
   beforeEach(() => {
-    mkdirSync(TMP_DIR, { recursive: true });
+    TMP_DIR = mkdtempSync(join(tmpdir(), "observability-mcp-test-"));
   });
 
   afterEach(() => {

--- a/mcp-server/src/connectors/loki.ts
+++ b/mcp-server/src/connectors/loki.ts
@@ -238,8 +238,9 @@ export class LokiConnector implements ObservabilityConnector {
   }
 
   private escapeLogQLRegex(value: string): string {
-    // Escape backticks which would break the LogQL regex delimiter
-    return value.replace(/`/g, "\\`");
+    // Escape backslash first (so we don't double-escape sequences we add),
+    // then the backtick that delimits LogQL regex literals.
+    return value.replace(/\\/g, "\\\\").replace(/`/g, "\\`");
   }
 
   private buildAuthHeaders(): Record<string, string> {

--- a/mcp-server/src/connectors/registry.ts
+++ b/mcp-server/src/connectors/registry.ts
@@ -2,6 +2,7 @@ import type { ObservabilityConnector } from "./interface.js";
 import type { Config, ConnectorHealth, SignalType, SourceConfig } from "../types.js";
 import { PrometheusConnector } from "./prometheus.js";
 import { LokiConnector } from "./loki.js";
+import { sanitizeForLog } from "../util/sanitize.js";
 
 const connectorFactories: Record<string, () => ObservabilityConnector> = {
   prometheus: () => new PrometheusConnector(),
@@ -26,17 +27,19 @@ export class ConnectorRegistry {
 
   private async connectSource(source: SourceConfig): Promise<void> {
     const factory = connectorFactories[source.type];
+    const safeName = sanitizeForLog(source.name);
+    const safeType = sanitizeForLog(source.type);
     if (!factory) {
-      console.warn(`Unknown connector type: ${source.type}, skipping ${source.name}`);
+      console.warn("Unknown connector type: %s, skipping %s", safeType, safeName);
       return;
     }
     const connector = factory();
     try {
       await connector.connect(source);
       this.connectors.set(source.name, connector);
-      console.log(`Connector "${source.name}" (${source.type}) connected`);
+      console.log('Connector "%s" (%s) connected', safeName, safeType);
     } catch (err) {
-      console.error(`Failed to connect "${source.name}":`, err);
+      console.error('Failed to connect "%s":', safeName, err);
     }
   }
 

--- a/mcp-server/src/connectors/tls.test.ts
+++ b/mcp-server/src/connectors/tls.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { Agent } from "node:https";
-import { writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { buildTlsAgent } from "./tls.js";
 import type { SourceConfig } from "../types.js";
 
-const TMP_DIR = join(tmpdir(), "tls-test-" + Date.now());
+let TMP_DIR: string;
 
 function makeConfig(overrides: Partial<SourceConfig> = {}): SourceConfig {
   return { name: "test", type: "prometheus", url: "https://localhost:9090", enabled: true, ...overrides };
@@ -47,7 +47,7 @@ describe("buildTlsAgent", () => {
 
   describe("with certificate files", () => {
     before(() => {
-      mkdirSync(TMP_DIR, { recursive: true });
+      TMP_DIR = mkdtempSync(join(tmpdir(), "tls-test-"));
       writeFileSync(join(TMP_DIR, "ca.pem"), "-----BEGIN CERTIFICATE-----\nfake-ca\n-----END CERTIFICATE-----\n");
       writeFileSync(join(TMP_DIR, "client.pem"), "-----BEGIN CERTIFICATE-----\nfake-client\n-----END CERTIFICATE-----\n");
       writeFileSync(join(TMP_DIR, "client-key.pem"), "-----BEGIN PRIVATE KEY-----\nfake-key\n-----END PRIVATE KEY-----\n");

--- a/mcp-server/src/tools/get-service-health.ts
+++ b/mcp-server/src/tools/get-service-health.ts
@@ -2,6 +2,7 @@ import type { ConnectorRegistry } from "../connectors/registry.js";
 import type { ServiceHealth, AnomalyReport, HealthThresholds } from "../types.js";
 import { calculateHealthScore } from "../analysis/health.js";
 import { detectRecentAnomaly } from "../analysis/anomaly.js";
+import { sanitizeForLog } from "../util/sanitize.js";
 
 let _thresholds: HealthThresholds | null = null;
 
@@ -54,7 +55,7 @@ export async function getServiceHealthHandler(
       latencyP99 = latResult.summary.current;
       checkAnomaly(latResult.values.map(v => v.value), "latency_p99", args.service, connector.name, anomalies);
     } catch (err) {
-      console.error(`Health check metrics failed for ${args.service}:`, err);
+      console.error("Health check metrics failed for %s:", sanitizeForLog(args.service), err);
     }
   }
 
@@ -80,7 +81,7 @@ export async function getServiceHealthHandler(
         }
       }
     } catch (err) {
-      console.error(`Health check logs failed for ${args.service}:`, err);
+      console.error("Health check logs failed for %s:", sanitizeForLog(args.service), err);
     }
   }
 

--- a/mcp-server/src/util/sanitize.ts
+++ b/mcp-server/src/util/sanitize.ts
@@ -1,0 +1,6 @@
+// Strip CR/LF/control chars from values that flow into log output so a
+// malicious source config can't inject forged log lines, and cap length so
+// pathological inputs don't blow up the log volume.
+export function sanitizeForLog(value: unknown): string {
+  return String(value).replace(/[\r\n\x00-\x1f\x7f]/g, "_").slice(0, 500);
+}


### PR DESCRIPTION
Addresses the relevant CodeQL alerts; non-relevant ones get dismissed in parallel.

## Fixed
- **#49** `js/incomplete-sanitization` — `escapeLogQLRegex` now escapes `\\` before `` ` ``, closing a regex-delimiter break-out
- **#50–52** `js/tainted-format-string` + **#56–60** `js/log-injection` — route user-supplied identifiers through `sanitizeForLog()` and use `%s` placeholders
- **#61–67, #105** `js/insecure-temporary-file` — `mkdtempSync` instead of `join(tmpdir(), name + Date.now())`

## Dismissed (false positives / accepted risk)
- **#55** `js/disabling-certificate-validation` — `rejectUnauthorized: false` is gated on opt-in `tls.skipVerify` (documented feature for self-signed certs)
- **#53, #54** `js/unvalidated-dynamic-method-call` — registry lookup against a fixed factory map with null-check, not a user-controlled method dispatch
- **Scorecard PinnedDependenciesID** — actions pinned by tag, not SHA (Dependabot keeps them current)
- **#68–71** unused/useless-assignment — code-quality noise, not security

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>