### PR TITLE
feat(metrics): /metrics Prometheus endpoint for self-monitoring

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -12,6 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.12.0",
         "express": "^5.2.1",
         "js-yaml": "^4.1.0",
+        "prom-client": "^15.1.0",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -92,6 +93,15 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@types/body-parser": {
@@ -250,6 +260,12 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -1017,6 +1033,19 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1271,6 +1300,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/toidentifier": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -33,6 +33,7 @@
     "@modelcontextprotocol/sdk": "^1.12.0",
     "express": "^5.2.1",
     "js-yaml": "^4.1.0",
+    "prom-client": "^15.1.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { loadConfig, saveConfig, DEFAULT_HEALTH_THRESHOLDS, DEFAULT_SETTINGS } from "./config/loader.js";
 import { ConnectorRegistry, getSupportedTypes } from "./connectors/registry.js";
 import { getPluginLoader } from "./connectors/loader.js";
+import { selfRegistry } from "./metrics/self.js";
 import { listSourcesHandler } from "./tools/list-sources.js";
 import { listServicesHandler } from "./tools/list-services.js";
 import { queryMetricsHandler } from "./tools/query-metrics.js";
@@ -155,6 +156,17 @@ async function main() {
     res.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
     next();
   });
+
+  // Self-monitoring — Prometheus scrape endpoint.
+  // Disabled with METRICS_ENABLED=false for environments that prefer
+  // sidecar agents. The Helm chart's ServiceMonitor template targets
+  // this endpoint when enabled.
+  if (process.env.METRICS_ENABLED !== "false") {
+    app.get("/metrics", async (_req, res) => {
+      res.set("Content-Type", selfRegistry.contentType);
+      res.end(await selfRegistry.metrics());
+    });
+  }
 
   // Serve Web UI
   app.use(express.static(join(__dirname, "ui")));

--- a/mcp-server/src/metrics/self.ts
+++ b/mcp-server/src/metrics/self.ts
@@ -1,0 +1,76 @@
+// Server self-metrics exposed at /metrics for Prometheus scraping.
+// Pairs with the Helm chart's ServiceMonitor template.
+//
+// Default Node metrics (CPU, memory, event loop lag, heap) come from
+// prom-client's collectDefaultMetrics. On top of that we ship four
+// product-specific counters/histograms that operators actually need
+// to graph: MCP tool calls, connector backend calls, /api/* requests,
+// active session count.
+
+import {
+  Registry,
+  collectDefaultMetrics,
+  Counter,
+  Histogram,
+  Gauge,
+} from "prom-client";
+
+export const selfRegistry = new Registry();
+selfRegistry.setDefaultLabels({ service: "observability-mcp" });
+collectDefaultMetrics({ register: selfRegistry, prefix: "obsmcp_" });
+
+export const mcpToolCalls = new Counter({
+  name: "obsmcp_mcp_tool_calls_total",
+  help: "MCP tool invocations by tool and outcome.",
+  labelNames: ["tool", "outcome"] as const,
+  registers: [selfRegistry],
+});
+
+export const mcpToolLatency = new Histogram({
+  name: "obsmcp_mcp_tool_duration_seconds",
+  help: "MCP tool invocation latency.",
+  labelNames: ["tool"] as const,
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+  registers: [selfRegistry],
+});
+
+export const connectorCalls = new Counter({
+  name: "obsmcp_connector_calls_total",
+  help: "Calls to a configured connector, by source and outcome.",
+  labelNames: ["source", "type", "operation", "outcome"] as const,
+  registers: [selfRegistry],
+});
+
+export const apiRequests = new Counter({
+  name: "obsmcp_api_requests_total",
+  help: "Web UI / API request count, by route and status.",
+  labelNames: ["route", "method", "status"] as const,
+  registers: [selfRegistry],
+});
+
+export const mcpActiveSessions = new Gauge({
+  name: "obsmcp_mcp_active_sessions",
+  help: "Active MCP Streamable HTTP sessions.",
+  registers: [selfRegistry],
+});
+
+/**
+ * Wrap a (potentially async) tool handler to record call count + latency.
+ * Outcome is "ok" or "error" — never throws on its own.
+ */
+export async function withToolMetrics<T>(
+  tool: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const end = mcpToolLatency.startTimer({ tool });
+  try {
+    const r = await fn();
+    mcpToolCalls.inc({ tool, outcome: "ok" });
+    return r;
+  } catch (err) {
+    mcpToolCalls.inc({ tool, outcome: "error" });
+    throw err;
+  } finally {
+    end();
+  }
+}


### PR DESCRIPTION
Pairs with the ServiceMonitor template that #50 added — the chart can now scrape something real.

prom-client v15 (audit-clean), dedicated registry under `obsmcp_` prefix, default Node metrics + four product counters/histograms (tool calls, tool latency, connector calls, API requests, active sessions). Endpoint toggleable via `METRICS_ENABLED=false`.

Instrumentation hooks (`withToolMetrics`) added but not yet wired into handlers — follow-up PR to keep this one small.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>