### PR TITLE
build: pass GIT_COMMIT + BUILD_DATE into image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,6 +64,9 @@ jobs:
           context: ./mcp-server
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.repository.updated_at }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.image.outputs.lower }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ steps.platform.outputs.pair }}
           cache-to: type=gha,mode=max,scope=${{ steps.platform.outputs.pair }}

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,4 +1,21 @@
 FROM node:26-alpine
+
+# Build-time metadata. Both default empty so a bare `docker build` works.
+# CI passes --build-arg GIT_COMMIT=$(git rev-parse HEAD) and BUILD_DATE
+# so /api/info reports them.
+ARG GIT_COMMIT=""
+ARG BUILD_DATE=""
+
+# OCI image labels — picked up by registries and SBOM tooling.
+LABEL org.opencontainers.image.title="observability-mcp" \
+      org.opencontainers.image.description="Unified observability gateway for AI agents." \
+      org.opencontainers.image.source="https://github.com/ThoTischner/observability-mcp" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.revision="${GIT_COMMIT}" \
+      org.opencontainers.image.created="${BUILD_DATE}"
+
+ENV GIT_COMMIT=$GIT_COMMIT BUILD_DATE=$BUILD_DATE
+
 WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm install


### PR DESCRIPTION
Wires the GIT_COMMIT / BUILD_DATE env vars that /api/info (from #59) reads. Adds OCI image labels for registry/SBOM tooling. CI workflow passes `github.sha` and the repo's `updated_at`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>