### PR TITLE
feat(helm): chart test pod + ArtifactHub annotations + v0.2.0

### DIFF
--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,7 +4,7 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 0.1.0
+version: 0.2.0
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
@@ -44,3 +44,18 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/operator: "false"
   artifacthub.io/prerelease: "false"
+  artifacthub.io/images: |
+    - name: observability-mcp
+      image: ghcr.io/thotischner/observability-mcp:1.3.4
+      platforms:
+        - linux/amd64
+        - linux/arm64
+  artifacthub.io/changes: |
+    - kind: added
+      description: Helm test pod (`helm test <release>`) that probes /readyz on the service
+    - kind: added
+      description: Optional prometheus.io/scrape annotations on the Service for clusters without prometheus-operator
+    - kind: added
+      description: NOTES.txt with post-install instructions for accessing UI, configuring sources, and Claude Code wiring
+    - kind: added
+      description: artifacthub.io/images and artifacthub.io/changes annotations

--- a/helm/observability-mcp/templates/tests/test-connection.yaml
+++ b/helm/observability-mcp/templates/tests/test-connection.yaml
@@ -1,0 +1,45 @@
+{{- /*
+A throwaway pod that `helm test <release>` runs to verify the service is
+reachable and /readyz responds 200. Doesn't require curl in the app image
+— uses busybox so it stays light and platform-independent.
+*/ -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "observability-mcp.fullname" . }}-test-connection
+  labels:
+    {{- include "observability-mcp.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: probe
+      image: busybox:1.37
+      command:
+        - sh
+        - -c
+        - |
+          set -eu
+          host="{{ include "observability-mcp.fullname" . }}"
+          port="{{ .Values.service.port }}"
+          for i in $(seq 1 30); do
+            if wget -q -O- "http://${host}:${port}/readyz" >/dev/null; then
+              echo "readyz OK"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "readyz never responded"
+          exit 1
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]


### PR DESCRIPTION
## Summary
- Adds `templates/tests/test-connection.yaml` so `helm test <release>` runs a hardened busybox pod that probes `/readyz` on the service (30 attempts × 2s).
- Adds `artifacthub.io/images` (with platforms amd64/arm64) and `artifacthub.io/changes` annotations so the ArtifactHub page lists the container image and a per-version changelog.
- Bumps chart version `0.1.0 → 0.2.0` (NOTES.txt + scrape annotations + these annotations since the initial chart).

## Test plan
- [x] `helm lint helm/observability-mcp` — clean
- [x] `helm template testrel helm/observability-mcp --show-only templates/tests/test-connection.yaml` — renders with correct host:port substitution
- [ ] After merge: `helm install` against a real cluster + `helm test` confirms the probe passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)