### PR TITLE
feat(metrics): instrument all connectors via the loader

### DIFF
--- a/mcp-server/src/connectors/loader.ts
+++ b/mcp-server/src/connectors/loader.ts
@@ -7,6 +7,7 @@ import type { ConnectorFactory, ConnectorManifest } from "../sdk/index.js";
 import { PrometheusConnector } from "./prometheus.js";
 import { LokiConnector } from "./loki.js";
 import { sanitizeForLog } from "../util/sanitize.js";
+import { instrumentConnector } from "../metrics/instrument-connector.js";
 
 export interface LoadedConnector {
   /** Connector type id, e.g. "prometheus". Matches `source.type` in sources.yaml. */
@@ -70,7 +71,7 @@ export class PluginLoader {
       // this becomes a real pattern.
       throw new Error(`Connector ${name} returned a Promise; async factories not yet wired`);
     }
-    return c;
+    return instrumentConnector(c);
   }
 
   private loadBuiltins(): void {

--- a/mcp-server/src/metrics/instrument-connector.ts
+++ b/mcp-server/src/metrics/instrument-connector.ts
@@ -1,0 +1,50 @@
+import type { ObservabilityConnector } from "../connectors/interface.js";
+import { connectorCalls } from "./self.js";
+
+type Op =
+  | "healthCheck"
+  | "listServices"
+  | "queryMetrics"
+  | "queryLogs"
+  | "listAvailableMetrics";
+
+const OPS: Op[] = [
+  "healthCheck",
+  "listServices",
+  "queryMetrics",
+  "queryLogs",
+  "listAvailableMetrics",
+];
+
+/**
+ * Decorate a connector so every observable backend call increments
+ * obsmcp_connector_calls_total{source,type,operation,outcome}. The
+ * `source` label is filled in on first `connect()` once the config
+ * is known. Keeps connector implementations free of metrics code.
+ */
+export function instrumentConnector<T extends ObservabilityConnector>(c: T): T {
+  let source = "";
+  const type = c.type;
+  const wrappedConnect = c.connect.bind(c);
+  c.connect = async (config) => {
+    source = config.name;
+    return wrappedConnect(config);
+  };
+
+  for (const op of OPS) {
+    const fn = (c as unknown as Record<Op, undefined | ((...a: unknown[]) => unknown)>)[op];
+    if (typeof fn !== "function") continue;
+    const bound = fn.bind(c);
+    (c as unknown as Record<Op, (...a: unknown[]) => unknown>)[op] = async (...args) => {
+      try {
+        const r = await bound(...args);
+        connectorCalls.inc({ source: source || "<pending>", type, operation: op, outcome: "ok" });
+        return r;
+      } catch (err) {
+        connectorCalls.inc({ source: source || "<pending>", type, operation: op, outcome: "error" });
+        throw err;
+      }
+    };
+  }
+  return c;
+}


### PR DESCRIPTION
Decorator pattern at the loader's `create()` site means every connector (builtin or filesystem plugin) reports `obsmcp_connector_calls_total{source,type,operation,outcome}` for free. No per-connector code changes; plugin authors get instrumentation by virtue of implementing the interface.

Closes the metrics-wiring story started in #54 / #56.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>