### PR TITLE
feat(helm): publish workflow + NetworkPolicy + ServiceMonitor

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,62 @@
+name: Publish Helm chart
+
+# Publishes the chart at helm/observability-mcp/ to a gh-pages branch
+# (Helm chart-releaser convention). Operators can then:
+#   helm repo add observability-mcp https://thotischner.github.io/observability-mcp
+#   helm install obs ./observability-mcp/observability-mcp
+#
+# Triggered on tag push (so the chart version matches the app release)
+# or manually. ArtifactHub picks up the index via the gh-pages URL.
+
+on:
+  push:
+    tags: ['v*']
+    paths:
+      - 'helm/**'
+      - '.github/workflows/helm-release.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Lint chart
+        run: helm lint helm/observability-mcp
+
+      - name: Template chart (smoke)
+        run: |
+          helm template smoke helm/observability-mcp \
+            --set sources.prometheusUrl=http://prometheus:9090 \
+            --set ingress.enabled=true \
+            --set auth.enabled=true \
+            --set auth.token=test \
+            --set persistence.enabled=true \
+            --set autoscaling.enabled=true > /tmp/rendered.yaml
+          wc -l /tmp/rendered.yaml
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: helm
+          mark_as_latest: "true"
+          skip_existing: "true"
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/helm/observability-mcp/templates/networkpolicy.yaml
+++ b/helm/observability-mcp/templates/networkpolicy.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "observability-mcp.fullname" . }}
+  labels:
+    {{- include "observability-mcp.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "observability-mcp.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    {{- with .Values.networkPolicy.ingress }}
+    {{- toYaml . | nindent 4 }}
+    {{- else }}
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - port: 3000
+          protocol: TCP
+    {{- end }}
+  egress:
+    {{- with .Values.networkPolicy.egress }}
+    {{- toYaml . | nindent 4 }}
+    {{- else }}
+    # Default-permit DNS; operators should add per-source rules.
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- end }}
+{{- end }}

--- a/helm/observability-mcp/templates/servicemonitor.yaml
+++ b/helm/observability-mcp/templates/servicemonitor.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "observability-mcp.fullname" . }}
+  labels:
+    {{- include "observability-mcp.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "observability-mcp.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path | default "/metrics" }}
+      interval: {{ .Values.serviceMonitor.interval | default "30s" }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout | default "10s" }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/observability-mcp/values.yaml
+++ b/helm/observability-mcp/values.yaml
@@ -144,10 +144,22 @@ probes:
     periodSeconds: 10
     timeoutSeconds: 3
 
-# Optional NetworkPolicy locking egress to declared sources only.
-# Out of scope for the v0.1 skeleton — wire when sources have hostnames.
+# Optional NetworkPolicy.
+# Defaults: ingress from any in-cluster namespace, egress to kube-dns only.
+# Override `ingress`/`egress` with full rule lists for stricter posture.
 networkPolicy:
   enabled: false
+  ingress: []
+  egress: []
+
+# Prometheus Operator ServiceMonitor — only renders if the CRD is installed.
+serviceMonitor:
+  enabled: false
+  path: /metrics
+  interval: 30s
+  scrapeTimeout: 10s
+  labels: {}
+  relabelings: []
 
 # Service account token mounting — disable for stricter pods.
 automountServiceAccountToken: false


### PR DESCRIPTION
Makes the chart from #44 actually publishable to a Helm repo and adds the two enterprise templates that were missing.

- `.github/workflows/helm-release.yml` — lint + template smoke + helm/chart-releaser on tag push or manual dispatch. Pushes to `gh-pages` so `helm repo add observability-mcp https://thotischner.github.io/observability-mcp` works.
- `templates/networkpolicy.yaml` — off by default; ingress + egress accept full rule lists.
- `templates/servicemonitor.yaml` — only renders when `monitoring.coreos.com/v1` CRD is present.

Lint + template green for default + flags.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>