### PR TITLE
ui: enterprise design refresh — pass 2 (rows, forms, health)

### DIFF
--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -165,23 +165,53 @@
     }
     .card-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: var(--sp-4); }
     .card-header h2 { font-size: var(--fs-lg); font-weight: 600; letter-spacing: -0.01em; color: var(--text); }
-    .source-row { display: flex; align-items: center; gap: 12px; padding: 12px 14px; border: 1px solid var(--border); border-radius: 6px; margin-bottom: 8px; transition: border-color 0.15s; }
-    .source-row:hover { border-color: var(--accent); }
-    .dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
-    .dot-up { background: var(--green); box-shadow: 0 0 6px var(--green); }
-    .dot-down { background: var(--red); box-shadow: 0 0 6px var(--red); }
-    .dot-disabled { background: var(--text2); }
+    .source-row {
+      display: flex; align-items: center; gap: var(--sp-3);
+      padding: var(--sp-3) var(--sp-4);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      margin-bottom: var(--sp-2);
+      background: var(--surface);
+      transition: background var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease);
+    }
+    .source-row:hover { background: var(--surface-2); border-color: var(--border-strong); }
+    .dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; position: relative; }
+    .dot-up { background: var(--success); box-shadow: 0 0 0 3px var(--success-soft); }
+    .dot-up::after { content: ''; position: absolute; inset: -4px; border-radius: 50%; background: var(--success); opacity: 0.4; animation: pulse 2s var(--ease) infinite; }
+    @keyframes pulse { 0%, 100% { opacity: 0.4; transform: scale(1); } 50% { opacity: 0; transform: scale(1.8); } }
+    .dot-down { background: var(--danger); box-shadow: 0 0 0 3px var(--danger-soft); }
+    .dot-disabled { background: var(--text-dim); box-shadow: 0 0 0 3px rgba(107,114,128,0.15); }
     .source-info { flex: 1; min-width: 0; }
