### PR TITLE
ci: path-based PR auto-labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,61 @@
+# Path-based PR labels. Picked up by .github/workflows/labeler.yml.
+# Spec: https://github.com/actions/labeler
+
+server:
+  - changed-files:
+      - any-glob-to-any-file: 'mcp-server/src/**'
+
+ui:
+  - changed-files:
+      - any-glob-to-any-file: 'mcp-server/src/ui/**'
+
+connector:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'mcp-server/src/connectors/**'
+          - 'mcp-server/plugins/**'
+          - 'mcp-server/src/sdk/**'
+
+agent:
+  - changed-files:
+      - any-glob-to-any-file: 'agent/**'
+
+helm:
+  - changed-files:
+      - any-glob-to-any-file: 'helm/**'
+
+docker:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'mcp-server/Dockerfile'
+          - 'agent/Dockerfile'
+          - 'example-services/Dockerfile'
+          - 'docker-compose.yml'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file: '.github/workflows/**'
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - 'README.md'
+          - 'CHANGELOG.md'
+          - 'CONTRIBUTING.md'
+          - 'SECURITY.md'
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/package.json'
+          - '**/package-lock.json'
+          - '.github/dependabot.yml'
+
+security:
+  - changed-files:
+      - any-glob-to-any-file: 'SECURITY.md'
+  - head-branch: ['^security/', '^cve/']
+
+release:
+  - head-branch: ['^release/', '^chore/release']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: PR auto-labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true


### PR DESCRIPTION
Auto-applies labels based on changed paths and branch prefixes. Makes the PR list filterable without manual triage.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>