### PR TITLE
chore(release): v1.4.0

### DIFF
--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -8,7 +8,7 @@ version: 0.3.0
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
-appVersion: "1.3.4"
+appVersion: "1.4.0"
 
 home: https://github.com/ThoTischner/observability-mcp
 sources:
@@ -46,7 +46,7 @@ annotations:
   artifacthub.io/prerelease: "false"
   artifacthub.io/images: |
     - name: observability-mcp
-      image: ghcr.io/thotischner/observability-mcp:1.3.4
+      image: ghcr.io/thotischner/observability-mcp:1.4.0
       platforms:
         - linux/amd64
         - linux/arm64

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thotischner/observability-mcp",
-      "version": "1.3.4",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Minor release. Major themes since v1.3.4:

- **Plugin Loader complete** (architecture roadmap steps 1–5) — Prometheus + Loki extracted as filesystem plugins, Zod manifest validation, `PLUGINS_DISABLED` runtime env, airgapped story documented.
- **OpenAPI 3.1 spec** at `/api/openapi.json`.
- **`/healthz` + `/readyz`** root probes (k8s convention) + **`/api/info`** with version, plugins, build metadata.
- **UI passes 3 + 4** — left-aligned stat cards with live context lines, Overview header + live pulse indicator, inline SVG sparklines on health cards.
- **Helm chart v0.3.0** — `helm test` probe, `values.schema.json`, NOTES.txt, ArtifactHub `images` + `changes` annotations, optional scrape annotations.
- **Repo refactor** — `agent/`, `example-services/`, `prometheus/`, `loki/`, `promtail/` moved under `examples/`. `mcp-server/`, `helm/`, `docs/` stay at root.
- **SBOM + SLSA provenance** attestations on GHCR images.
- **Tool / API / session / connector metrics** on `/metrics` (`obsmcp_*`).
- **Makefile** with canonical Docker workflows.
- **Airgapped deployment guide** at `docs/airgapped-deployment.md`.
- **Contact email** scrubbed in SECURITY.md, .artifacthub-repo.yml, bug template.

Full notes: `CHANGELOG.md` `## [1.4.0]`.

## Why a manual PR

`auto-release.yml` ran but (a) defaulted to a patch bump (`v1.3.5`) when the scope is clearly minor, and (b) the workflow's `GITHUB_TOKEN` lacks pull-request:write for the PR creation step — known limitation, can be fixed in a follow-up.

This PR is a manual replacement for that automated flow.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Local smoke green (all 6 MCP tools, anomaly detection, /metrics, /api/info)
- [ ] CI smoke green
- [ ] After merge: `tag-on-release.yml` pushes `v1.4.0`, downstream npm + Docker publish workflows fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)