### PR TITLE
fix(ci): release workflow bumps + tag regex + permissions note

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,6 +10,12 @@ on:
   schedule:
     - cron: '0 23 * * 0'
   workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump size (npm version arg)"
+        type: choice
+        options: [patch, minor, major]
+        default: patch
 
 permissions:
   contents: write
@@ -49,16 +55,23 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Bump patch version
+      - name: Bump version
         if: steps.check.outputs.skip != 'true'
         id: bump
         working-directory: ./mcp-server
+        env:
+          # workflow_dispatch supplies inputs.bump; scheduled runs default to patch.
+          BUMP: ${{ github.event.inputs.bump || 'patch' }}
         run: |
           set -euo pipefail
-          new_version=$(npm version patch --no-git-tag-version)
+          new_version=$(npm version "$BUMP" --no-git-tag-version)
           echo "new_version=${new_version}" >> "$GITHUB_OUTPUT"
-          echo "bumped to ${new_version}"
+          echo "bumped to ${new_version} ($BUMP)"
 
+      # NOTE: GITHUB_TOKEN can create PRs only when the repo setting
+      # "Settings → Actions → General → Allow GitHub Actions to create
+      # and approve pull requests" is enabled. If not, set a RELEASE_PAT
+      # repo secret with a PAT scoped to `repo` + `workflow`.
       - name: Open release PR
         if: steps.check.outputs.skip != 'true'
         id: cpr

--- a/.github/workflows/tag-on-release.yml
+++ b/.github/workflows/tag-on-release.yml
@@ -28,7 +28,9 @@ jobs:
           set -euo pipefail
           msg=$(git log -1 --pretty=%s)
           echo "head subject: $msg"
-          if ! [[ "$msg" =~ ^chore\(release\):[[:space:]]+v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+          # Tolerates the "(#NN)" suffix that GitHub appends when the
+          # release PR is squash-merged.
+          if ! [[ "$msg" =~ ^chore\(release\):[[:space:]]+v([0-9]+\.[0-9]+\.[0-9]+)([[:space:]]+\(\#[0-9]+\))?$ ]]; then
             echo "not a release commit, skipping"
             exit 0
           fi


### PR DESCRIPTION
## Summary
Three fixes for the release workflows after observing the v1.4.0 release path live:

1. **tag-on-release.yml** — accept the `(#NN)` suffix GitHub appends on squash-merge. Without this the regex never matched and `v1.4.0` had to be tagged manually.
2. **auto-release.yml** — add a `bump` input (`patch`/`minor`/`major`, default `patch`) so `workflow_dispatch` can pick the right size when the accumulated changes warrant a minor/major bump. Scheduled runs keep the patch default.
3. **auto-release.yml** — note the `GITHUB_TOKEN`/`RELEASE_PAT` requirement for PR creation. The action fails with "Resource not accessible by personal access token" unless the "Allow GitHub Actions to create and approve pull requests" repo setting is enabled (Settings → Actions → General) or `RELEASE_PAT` is configured.

The `gh-pages` branch for `helm-release.yml` was bootstrapped out-of-band — chart-releaser needs it to exist.

## Test plan
- [x] Regex verified locally against `chore(release): v1.4.0 (#84)` and `chore(release): v1.4.0`
- [x] Negative match against unrelated subjects
- [ ] Next scheduled or manually-dispatched release exercises the fixes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)