### PR TITLE
feat(plugins): PluginLoader replaces connectorFactories — roadmap PR 2

### DIFF
--- a/mcp-server/src/connectors/loader.ts
+++ b/mcp-server/src/connectors/loader.ts
@@ -1,0 +1,181 @@
+import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import type { ObservabilityConnector } from "./interface.js";
+import type { ConnectorFactory, ConnectorManifest } from "../sdk/index.js";
+import { PrometheusConnector } from "./prometheus.js";
+import { LokiConnector } from "./loki.js";
+import { sanitizeForLog } from "../util/sanitize.js";
+
+export interface LoadedConnector {
+  /** Connector type id, e.g. "prometheus". Matches `source.type` in sources.yaml. */
+  name: string;
+  /** Where this connector came from (debug + UI display). */
+  source: "builtin" | "filesystem" | "config";
+  /** Optional metadata for plugins that ship a manifest.json. */
+  manifest?: ConnectorManifest;
+  factory: ConnectorFactory;
+}
+
+/**
+ * Resolves which connector implementations the server should know about,
+ * applying three sources in order (later overrides earlier):
+ *   1. builtin shim — Prometheus/Loki bundled with the server
+ *   2. filesystem  — every subdir of PLUGINS_DIR with a valid package.json
+ *   3. config-pinned — `plugins:` block in sources.yaml (not yet wired)
+ *
+ * The legacy `connectorFactories` map in registry.ts can be replaced
+ * with this loader's output without changing observable behaviour.
+ */
+export class PluginLoader {
+  private connectors = new Map<string, LoadedConnector>();
+  private pluginsDir: string;
+
+  constructor(opts: { pluginsDir?: string } = {}) {
+    this.pluginsDir = opts.pluginsDir
+      ?? process.env.PLUGINS_DIR
+      ?? "/app/plugins";
+  }
+
+  async load(): Promise<void> {
+    this.loadBuiltins();
+    await this.loadFilesystem();
+  }
+
+  list(): LoadedConnector[] {
+    return Array.from(this.connectors.values());
+  }
+
+  get(name: string): LoadedConnector | undefined {
+    return this.connectors.get(name);
+  }
+
+  has(name: string): boolean {
+    return this.connectors.has(name);
+  }
+
+  supportedTypes(): string[] {
+    return Array.from(this.connectors.keys());
+  }
+
+  /** Create a fresh instance of a connector. Returns undefined for unknown types. */
+  create(name: string): ObservabilityConnector | undefined {
+    const entry = this.connectors.get(name);
+    if (!entry) return undefined;
+    const c = entry.factory();
+    if (c instanceof Promise) {
+      // For now connectors are sync-constructed; if a plugin returns a
+      // Promise we await it lazily in the consumer. Document if/when
+      // this becomes a real pattern.
+      throw new Error(`Connector ${name} returned a Promise; async factories not yet wired`);
+    }
+    return c;
+  }
+
+  private loadBuiltins(): void {
+    this.register({
+      name: "prometheus",
+      source: "builtin",
+      factory: () => new PrometheusConnector(),
+    });
+    this.register({
+      name: "loki",
+      source: "builtin",
+      factory: () => new LokiConnector(),
+    });
+  }
+
+  private async loadFilesystem(): Promise<void> {
+    const dir = this.pluginsDir;
+    if (!existsSync(dir)) return;
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const pluginRoot = join(dir, entry);
+      try {
+        if (!statSync(pluginRoot).isDirectory()) continue;
+        await this.loadFilesystemPlugin(pluginRoot);
+      } catch (err) {
+        console.warn("Failed to load plugin %s: %s", sanitizeForLog(entry), sanitizeForLog(String(err)));
+      }
+    }
+  }
+
+  private async loadFilesystemPlugin(pluginRoot: string): Promise<void> {
+    const pkgPath = join(pluginRoot, "package.json");
+    if (!existsSync(pkgPath)) return;
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as {
+      main?: string;
+      observabilityMcp?: { kind?: string; name?: string; manifest?: string };
+    };
+    const marker = pkg.observabilityMcp;
+    if (!marker || marker.kind !== "connector" || !marker.name) return;
+
+    let manifest: ConnectorManifest | undefined;
+    if (marker.manifest) {
+      const manifestPath = resolve(pluginRoot, marker.manifest);
+      if (existsSync(manifestPath)) {
+        manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as ConnectorManifest;
+        if (manifest.schemaVersion !== 1) {
+          console.warn(
+            "Plugin %s declares unsupported manifest schemaVersion %s; skipping",
+            sanitizeForLog(marker.name),
+            sanitizeForLog(String(manifest.schemaVersion))
+          );
+          return;
+        }
+      }
+    }
+
+    const entryFile = pkg.main || "index.js";
+    const entryPath = resolve(pluginRoot, entryFile);
+    if (!existsSync(entryPath)) {
+      console.warn("Plugin %s missing entry file %s", sanitizeForLog(marker.name), sanitizeForLog(entryFile));
+      return;
+    }
+    const mod = await import(pathToFileURL(entryPath).href);
+    const factory: ConnectorFactory | undefined = mod.default ?? mod.createConnector;
+    if (typeof factory !== "function") {
+      console.warn("Plugin %s has no default export factory", sanitizeForLog(marker.name));
+      return;
+    }
+    this.register({
+      name: marker.name,
+      source: "filesystem",
+      manifest,
+      factory,
+    });
+    console.log(
+      'Connector plugin "%s" loaded from %s',
+      sanitizeForLog(marker.name),
+      sanitizeForLog(pluginRoot)
+    );
+  }
+
+  private register(entry: LoadedConnector): void {
+    // Later sources override earlier ones; current call order is
+    // builtin → filesystem → config-pinned, matching the design doc.
+    this.connectors.set(entry.name, entry);
+  }
+}
+
+/**
+ * Singleton loader populated at server startup. The registry consults
+ * this for connector creation. Tests may swap in their own instance
+ * with `setPluginLoader`.
+ */
+let activeLoader: PluginLoader | null = null;
+
+export function getPluginLoader(): PluginLoader {
+  if (!activeLoader) activeLoader = new PluginLoader();
+  return activeLoader;
+}
+
+export function setPluginLoader(loader: PluginLoader): void {
+  activeLoader = loader;
+}

