### PR TITLE
feat(api): /healthz + /readyz root-level k8s probes

### DIFF
--- a/helm/observability-mcp/values.yaml
+++ b/helm/observability-mcp/values.yaml
@@ -127,22 +127,26 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
-# Liveness / readiness — server exposes /api/health (200 when up).
+# Liveness / readiness — root-level /healthz and /readyz (k8s convention).
+# /healthz returns 200 once the event loop is alive.
+# /readyz returns 200 once the HTTP listener is up; sources are runtime-
+# configurable so source presence is not a readiness signal.
 probes:
   liveness:
     httpGet:
-      path: /api/health
+      path: /healthz
       port: http
     initialDelaySeconds: 10
     periodSeconds: 20
     timeoutSeconds: 3
   readiness:
     httpGet:
-      path: /api/sources
+      path: /readyz
       port: http
-    initialDelaySeconds: 5
-    periodSeconds: 10
+    initialDelaySeconds: 2
+    periodSeconds: 5
     timeoutSeconds: 3
+    failureThreshold: 6
 
 # Optional NetworkPolicy.
 # Defaults: ingress from any in-cluster namespace, egress to kube-dns only.

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -173,6 +173,16 @@ async function main() {
     next();
   });
 
+  // k8s-convention liveness/readiness probes at the root of the path
+  // tree, no /api prefix. Helm chart points its probes here. Cheap
+  // enough to skip the request-counter middleware.
+  let ready = false;
+  app.get("/healthz", (_req, res) => res.type("text").send("ok"));
+  app.get("/readyz", (_req, res) => {
+    if (ready) return res.type("text").send("ok");
+    return res.status(503).type("text").send("starting");
+  });
+
   // Self-monitoring — Prometheus scrape endpoint.
   // Disabled with METRICS_ENABLED=false for environments that prefer
   // sidecar agents. The Helm chart's ServiceMonitor template targets
@@ -508,6 +518,7 @@ async function main() {
 
   const PORT = parseInt(process.env.PORT || "3000");
   app.listen(PORT, () => {
+    ready = true;
     console.log(`observability-mcp server running on port ${PORT}`);
     console.log(`  MCP endpoint: http://localhost:${PORT}/mcp`);
     console.log(`  Web UI: http://localhost:${PORT}`);


### PR DESCRIPTION
K8s convention is /healthz and /readyz at the root. The chart probes were pointing at /api/health and /api/sources, which work but aren't the convention. Adds both endpoints, updates the chart to use them, tightens readiness cadence.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>