### PR TITLE
feat(plugins): ship Loki as a filesystem plugin

### DIFF
--- a/mcp-server/plugins/loki/index.js
+++ b/mcp-server/plugins/loki/index.js
@@ -1,0 +1,9 @@
+// Filesystem plugin shim for Loki. See ../prometheus/index.js for the
+// rationale — same pattern, awaiting the SDK npm package before the
+// plugin can stand on its own.
+
+import { LokiConnector } from "../../dist/connectors/loki.js";
+
+export default function create() {
+  return new LokiConnector();
+}

--- a/mcp-server/plugins/loki/manifest.json
+++ b/mcp-server/plugins/loki/manifest.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "name": "loki",
+  "displayName": "Loki",
+  "version": "1.0.0",
+  "description": "LogQL-based log backend with dynamic service-label discovery (service_name / service / job / app / container).",
+  "signalTypes": ["logs"],
+  "license": "MIT",
+  "capabilities": {
+    "queryLogs": true,
+    "listServices": true
+  },
+  "compat": {
+    "serverVersion": ">=1.4.0"
+  }
+}

--- a/mcp-server/plugins/loki/package.json
+++ b/mcp-server/plugins/loki/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@observability-mcp/connector-loki",
+  "version": "1.0.0",
+  "description": "Loki connector for observability-mcp.",
+  "private": true,
+  "type": "module",
+  "main": "./index.js",
+  "license": "MIT",
+  "observabilityMcp": {
+    "kind": "connector",
+    "name": "loki",
+    "manifest": "./manifest.json"
+  }
+}


### PR DESCRIPTION
Mirror of #61 for Loki. /api/info will now report both connectors with `source: filesystem` once the image is rebuilt.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>