### PR TITLE
fix: scrub stray contact email from public surfaces

### DIFF
--- a/.artifacthub-repo.yml
+++ b/.artifacthub-repo.yml
@@ -6,6 +6,6 @@
 repositoryID: ""    # set after first claim — ArtifactHub assigns one
 owners:
   - name: ThoTischner
-    email: info@holzbau-konfigurator.de
+    email: ai-solutions-camp@email.de
 
 ignore: []          # no chart paths to ignore — only helm/observability-mcp/

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for reporting. **Security issues** go to `info@holzbau-konfigurator.de` or a private advisory — see [SECURITY.md](../SECURITY.md). Don't paste vuln details here.
+        Thanks for reporting. **Security issues** go to `ai-solutions-camp@email.de` or a private advisory — see [SECURITY.md](../SECURITY.md). Don't paste vuln details here.
 
   - type: textarea
     id: what

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ path.
 Report privately via one of:
 
 - **GitHub Security Advisories** — preferred. https://github.com/ThoTischner/observability-mcp/security/advisories/new
-- **Email** — `info@holzbau-konfigurator.de`
+- **Email** — `ai-solutions-camp@email.de`
 
 What to include:
 


### PR DESCRIPTION
## Summary
Replaces a stray contact email that leaked into three public files. The previous address belonged to a different project of the maintainer and should not appear in this repo.

- `SECURITY.md` — vulnerability reporting address
- `.artifacthub-repo.yml` — owner email visible on the ArtifactHub repo page
- `.github/ISSUE_TEMPLATE/bug.yml` — security notice on the bug template

All three now use `ai-solutions-camp@email.de`.

## Test plan
- [x] `grep -r holzbau` shows zero matches in tracked files
- [ ] Verify ArtifactHub picks up the new owner on next scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)