### PR TITLE
docs: refresh project structure for examples/ split + Makefile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,30 +60,29 @@ Chaos modes are correlated: error-spike also increases CPU + latency + error log
 ## Project Structure
 
 ```
-mcp-server/src/
-├── index.ts              # Express + MCP server + API endpoints
-├── types.ts              # Shared type definitions
-├── connectors/
-│   ├── interface.ts      # ObservabilityConnector interface (implement this for new backends)
-│   ├── registry.ts       # Connector lifecycle management
-│   ├── prometheus.ts     # Prometheus connector (PromQL, default metrics)
-│   └── loki.ts           # Loki connector (LogQL)
-├── tools/
-│   ├── list-sources.ts   # MCP tool: list backends
-│   ├── list-services.ts  # MCP tool: discover services
-│   ├── query-metrics.ts  # MCP tool: query metrics (with validation)
-│   ├── query-logs.ts     # MCP tool: query logs (with validation)
-│   ├── get-service-health.ts  # MCP tool: aggregated health score
-│   ├── detect-anomalies.ts    # MCP tool: cross-signal anomaly detection
-│   └── validation.ts     # Shared input validation helpers
-├── analysis/
-│   ├── anomaly.ts        # Z-score anomaly detection
-│   ├── health.ts         # Health scoring (configurable thresholds)
-│   └── correlator.ts     # Cross-signal correlation
-├── config/
-│   └── loader.ts         # YAML config loader with defaults
-└── ui/
-    └── index.html        # Single-file Web UI (Dashboard, Sources, Services, Health, Settings)
+.
+├── mcp-server/           # The product — MCP server + Web UI + analysis engine
+│   ├── src/
+│   │   ├── index.ts          # Express + MCP server + /api/* + /healthz + /readyz
+│   │   ├── openapi.ts        # OpenAPI 3.1 spec served at /api/openapi.json
+│   │   ├── types.ts          # Shared types
+│   │   ├── connectors/       # Connector interface + builtin shims + PluginLoader
+│   │   ├── sdk/              # Public SDK barrel + Zod manifest schema for plugins
+│   │   ├── tools/            # 6 MCP tools + shared validation
+│   │   ├── analysis/         # Anomaly detection, health scoring, correlation
+│   │   ├── metrics/          # prom-client self-metrics + connector instrumentation
+│   │   ├── config/           # sources.yaml loader (with ${VAR} substitution)
+│   │   ├── util/             # sanitizeForLog, etc.
+│   │   └── ui/index.html     # Single-file Web UI (Dashboard/Sources/Services/Health/Settings)
+│   └── plugins/              # Filesystem connectors: prometheus/, loki/
+├── helm/observability-mcp/   # ArtifactHub-grade Helm chart (Deployment/HPA/NetworkPolicy/ServiceMonitor/test/values.schema)
+├── examples/                 # Demo material — opt-in via `docker compose --profile demo`
+│   ├── agent/                # Optional autonomous detection agent (uses Ollama)
+│   ├── example-services/     # 3 chaos-able microservices
+│   ├── prometheus/           # Demo Prometheus config
+│   ├── loki/                 # Demo Loki config
+│   └── promtail/             # Demo log shipper
+└── docs/                     # configuration, auth-and-tls, plugin-architecture, airgapped-deployment, ...
 ```
 
 ## Adding a New Connector

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ npx @thotischner/observability-mcp
 
 The server starts with **zero sources**. Add Prometheus/Loki via the Web UI or `PROMETHEUS_URL` / `LOKI_URL` env vars.
 
+Want the full chaos-engineering demo (Prometheus + Loki + 3 example services + the autonomous agent)? Clone and run:
+
+```bash
+make demo   # equivalent to: docker compose --profile demo up --build --wait
+```
+
+See `make help` for all canonical workflows.
+
 ## Why?
 
 Every observability vendor ships its own MCP server — Prometheus, Grafana, Datadog, Elastic, each siloed. AI agents that need to reason across systems must juggle N separate servers. There is no unified abstraction layer.
@@ -77,6 +85,17 @@ graph TB
     style Agent fill:#58a6ff,stroke:#58a6ff,color:#000
     style Next fill:#0d1117,stroke:#3fb950,color:#8b949e,stroke-dasharray: 5 5
 ```
+
+## Repo layout
+
+```
+mcp-server/   # the product — server, Web UI, analysis engine, built-in plugins
+helm/         # ArtifactHub-grade Helm chart
+docs/         # configuration, auth, plugin architecture, airgapped deployment, ...
+examples/     # demo material — agent, example services, Prometheus+Loki configs
+```
+
+`mcp-server/` is what you install. Everything under `examples/` is opt-in via `docker compose --profile demo` — it's how the repo demos chaos detection end-to-end, but production deployments don't need any of it.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
README + CLAUDE.md were written before the repo refactor that moved demo material under `examples/` and before the Makefile landed. Bringing them up to date:

- **CLAUDE.md Project Structure** now shows the top-level layout (`mcp-server/`, `helm/`, `examples/`, `docs/`) and includes the new `mcp-server/src/` subdirs (`sdk/`, `metrics/`, `plugins/`, `util/`).
- **README Try-it-in-10-seconds** mentions `make demo` so newcomers find the canonical demo workflow.
- **README** adds a short "Repo layout" section so the `examples/` split is discoverable.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)