### PR TITLE
refactor: docker-compose demo profile

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,11 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build & start the full stack
-        run: docker compose up -d --build --wait --wait-timeout 300
+        # The demo profile pulls in Prometheus, Loki, example services
+        # and the agent so the MCP tool calls have something to talk to.
+        # Operators in production typically `docker compose up mcp-server`
+        # and point at their own backends.
+        run: docker compose --profile demo up -d --build --wait --wait-timeout 300
 
       - name: List running services
         if: always()
@@ -117,4 +121,4 @@ jobs:
 
       - name: Tear down
         if: always()
-        run: docker compose down -v
+        run: docker compose --profile demo down -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,12 @@ This project is fully containerized. **Never run `npm install` on the host machi
 
 ### Quick Start
 ```bash
-docker-compose up --build
+docker compose --profile demo up --build
 ```
 
 All 8 containers start with health checks. Services generate traffic automatically.
+
+Without `--profile demo`, only `mcp-server` runs — for production deployments where Prometheus/Loki are managed elsewhere.
 
 ### Rebuild a Single Service
 ```bash

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ graph TB
 |--------|---------|----------|
 | **npm** | `npx @thotischner/observability-mcp` | Local dev, Node toolchains, zero install |
 | **Docker (GHCR)** | `docker run -p 3000:3000 ghcr.io/thotischner/observability-mcp:latest` | Production, Kubernetes, isolation |
-| **From source** | `git clone … && docker-compose up` | Full POC with example services and chaos |
+| **From source** | `git clone … && docker compose --profile demo up` | Full POC with example services and chaos |
 
 GHCR is multi-arch (amd64 + arm64). Available tags: `latest`, `main`, `X.Y.Z`, `X.Y`, `X`, `sha-<commit>`. Note: the leading `v` is stripped from semver tags.
 
@@ -154,10 +154,12 @@ GRAFANA_PROM_USER=… GRAFANA_LOKI_USER=… GRAFANA_TOKEN=glc_… \
 ```bash
 git clone https://github.com/ThoTischner/observability-mcp.git
 cd observability-mcp
-docker-compose up --build
+docker compose --profile demo up --build
 ```
 
 Boots 8 containers with health checks: 3 example microservices, Prometheus, Loki, Promtail, the MCP server, and the agent. Open `http://localhost:3000`.
+
+Without `--profile demo`, only `mcp-server` starts — useful when you already run Prometheus/Loki elsewhere and just want to expose them via MCP.
 
 ## MCP Tools
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,17 @@
 services:
-  # --- Example Microservices ---
+  # ============================================================
+  # CORE — always runs.
+  # `docker compose up mcp-server` gives a bare server you can point at
+  # your own Prometheus/Loki via the Web UI or env vars.
+  # ------------------------------------------------------------
+  # DEMO PROFILE — `docker compose --profile demo up` adds the example
+  # microservices, Prometheus, Loki, Promtail, and the autonomous agent
+  # so you can see chaos detection end-to-end without external infra.
+  # ============================================================
+
+  # --- Example Microservices (demo) ---
   api-gateway:
+    profiles: ["demo"]
     build:
       context: ./example-services
     environment:
@@ -20,6 +31,7 @@ services:
       - observability
 
   payment-service:
+    profiles: ["demo"]
     build:
       context: ./example-services
     environment:
@@ -39,6 +51,7 @@ services:
       - observability
 
   order-service:
+    profiles: ["demo"]
     build:
       context: ./example-services
     environment:
@@ -57,8 +70,9 @@ services:
     networks:
       - observability
 
-  # --- Observability Stack ---
+  # --- Observability Stack (demo) ---
   prometheus:
+    profiles: ["demo"]
     image: prom/prometheus:v2.53.0
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
@@ -81,6 +95,7 @@ services:
         condition: service_healthy
 
   loki:
+    profiles: ["demo"]
     image: grafana/loki:3.1.0
     volumes:
       - ./loki/loki-config.yml:/etc/loki/local-config.yaml:ro
@@ -99,6 +114,7 @@ services:
       - observability
 
   promtail:
+    profiles: ["demo"]
     image: grafana/promtail:3.1.0
     volumes:
       - ./promtail/promtail-config.yml:/etc/promtail/config.yml:ro
@@ -139,8 +155,9 @@ services:
       loki:
         condition: service_healthy
 
-  # --- AI Agent ---
+  # --- AI Agent (demo) ---
   agent:
+    profiles: ["demo"]
     build:
       context: ./agent
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,11 +149,9 @@ services:
     restart: unless-stopped
     networks:
       - observability
-    depends_on:
-      prometheus:
-        condition: service_healthy
-      loki:
-        condition: service_healthy
+    # No depends_on prometheus/loki — they live in the demo profile and
+    # mcp-server must be able to start standalone (pointing at external
+    # backends or with sources added later via the Web UI).
 
   # --- AI Agent (demo) ---
   agent:


### PR DESCRIPTION
First step of the repo refactor. mcp-server is the only service in the default profile; everything else gates on `--profile demo`. Behaviour for the existing POC is preserved (smoke test uses --profile demo); production operators get a lean `docker compose up mcp-server`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>