### PR TITLE
chore: commit .mcp.json for Claude Code auto-detection

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "observability": {
+      "type": "http",
+      "url": "http://localhost:3000/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Drops `.mcp.json` at the repo root so Claude Code auto-discovers the local mcp-server. After `make demo`, contributors can ask Claude to call MCP tools without running `claude mcp add`.

URL is `http://localhost:3000/mcp` to match docker-compose and the README quickstart. If you run on a different port (k8s NodePort, port-forward, etc.) override locally — don't commit your port back.

## Test plan
- [x] JSON valid
- [ ] After merge: `make demo` + open Claude Code in the repo, ask "list sources" → should hit the local server

🤖 Generated with [Claude Code](https://claude.com/claude-code)