### PR TITLE
docs: v1.4.0 changelog + completion-status snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,56 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.4.0] — 2026-05-14
+
 ### Added
+- **Plugin Loader complete (steps 1–5 of the architecture roadmap)** —
+  Prometheus and Loki connectors extracted as filesystem plugins under
+  `mcp-server/plugins/`. The PluginLoader scans `PLUGINS_DIR` (default
+  `/app/plugins`), validates each `manifest.json` against a Zod schema,
+  and falls back to the built-in shim on demand. `PLUGINS_DISABLED`
+  short-circuits selected plugins at runtime.
+- **OpenAPI 3.1 spec** at `/api/openapi.json` describing the operator
+  REST surface (`/api/sources`, `/api/services`, `/api/health`,
+  `/api/settings`, `/api/metrics-config`, `/api/info`, `/metrics`).
+- **Root-level `/healthz` + `/readyz`** for the k8s convention.
+- **`/api/info`** exposes version, build commit/date, plugin inventory,
+  and runtime. The Web UI footer renders this live.
+- **Web UI enterprise refresh — passes 3 + 4.** Left-aligned stat cards
+  with live context sublines (`X/Y connected` color-coded), Overview
+  header with live-pulse indicator, inline SVG sparklines on each
+  health card (30 samples ≈ 7.5 min at 15s refresh).
+- **Helm chart v0.3.0** — `helm test` connection probe, ArtifactHub
+  `images` + `changes` annotations, `values.schema.json` validating
+  `helm install` input before render, NOTES.txt with post-install
+  steps, optional `prometheus.io/scrape` annotations for clusters
+  without prometheus-operator.
+- **Docker image build args** `GIT_COMMIT` and `BUILD_DATE` baked in via
+  Dockerfile ARGs and exposed through `/api/info` build metadata.
+- **SBOM (CycloneDX) and SLSA provenance attestations** attached to
+  every GHCR image via `docker/build-push-action@v7` (`sbom: true`,
+  `provenance: mode=max`).
+- **GitHub issue + PR templates** under `.github/` for bug, feature,
+  connector-request, and config questions.
+- **Path-based PR auto-labeler** with labels server/ui/connector/agent/
+  helm/docker/ci/docs/dependencies/security/release.
+- **Tool/API/session metrics instrumentation** — `obsmcp_tool_calls_total`,
+  `obsmcp_api_requests_total`, `obsmcp_active_sessions`, `obsmcp_connector_calls_total`
+  (per connector via a loader decorator).
+- **Connector-level metrics** wrapped at the loader's `create()` site
+  so connector authors get observability for free.
+- **Web UI server-info footer** populated from `/api/info`.
+- **`Makefile`** with canonical Docker workflows: `make demo`, `make up`,
+  `make test`, `make lint`, `make smoke`, `make release-dryrun`.
+- **`docs/airgapped-deployment.md`** — image mirroring, Sigstore
+  attestation verification, locked-down NetworkPolicy egress, private
+  plugins baked into a derived image, GitOps config.
+- **Docker compose `demo` profile** — `docker compose up` runs only
+  mcp-server by default; `--profile demo` adds Prometheus, Loki,
+  example services and the agent.
+- **Repo refactor** — `examples/agent`, `examples/example-services`,
+  `examples/prometheus`, `examples/loki`, `examples/promtail`. mcp-server
+  is the deliverable, the rest is demo material.
 - **Plugin system foundation** — `mcp-server/src/sdk/` barrel re-exporting the
   connector interface, manifest type, and a Zod schema for runtime validation.
   Filesystem `PluginLoader` (default `/app/plugins`) loads connectors at
@@ -47,6 +96,10 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   against all six core tools.
 
 ### Fixed
+- Contact email in SECURITY.md, .artifacthub-repo.yml, and the bug
+  issue template corrected to `ai-solutions-camp@email.de`.
+- Loki ring init on WSL2/Docker with the upgraded image.
+- Mermaid label crash on certain unicode chars in the docs.
 - Transitive CVEs from `@modelcontextprotocol/sdk` (`fast-uri`, `hono`,
   `ip-address`, `@hono/node-server`) pinned via `npm overrides`.
 - `escapeLogQLRegex` in the Loki connector now escapes backslashes before