-    .source-info .name { font-weight: 600; font-size: 14px; }
-    .source-info .url { color: var(--text2); font-size: 12px; font-family: monospace; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-    .source-actions { display: flex; gap: 6px; flex-shrink: 0; }
-    .tag { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 500; margin-left: 6px; }
-    .tag-metrics { color: var(--accent); background: #1f6feb1a; border: 1px solid #1f6feb33; }
-    .tag-logs { color: var(--purple); background: #8957e51a; border: 1px solid #8957e533; }
-    .tag-type { color: var(--text2); background: var(--surface2); border: 1px solid var(--border); }
-    .tag-latency { color: var(--text2); font-size: 11px; }
-    .service-row { display: flex; align-items: center; justify-content: space-between; padding: 10px 14px; border: 1px solid var(--border); border-radius: 6px; margin-bottom: 6px; }
-    .service-row .name { font-weight: 600; font-size: 14px; }
+    .source-info .name { font-weight: 600; font-size: var(--fs-lg); letter-spacing: -0.01em; }
+    .source-info .url {
+      color: var(--text-muted); font-size: var(--fs-sm);
+      font-family: 'JetBrains Mono', ui-monospace, monospace; font-variant-ligatures: none;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .source-actions { display: flex; gap: var(--sp-1); flex-shrink: 0; }
+    .tag {
+      display: inline-flex; align-items: center; gap: 4px;
+      padding: 2px 8px;
+      border-radius: var(--radius-pill);
+      font-size: var(--fs-xs); font-weight: 500;
+      letter-spacing: 0.02em;
+      margin-left: 6px;
+    }
+    .tag-metrics { color: var(--accent); background: var(--accent-soft); border: 1px solid rgba(79,140,255,0.25); }
+    .tag-logs    { color: var(--info);   background: var(--info-soft);   border: 1px solid rgba(167,139,250,0.25); }
+    .tag-type    { color: var(--text-muted); background: var(--surface-2); border: 1px solid var(--border-strong); text-transform: capitalize; }
+    .tag-latency { color: var(--text-muted); font-size: var(--fs-xs); font-variant-numeric: tabular-nums; }
+    .service-row {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: var(--sp-3) var(--sp-4);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      margin-bottom: var(--sp-2);
+      background: var(--surface);
+      transition: background var(--t-fast) var(--ease);
+    }
+    .service-row:hover { background: var(--surface-2); }
+    .service-row .name { font-weight: 600; font-size: var(--fs-lg); }
     .btn {
       padding: 7px 14px;
       border-radius: var(--radius-sm);
@@ -209,73 +239,167 @@
     .btn-sm { padding: 4px 10px; font-size: var(--fs-sm); }
     .btn-icon { background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 4px 8px; border-radius: var(--radius-sm); font-size: var(--fs-xl); transition: color var(--t-fast) var(--ease), background var(--t-fast) var(--ease); }
     .btn-icon:hover { background: var(--surface-2); color: var(--text); }
-    .toggle { position: relative; width: 36px; height: 20px; cursor: pointer; }
+    .toggle { position: relative; width: 38px; height: 22px; cursor: pointer; flex-shrink: 0; }
     .toggle input { display: none; }
-    .toggle .slider { position: absolute; inset: 0; background: var(--border); border-radius: 10px; transition: 0.2s; }
-    .toggle .slider::before { content: ''; position: absolute; width: 16px; height: 16px; left: 2px; top: 2px; background: var(--text); border-radius: 50%; transition: 0.2s; }
-    .toggle input:checked + .slider { background: var(--green); }
-    .toggle input:checked + .slider::before { transform: translateX(16px); }
-    .modal-overlay { display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.6); z-index: 100; align-items: center; justify-content: center; }
-    .modal-overlay.open { display: flex; }
-    .modal { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; width: 520px; max-width: 90vw; max-height: 90vh; overflow-y: auto; }
-    .modal-header { display: flex; align-items: center; justify-content: space-between; padding: 16px 20px; border-bottom: 1px solid var(--border); }
-    .modal-header h3 { font-size: 16px; font-weight: 600; }
-    .modal-body { padding: 20px; }
-    .modal-footer { display: flex; justify-content: flex-end; gap: 8px; padding: 16px 20px; border-top: 1px solid var(--border); }
-    .form-group { margin-bottom: 16px; }
-    .form-group label { display: block; font-size: 13px; font-weight: 500; color: var(--text2); margin-bottom: 6px; }
-    .form-group input, .form-group select, .form-group textarea { width: 100%; padding: 8px 12px; background: var(--bg); border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-size: 14px; font-family: inherit; }
-    .form-group input:focus, .form-group select:focus, .form-group textarea:focus { outline: none; border-color: var(--accent); }
-    .form-group select { appearance: none; background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%238b949e'%3E%3Cpath d='M6 8L1 3h10z'/%3E%3C/svg%3E"); background-repeat: no-repeat; background-position: right 12px center; }
-    .form-group textarea { resize: vertical; min-height: 80px; font-family: monospace; font-size: 13px; }
-    .form-hint { font-size: 11px; color: var(--text2); margin-top: 4px; }
-    .form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-    .form-row-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; }
-    .test-result { padding: 10px 14px; border-radius: 6px; font-size: 13px; margin-top: 12px; display: none; }
+    .toggle .slider {
+      position: absolute; inset: 0;
+      background: var(--surface-3);
+      border: 1px solid var(--border-strong);
+      border-radius: var(--radius-pill);
+      transition: background var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease);
+    }
+    .toggle .slider::before {
+      content: ''; position: absolute;
+      width: 16px; height: 16px; left: 2px; top: 2px;
+      background: var(--text);
+      border-radius: 50%;
+      transition: transform var(--t-fast) var(--ease), background var(--t-fast) var(--ease);
+      box-shadow: 0 1px 2px rgba(0,0,0,0.4);
+    }
+    .toggle input:checked + .slider { background: var(--accent); border-color: var(--accent); }
+    .toggle input:checked + .slider::before { transform: translateX(16px); background: #fff; }
+    .toggle:hover .slider { border-color: rgba(255,255,255,0.18); }
+    .modal-overlay {
+      display: none; position: fixed; inset: 0;
+      background: rgba(8,10,15,0.72);
+      backdrop-filter: blur(4px);
+      z-index: 100; align-items: center; justify-content: center;
+    }
+    .modal-overlay.open { display: flex; animation: fadeIn 140ms var(--ease); }
+    .modal {
+      background: var(--surface);
+      border: 1px solid var(--border-strong);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow-lg);
+      width: 560px; max-width: 92vw; max-height: 88vh;
+      overflow-y: auto;
+      animation: modalIn 180ms var(--ease);
+    }
+    @keyframes modalIn { from { opacity: 0; transform: translateY(8px) scale(0.98); } to { opacity: 1; transform: none; } }
+    .modal-header { display: flex; align-items: center; justify-content: space-between; padding: var(--sp-4) var(--sp-5); border-bottom: 1px solid var(--border); }
+    .modal-header h3 { font-size: var(--fs-xl); font-weight: 600; letter-spacing: -0.01em; }
+    .modal-body { padding: var(--sp-5); }
+    .modal-footer { display: flex; justify-content: flex-end; gap: var(--sp-2); padding: var(--sp-4) var(--sp-5); border-top: 1px solid var(--border); background: var(--surface); position: sticky; bottom: 0; }
+    .form-group { margin-bottom: var(--sp-4); }
+    .form-group label { display: block; font-size: var(--fs-sm); font-weight: 500; color: var(--text-muted); margin-bottom: 6px; letter-spacing: 0.02em; }
+    .form-group input, .form-group select, .form-group textarea {
+      width: 100%; padding: 9px 12px;
+      background: var(--bg);
+      border: 1px solid var(--border-strong);
+      border-radius: var(--radius-sm);
+      color: var(--text);
+      font: var(--fs-lg)/1.4 inherit;
+      transition: border-color var(--t-fast) var(--ease), background var(--t-fast) var(--ease), box-shadow var(--t-fast) var(--ease);
+    }
+    .form-group input:hover, .form-group select:hover, .form-group textarea:hover { border-color: rgba(255,255,255,0.16); }
+    .form-group input:focus, .form-group select:focus, .form-group textarea:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px var(--accent-ring);
+    }
+    .form-group select {
+      appearance: none;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%23a1a8b3'%3E%3Cpath d='M2 4l4 4 4-4'/%3E%3C/svg%3E");
+      background-repeat: no-repeat; background-position: right 12px center;
+      padding-right: 36px;
+    }
+    .form-group textarea { resize: vertical; min-height: 96px; font: var(--fs-md)/1.55 'JetBrains Mono', ui-monospace, monospace; }
+    .form-hint { font-size: var(--fs-xs); color: var(--text-dim); margin-top: 6px; line-height: 1.5; }
+    .form-row { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-3); }
+    .form-row-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: var(--sp-3); }
+    .test-result { padding: 10px 14px; border-radius: var(--radius-sm); font-size: var(--fs-md); margin-top: var(--sp-3); display: none; }
     .test-result.show { display: block; }
