### PR TITLE
feat(plugins): Zod manifest validation + PLUGINS_DISABLED — roadmap PR 3

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,7 +40,7 @@ jobs:
         run: npm ci
       - name: Run tests
         working-directory: ./mcp-server
-        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts
+        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts
 
   trivy:
     runs-on: ubuntu-latest

--- a/mcp-server/src/connectors/loader.ts
+++ b/mcp-server/src/connectors/loader.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from "node:url";
 
 import type { ObservabilityConnector } from "./interface.js";
 import type { ConnectorFactory, ConnectorManifest } from "../sdk/index.js";
+import { manifestSchema } from "../sdk/manifest-schema.js";
 import { PrometheusConnector } from "./prometheus.js";
 import { LokiConnector } from "./loki.js";
 import { sanitizeForLog } from "../util/sanitize.js";
@@ -32,10 +33,18 @@ export class PluginLoader {
   private connectors = new Map<string, LoadedConnector>();
   private pluginsDir: string;
 
-  constructor(opts: { pluginsDir?: string } = {}) {
+  private disabled: Set<string>;
+
+  constructor(opts: { pluginsDir?: string; disabled?: string[] } = {}) {
     this.pluginsDir = opts.pluginsDir
       ?? process.env.PLUGINS_DIR
       ?? "/app/plugins";
+    // Per-plugin disable via env: PLUGINS_DISABLED="prometheus,loki"
+    const envDisabled = (process.env.PLUGINS_DISABLED ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    this.disabled = new Set([...(opts.disabled ?? []), ...envDisabled]);
   }
 
   async load(): Promise<void> {
@@ -120,12 +129,25 @@ export class PluginLoader {
     if (marker.manifest) {
       const manifestPath = resolve(pluginRoot, marker.manifest);
       if (existsSync(manifestPath)) {
-        manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as ConnectorManifest;
-        if (manifest.schemaVersion !== 1) {
+        const raw = JSON.parse(readFileSync(manifestPath, "utf8"));
+        const parsed = manifestSchema.safeParse(raw);
+        if (!parsed.success) {
+          const issues = parsed.error.issues
+            .map((i) => `${i.path.join(".")}: ${i.message}`)
+            .join("; ");
           console.warn(
-            "Plugin %s declares unsupported manifest schemaVersion %s; skipping",
+            "Plugin %s has invalid manifest.json — %s; skipping",
             sanitizeForLog(marker.name),
-            sanitizeForLog(String(manifest.schemaVersion))
+            sanitizeForLog(issues)
+          );
+          return;
+        }
+        manifest = parsed.data;
+        if (manifest.name !== marker.name) {
+          console.warn(
+            "Plugin %s package.json marker name does not match manifest.json (%s); skipping",
+            sanitizeForLog(marker.name),
+            sanitizeForLog(manifest.name)
           );
           return;
         }
@@ -158,6 +180,10 @@ export class PluginLoader {
   }
 
   private register(entry: LoadedConnector): void {
+    if (this.disabled.has(entry.name)) {
+      console.log("Connector %s disabled via PLUGINS_DISABLED; skipping", sanitizeForLog(entry.name));
+      return;
+    }
     // Later sources override earlier ones; current call order is
     // builtin → filesystem → config-pinned, matching the design doc.
     this.connectors.set(entry.name, entry);

--- a/mcp-server/src/sdk/index.ts
+++ b/mcp-server/src/sdk/index.ts
@@ -12,6 +12,8 @@
 // constraint in their package.json (see docs/plugin-architecture.md).
 
 export type { ObservabilityConnector } from "../connectors/interface.js";
+export { manifestSchema } from "./manifest-schema.js";
+export type { ValidatedConnectorManifest } from "./manifest-schema.js";
 
 export type {
   SignalType,

--- a/mcp-server/src/sdk/manifest-schema.test.ts
+++ b/mcp-server/src/sdk/manifest-schema.test.ts
@@ -1,0 +1,58 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { manifestSchema } from "./manifest-schema.js";
+
+const minimal = {
+  schemaVersion: 1 as const,
+  name: "prometheus",
+  displayName: "Prometheus",
+  version: "1.0.0",
+  description: "PromQL backend",
+  signalTypes: ["metrics" as const],
+};
+
+describe("manifestSchema", () => {
+  it("accepts a minimal valid manifest", () => {
+    const r = manifestSchema.safeParse(minimal);
+    assert.equal(r.success, true);
+  });
+
+  it("rejects schemaVersion != 1", () => {
+    const r = manifestSchema.safeParse({ ...minimal, schemaVersion: 2 });
+    assert.equal(r.success, false);
+  });
+
+  it("rejects non-kebab names", () => {
+    const r = manifestSchema.safeParse({ ...minimal, name: "Prometheus_X" });
+    assert.equal(r.success, false);
+  });
+
+  it("rejects non-semver versions", () => {
+    const r = manifestSchema.safeParse({ ...minimal, version: "v1.0" });
+    assert.equal(r.success, false);
+  });
+
+  it("requires at least one signalType", () => {
+    const r = manifestSchema.safeParse({ ...minimal, signalTypes: [] });
+    assert.equal(r.success, false);
+  });
+
+  it("rejects unknown signalType", () => {
+    const r = manifestSchema.safeParse({ ...minimal, signalTypes: ["spans"] });
+    assert.equal(r.success, false);
+  });
+
+  it("accepts a fully-populated manifest", () => {
+    const full = {
+      ...minimal,
+      homepage: "https://example.com/connector-prom",
+      license: "MIT",
+      logo: "./logo.svg",
+      configSchema: { type: "object" },
+      capabilities: { queryMetrics: true, listServices: true },
+      compat: { serverVersion: ">=1.4.0" },
+    };
+    const r = manifestSchema.safeParse(full);
+    assert.equal(r.success, true);
+  });
+});

--- a/mcp-server/src/sdk/manifest-schema.ts
+++ b/mcp-server/src/sdk/manifest-schema.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+// Zod schema for connector plugin manifests. Mirror of the TS type in
+// ./index.ts (ConnectorManifest); kept here so both server and plugin
+// authors can import and validate at runtime.
+//
+// Bumping `schemaVersion` is a breaking change for the plugin contract.
+// See docs/plugin-architecture.md for the deprecation policy.
+
+export const manifestSchema = z.object({
+  schemaVersion: z.literal(1),
+  name: z.string().min(1).regex(/^[a-z][a-z0-9-]*$/, {
+    message: "name must be kebab-case lowercase ASCII",
+  }),
+  displayName: z.string().min(1),
+  version: z.string().regex(/^\d+\.\d+\.\d+(-[a-z0-9.-]+)?$/, {
+    message: "version must be semver",
+  }),
+  description: z.string().min(1),
+  signalTypes: z.array(z.enum(["metrics", "logs", "traces"])).min(1),
+  homepage: z.string().url().optional(),
+  license: z.string().optional(),
+  logo: z.string().optional(),
+  configSchema: z.unknown().optional(),
+  capabilities: z
+    .object({
+      queryMetrics: z.boolean().optional(),
+      queryLogs: z.boolean().optional(),
+      listServices: z.boolean().optional(),
+      listAvailableMetrics: z.boolean().optional(),
+    })
+    .optional(),
+  compat: z
+    .object({
+      serverVersion: z.string().optional(),
+    })
+    .optional(),
+});
+
+export type ValidatedConnectorManifest = z.infer<typeof manifestSchema>;


### PR DESCRIPTION
Step 3 of the plugin roadmap from #46.

- `sdk/manifest-schema.ts` — Zod schema mirroring `ConnectorManifest`, re-exported from the SDK barrel so plugin authors can validate their own manifest before shipping.
- Loader now uses the schema. Invalid manifests are rejected at load time with a precise issue list. Manifest `name` cross-checked against the `observabilityMcp.name` marker in `package.json`.
- `PLUGINS_DISABLED="name1,name2"` env short-circuits register. Lets airgapped operators ship a bundle and turn one connector off without rebuilding the image.
- CI unit-tests now run `src/sdk/*.test.ts` too.

7 unit tests for the schema; full suite green.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>