--- a/mcp-server/src/connectors/registry.ts
+++ b/mcp-server/src/connectors/registry.ts
@@ -1,21 +1,20 @@
 import type { ObservabilityConnector } from "./interface.js";
 import type { Config, ConnectorHealth, SignalType, SourceConfig } from "../types.js";
-import { PrometheusConnector } from "./prometheus.js";
-import { LokiConnector } from "./loki.js";
+import { getPluginLoader, type PluginLoader } from "./loader.js";
 import { sanitizeForLog } from "../util/sanitize.js";
 
-const connectorFactories: Record<string, () => ObservabilityConnector> = {
-  prometheus: () => new PrometheusConnector(),
-  loki: () => new LokiConnector(),
-};
-
 export function getSupportedTypes(): string[] {
-  return Object.keys(connectorFactories);
+  return getPluginLoader().supportedTypes();
 }
 
 export class ConnectorRegistry {
   private connectors: Map<string, ObservabilityConnector> = new Map();
   private sourceConfigs: Map<string, SourceConfig> = new Map();
+  private loader: PluginLoader;
+
+  constructor(loader: PluginLoader = getPluginLoader()) {
+    this.loader = loader;
+  }
 
   async initialize(config: Config): Promise<void> {
     for (const source of config.sources) {
@@ -26,14 +25,13 @@ export class ConnectorRegistry {
   }
 
   private async connectSource(source: SourceConfig): Promise<void> {
-    const factory = connectorFactories[source.type];
+    const connector = this.loader.create(source.type);
     const safeName = sanitizeForLog(source.name);
     const safeType = sanitizeForLog(source.type);
-    if (!factory) {
+    if (!connector) {
       console.warn("Unknown connector type: %s, skipping %s", safeType, safeName);
       return;
     }
-    const connector = factory();
     try {
       await connector.connect(source);
       this.connectors.set(source.name, connector);
@@ -65,11 +63,10 @@ export class ConnectorRegistry {
   }
 
   async testConnection(source: SourceConfig): Promise<ConnectorHealth> {
-    const factory = connectorFactories[source.type];
-    if (!factory) {
+    const connector = this.loader.create(source.type);
+    if (!connector) {
       return { status: "down", latencyMs: 0, message: `Unknown type: ${source.type}` };
     }
-    const connector = factory();
     try {
       await connector.connect(source);
       const health = await connector.healthCheck();
@@ -103,5 +100,4 @@ export class ConnectorRegistry {
     }
     return results;
   }
-
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -6,6 +6,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { z } from "zod";
 import { loadConfig, saveConfig, DEFAULT_HEALTH_THRESHOLDS, DEFAULT_SETTINGS } from "./config/loader.js";
 import { ConnectorRegistry, getSupportedTypes } from "./connectors/registry.js";
+import { getPluginLoader } from "./connectors/loader.js";
 import { listSourcesHandler } from "./tools/list-sources.js";
 import { listServicesHandler } from "./tools/list-services.js";
 import { queryMetricsHandler } from "./tools/query-metrics.js";
@@ -58,6 +59,7 @@ function validateSourceUrl(url: string): string | null {
 
 async function main() {
   let config = loadConfig();
+  await getPluginLoader().load();
   const registry = new ConnectorRegistry();
   await registry.initialize(config);
   applyConfigToRuntime(config, registry);


### PR DESCRIPTION
Step 2 of the plugin roadmap from #46.

New `connectors/loader.ts` resolves connectors from three sources in order: builtin shim (current Prometheus + Loki, unchanged), filesystem scan of `PLUGINS_DIR` (default `/app/plugins`), and config-pinned (placeholder for step 3).

`registry.ts` now asks the loader to create connectors instead of a private factory map. Behaviour for existing users is unchanged — same connectors load via the builtin shim. Plugin authors can already drop a package with `observabilityMcp: { kind: "connector", name, manifest }` into `/app/plugins` and it'll be picked up at startup.

Unit tests pass; `npx tsc --noEmit` clean.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>