### PR TITLE
feat(plugins): ship Prometheus as a filesystem plugin — roadmap step 4

### DIFF
--- a/mcp-server/plugins/prometheus/index.js
+++ b/mcp-server/plugins/prometheus/index.js
@@ -1,0 +1,14 @@
+// Filesystem plugin shim — re-exports the existing built-in
+// implementation so the same code path runs whether the connector is
+// loaded from the builtin registry or from /app/plugins/prometheus.
+//
+// Once we ship the SDK as @thotischner/observability-mcp-sdk on npm
+// (roadmap step 4b), this file will become a real standalone package
+// that imports the SDK and ships its own implementation. For now it
+// lives next to the server it eats its own dogfood from.
+
+import { PrometheusConnector } from "../../dist/connectors/prometheus.js";
+
+export default function create() {
+  return new PrometheusConnector();
+}

--- a/mcp-server/plugins/prometheus/manifest.json
+++ b/mcp-server/plugins/prometheus/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "name": "prometheus",
+  "displayName": "Prometheus",
+  "version": "1.0.0",
+  "description": "PromQL-based metrics backend with prom-client default scrape support and dynamic service-label resolution.",
+  "signalTypes": ["metrics"],
+  "license": "MIT",
+  "capabilities": {
+    "queryMetrics": true,
+    "listServices": true,
+    "listAvailableMetrics": true
+  },
+  "compat": {
+    "serverVersion": ">=1.4.0"
+  }
+}

--- a/mcp-server/plugins/prometheus/package.json
+++ b/mcp-server/plugins/prometheus/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@observability-mcp/connector-prometheus",
+  "version": "1.0.0",
+  "description": "Prometheus connector for observability-mcp.",
+  "private": true,
+  "type": "module",
+  "main": "./index.js",
+  "license": "MIT",
+  "observabilityMcp": {
+    "kind": "connector",
+    "name": "prometheus",
+    "manifest": "./manifest.json"
+  }
+}


### PR DESCRIPTION
Drinks our own dogfood. Adds `mcp-server/plugins/prometheus/` as a real filesystem plugin with package.json marker + manifest.json (validates against the Zod schema from #53) + an index.js that re-exports the built connector.

In the image, the plugin lives at `/app/plugins/prometheus` thanks to the existing `COPY . .` in the Dockerfile. The loader's later-wins semantics mean the filesystem entry overrides the builtin once the server starts; both share the same underlying code so behaviour is unchanged.

The Web UI's /api/info will now show `prometheus` with `source: filesystem` in the deployed image — visible proof the plugin system works.

Follow-up: publish SDK to npm so plugins can import it directly, then drop prometheus from the builtin shim.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>