-    .test-result.success { background: #238636aa; border: 1px solid var(--green); }
-    .test-result.failure { background: #f851491a; border: 1px solid var(--red); color: var(--red); }
-    .endpoint-bar { background: var(--surface2); border: 1px solid var(--border); border-radius: 6px; padding: 10px 16px; font-family: monospace; font-size: 13px; color: var(--accent); margin-bottom: 24px; display: flex; align-items: center; justify-content: space-between; }
-    .empty { color: var(--text2); text-align: center; padding: 32px; }
-    .spinner { display: inline-block; width: 14px; height: 14px; border: 2px solid var(--border); border-top-color: var(--accent); border-radius: 50%; animation: spin 0.6s linear infinite; }
+    .test-result.success { background: var(--success-soft); border: 1px solid rgba(74,222,128,0.30); color: var(--success); }
+    .test-result.failure { background: var(--danger-soft);  border: 1px solid rgba(239,91,110,0.35); color: var(--danger); }
+    .endpoint-bar {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 10px 16px;
+      font: var(--fs-md)/1 'JetBrains Mono', ui-monospace, monospace;
+      color: var(--accent);
+      margin-bottom: var(--sp-6);
+      display: flex; align-items: center; justify-content: space-between;
+    }
+    .endpoint-bar::before { content: 'POST'; display: inline-block; padding: 2px 6px; margin-right: 10px; background: var(--accent-soft); color: var(--accent); border-radius: 3px; font-size: var(--fs-xs); font-weight: 700; font-family: 'Inter var', sans-serif; }
+    .empty { color: var(--text-dim); text-align: center; padding: var(--sp-8) var(--sp-4); font-size: var(--fs-md); }
+    .spinner { display: inline-block; width: 14px; height: 14px; border: 2px solid var(--border-strong); border-top-color: var(--accent); border-radius: 50%; animation: spin 0.6s linear infinite; }
     @keyframes spin { to { transform: rotate(360deg); } }
     /* Tabs inside settings */
-    .tabs { display: flex; gap: 0; border-bottom: 1px solid var(--border); margin-bottom: 20px; }
-    .tab-btn { background: none; border: none; border-bottom: 2px solid transparent; color: var(--text2); padding: 10px 18px; cursor: pointer; font-size: 13px; font-weight: 500; }
+    .tabs { display: flex; gap: 0; border-bottom: 1px solid var(--border); margin-bottom: var(--sp-5); }
+    .tab-btn { background: none; border: none; border-bottom: 2px solid transparent; color: var(--text-muted); padding: 10px 18px; cursor: pointer; font-size: var(--fs-md); font-weight: 500; transition: color var(--t-fast) var(--ease), border-color var(--t-fast) var(--ease); }
     .tab-btn:hover { color: var(--text); }
-    .tab-btn.active { color: var(--accent); border-bottom-color: var(--accent); }
+    .tab-btn.active { color: var(--text); border-bottom-color: var(--accent); }
     .tab-content { display: none; } .tab-content.active { display: block; }
     /* Threshold cards */
-    .threshold-group { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 20px; }
-    .threshold-card { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 14px; }
-    .threshold-card h4 { font-size: 13px; font-weight: 600; margin-bottom: 10px; }
+    .threshold-group { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-4); margin-bottom: var(--sp-5); }
+    .threshold-card { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: var(--sp-4); }
+    .threshold-card h4 { font-size: var(--fs-md); font-weight: 600; margin-bottom: var(--sp-3); letter-spacing: 0.01em; }
     /* Metric table */
     .metric-table { width: 100%; border-collapse: collapse; }
-    .metric-table th { text-align: left; font-size: 12px; color: var(--text2); font-weight: 500; padding: 6px 10px; border-bottom: 1px solid var(--border); }
-    .metric-table td { padding: 8px 10px; border-bottom: 1px solid var(--border); font-size: 13px; }
-    .metric-table .query { font-family: monospace; font-size: 11px; color: var(--text2); max-width: 400px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-    .metric-table tr:hover td { background: var(--surface2); }
-    .toast { position: fixed; bottom: 24px; right: 24px; background: var(--green); color: #fff; padding: 10px 20px; border-radius: 8px; font-size: 13px; font-weight: 500; opacity: 0; transition: opacity 0.3s; pointer-events: none; z-index: 200; }
-    .toast.show { opacity: 1; }
+    .metric-table th { text-align: left; font-size: var(--fs-xs); color: var(--text-muted); font-weight: 500; padding: 8px 10px; border-bottom: 1px solid var(--border-strong); text-transform: uppercase; letter-spacing: 0.06em; }
+    .metric-table td { padding: 10px; border-bottom: 1px solid var(--border); font-size: var(--fs-md); }
+    .metric-table .query { font-family: 'JetBrains Mono', ui-monospace, monospace; font-variant-ligatures: none; font-size: var(--fs-xs); color: var(--text-muted); max-width: 400px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .metric-table tr { transition: background var(--t-fast) var(--ease); }
+    .metric-table tbody tr:hover td { background: var(--surface-2); }
+    .toast {
+      position: fixed; bottom: var(--sp-6); right: var(--sp-6);
+      background: var(--surface);
+      color: var(--text);
+      padding: 12px 18px;
+      border-radius: var(--radius);
+      border: 1px solid var(--border-strong);
+      box-shadow: var(--shadow);
+      font-size: var(--fs-md); font-weight: 500;
+      display: flex; align-items: center; gap: 10px;
+      opacity: 0; transform: translateY(8px);
+      transition: opacity var(--t-fast) var(--ease), transform var(--t-fast) var(--ease);
+      pointer-events: none; z-index: 200;
+    }
+    .toast::before { content: ''; width: 8px; height: 8px; border-radius: 50%; background: var(--success); box-shadow: 0 0 0 3px var(--success-soft); }
+    .toast.show { opacity: 1; transform: none; }
+    .toast.toast-error::before { background: var(--danger); box-shadow: 0 0 0 3px var(--danger-soft); }
     /* Health cards */
-    .health-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 20px; }
-    .health-card .hc-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 14px; }
-    .health-card .hc-name { font-size: 16px; font-weight: 600; }
-    .health-card .hc-score { font-size: 28px; font-weight: 700; }
-    .health-card .hc-score.healthy { color: var(--green); }
-    .health-card .hc-score.degraded { color: var(--yellow); }
-    .health-card .hc-score.critical { color: var(--red); }
-    .health-card .hc-status { display: inline-block; padding: 2px 10px; border-radius: 12px; font-size: 11px; font-weight: 600; text-transform: uppercase; }
-    .hc-status.healthy { background: #23863633; color: var(--green); }
-    .hc-status.degraded { background: #d2992233; color: var(--yellow); }
-    .hc-status.critical { background: #f8514933; color: var(--red); }
-    .hc-metrics { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-top: 12px; }
-    .hc-metric { background: var(--bg); border-radius: 6px; padding: 8px 10px; }
-    .hc-metric .label { font-size: 11px; color: var(--text2); }
-    .hc-metric .val { font-size: 15px; font-weight: 600; margin-top: 2px; }
-    .hc-anomalies { margin-top: 12px; }
-    .hc-anomaly { background: #f851491a; border: 1px solid #f8514933; border-radius: 6px; padding: 8px 10px; margin-top: 6px; font-size: 12px; color: var(--red); }
-    .hc-correlation { background: #d2a8ff1a; border: 1px solid #8957e533; border-radius: 6px; padding: 8px 10px; margin-top: 6px; font-size: 12px; color: var(--purple); }
+    .health-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: var(--sp-5); transition: border-color var(--t-fast) var(--ease); }
+    .health-card:hover { border-color: var(--border-strong); }
+    .health-card .hc-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: var(--sp-4); gap: var(--sp-3); }
+    .health-card .hc-name { font-size: var(--fs-xl); font-weight: 600; letter-spacing: -0.01em; }
+    .health-card .hc-score { font-size: var(--fs-3xl); font-weight: 600; font-variant-numeric: tabular-nums; letter-spacing: -0.02em; line-height: 1; }
+    .health-card .hc-score.healthy  { color: var(--success); }
+    .health-card .hc-score.degraded { color: var(--warning); }
+    .health-card .hc-score.critical { color: var(--danger); }
+    .health-card .hc-status {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 3px 10px;
+      border-radius: var(--radius-pill);
+      font-size: var(--fs-xs); font-weight: 600;
+      text-transform: uppercase; letter-spacing: 0.06em;
+    }
+    .hc-status::before { content: ''; width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+    .hc-status.healthy  { background: var(--success-soft); color: var(--success); border: 1px solid rgba(74,222,128,0.25); }
+    .hc-status.degraded { background: var(--warning-soft); color: var(--warning); border: 1px solid rgba(245,179,65,0.30); }
+    .hc-status.critical { background: var(--danger-soft);  color: var(--danger);  border: 1px solid rgba(239,91,110,0.35); }
+    .hc-metrics { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-2); margin-top: var(--sp-3); }
+    .hc-metric { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 10px 12px; }
+    .hc-metric .label { font-size: var(--fs-xs); color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.06em; font-weight: 500; }
+    .hc-metric .val { font-size: var(--fs-lg); font-weight: 600; margin-top: 4px; font-variant-numeric: tabular-nums; letter-spacing: -0.01em; }
+    .hc-anomalies { margin-top: var(--sp-3); }
+    .hc-anomaly {
+      background: var(--danger-soft);
+      border: 1px solid rgba(239,91,110,0.30);
+      border-left: 3px solid var(--danger);
+      border-radius: var(--radius-sm);
+      padding: 10px 12px; margin-top: 6px;
+      font-size: var(--fs-sm); color: var(--text); line-height: 1.5;
+    }
+    .hc-correlation {
+      background: var(--info-soft);
+      border: 1px solid rgba(167,139,250,0.25);
+      border-left: 3px solid var(--info);
+      border-radius: var(--radius-sm);
+      padding: 10px 12px; margin-top: 6px;
+      font-size: var(--fs-sm); color: var(--text); line-height: 1.5;
+    }
     @media (max-width: 768px) { .stats { grid-template-columns: repeat(2, 1fr); } .threshold-group { grid-template-columns: 1fr; } .form-row, .form-row-3 { grid-template-columns: 1fr; } }
   </style>
 </head>


### PR DESCRIPTION
Continues #45. Markup unchanged; deeper polish using the design tokens.

Sees source-row hover-elevation + pulsing up-dot, modal with backdrop blur + sticky footer + enter animation, forms with accent focus ring + monospace queries, health-card status pill with leading dot, hc-metric/-anomaly/-correlation with elevated surface + accent stripe, toast as notification-card, modern toggle.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>