--- a/COMPLETION-STATUS.md
+++ b/COMPLETION-STATUS.md
@@ -1,0 +1,86 @@
+# Loop completion status — 2026-05-14
+
+Snapshot of what the long-running `/loop` session accomplished against the six headline tasks, what still needs your hands, and what makes sense for a future round.
+
+## ✅ Done in this loop
+
+### 1. PR queue → release-ready
+~45 PRs merged. Branch-protected, smoke-gated, auto-release plumbed through a `chore(release): vX.Y.Z` PR. Local smoke verified 2026-05-14 (all containers healthy, both sources up, `/api/health` 100/100/100, MCP `tools/list` returns all 6 tools, `error-spike` chaos → `detect_anomalies` finds CPU+latency anomalies).
+
+### 2. UI overhaul → enterprise-ready
+Passes 1–4 merged:
+- **Pass 1** (#45) — Design tokens, Inter variable font, surface hierarchy, base components
+- **Pass 2** (#47) — Source/service row polish, modal interior, modern toggle, toast card
+- **Pass 3** (#71) — Overview header + Live indicator with pulse, left-aligned stat cards with status-colored context sublines (`X/Y connected`, `across N backends`)
+- **Pass 4** (#73) — Inline SVG sparklines on each health card (30 samples ≈ 7.5 min)
+
+### 3. Repo refactor → mcp-server as the product
+Done. Everything demo-only moved under `examples/`:
+```
+examples/
+├── agent/              (#74)
+├── example-services/   (#82)
+├── prometheus/         (#82)
+├── loki/               (#82)
+└── promtail/           (#82)
+```
+`mcp-server/`, `helm/`, `docs/` stay at root. Compose `--profile demo` makes the demo opt-in; default `docker compose up` runs only mcp-server.
+
+### 4. Plugin system → connectors as plugins
+Steps 1–5 of the 8-step roadmap (`docs/plugin-architecture.md`):
+1. ✅ SDK barrel — `mcp-server/src/sdk/`
+2. ✅ `PluginLoader` replaces hardcoded factories
+3. ✅ Zod manifest validation + `PLUGINS_DISABLED` env
+4. ✅ Prometheus as filesystem plugin
+5. ✅ Loki as filesystem plugin
+**Airgapped story:** plugins are tarballs baked into the image — no runtime `npm install`. Documented in `docs/airgapped-deployment.md`.
+
+### 5. Helm chart → ArtifactHub-grade
+Chart v0.3.0 with: Deployment/Service/SA/Ingress/PVC/HPA/Auth-Secret/NetworkPolicy/ServiceMonitor, hardened pod security context, `helm test` connection probe, `values.schema.json`, NOTES.txt, optional scrape annotations, ArtifactHub `images` + `changes` annotations, auto-publish workflow on tag (`gh-pages`).
+
+### 6. MCP-Hub listings → submission pack ready
+Personal guide written at `~/observability-mcp-hub-listing.md` (outside the repo, per your instruction) with copy-paste templates for: modelcontextprotocol/servers, Smithery, mcp.so, mcpservers.org, Glama, PulseMCP, AnyMCP. `smithery.yaml` already in-repo; README badges polished.
+
+## 🟡 Needs your hands (cannot be automated)
+
+| Task | Why it's user-action |
+|---|---|
+| **Trigger the release** | `gh workflow run auto-release.yml` opens a `chore(release): v1.4.0` PR; needs your green light on the version bump |
+| **ArtifactHub submission** | One-time form at artifacthub.io/control-panel; you own the org |
+| **MCP hub submissions** | 7 separate platforms, each with their own PR/form; templates in `~/observability-mcp-hub-listing.md` |
+| **npm publish of the SDK package** | Needs `NPM_TOKEN` secret (or use the existing one); a workflow step has to be added |
+| **Delete abandoned branch** `refactor/agent-under-examples` | Old work that classifier blocked me from cleaning |
+
+## 🔜 Plugin roadmap — remaining steps
+
+These are explicit on the architecture roadmap but not in scope for this loop:
+
+- **Step 6** Publish `@thotischner/observability-mcp-sdk` as its own npm package — needs the workflow + token
+- **Step 7** Sigstore plugin verification (`PLUGIN_REQUIRE_SIGNATURE=true` env) — documented in airgapped guide, real implementation pending
+- **Step 8** Helm init-container that fetches signed plugin tarballs before the main container starts
+- **Step 9** Connector hub catalog (manifest schema + registration flow + UI) — Confluent-Hub-style
+
+## How to verify
+
+```bash
+make demo            # full stack
+make smoke           # local approximation of the CI integration test
+make release-dryrun  # what auto-release would publish
+```
+
+Or for a quick API check after `make demo`:
+
+```bash
+curl -s http://localhost:3000/api/info | jq
+curl -s http://localhost:3000/api/sources | jq
+curl -s http://localhost:3000/api/health | jq
+curl -s http://localhost:3000/api/openapi.json | jq '.paths | keys'
+```
+
+## Memory state
+
+The loop kept its plan in `~/.claude/projects/.../memory/project_loop_plan.md`. Key memories worth keeping:
+- `project-contact` — correct address `ai-solutions-camp@email.de`, not the auto-injected holzbau email
+- `project-host-ports` — this host's :3000 is sometimes occupied; smoke needs port override or coordination
+- `project-cve-strategy` — npm overrides pattern
+- `feedback-docker-first` — everything containerized, no host `npm install`


### PR DESCRIPTION
## Summary
- CHANGELOG draft for v1.4.0 (plugin loader steps 1-5, OpenAPI, /healthz+/readyz, /api/info, UI passes 3+4, Helm v0.3.0, SBOM/SLSA, labeler, metrics, Makefile, airgapped guide, repo refactor)
- `COMPLETION-STATUS.md` — single-page review snapshot: what's done, what needs the user's hands, what's still on the plugin roadmap

The actual version bump in `mcp-server/package.json` is left to `auto-release.yml` (PR-flow with branch protection).

## Test plan
- [x] Markdown renders
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)