### PR TITLE
feat(plugins): offline fail-closed plugin verification (VERIFY_PLUGINS)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,7 +49,7 @@ jobs:
         run: npm ci
       - name: Run tests
         working-directory: ./mcp-server
-        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts
+        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/connectors/verify.test.ts
 
   trivy:
     runs-on: ubuntu-latest

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -122,7 +122,35 @@ Three supported workflows:
 
 - **Sideloaded tarballs.** For VM / bare-metal deployments, operators `wget <url>` the connector tarball, `tar -xzf` into `/app/plugins/`, restart. The tarball is a published `*.tgz` from the hub (or a mirror) — the same format `npm pack` produces.
 
-Signing: each tarball is accompanied by a sigstore signature published alongside. The server's `--verify-plugins=true` flag (default in prod) checks the signature against a configured trust root before loading.
+### Verification (airgapped trust root)
+
+Plugin verification is **fully offline** — no Fulcio/Rekor, no cosign binary, no network. That is a deliberate choice: a sigstore keyless flow needs to reach a transparency log, which an airgapped site cannot. Instead the server checks a local trust root with Node's built-in crypto.
+
+A plugin is loaded only when **both** hold:
+
+1. **Integrity.** The plugin's `manifest.json` carries an `integrity` field — `sha256-<base64>` of the entry file — and it matches the on-disk entry.
+2. **Authenticity.** A detached signature `manifest.json.sig` (sibling of the manifest) verifies the raw manifest bytes against the configured trust-root public key. Ed25519 and RSA/EC PEM keys are supported; the `.sig` may be raw DER or base64-armored.
+
+Because the signature covers the manifest and the manifest pins the entry-file hash, signing the manifest transitively authenticates the code.
+
+| Setting | Env | Default | Meaning |
+|---------|-----|---------|---------|
+| Verify  | `VERIFY_PLUGINS` | off | When `true/1/yes`, filesystem plugins are gated. |
+| Trust root | `PLUGIN_TRUST_ROOT` | — | Path to the PEM public key. |
+
+**Fail-closed.** With `VERIFY_PLUGINS=true` and no/invalid trust root, *no* filesystem plugin loads (builtin Prometheus/Loki, part of the trusted image, are never gated, so the server stays functional). Any plugin missing a manifest, signature, or failing either check is skipped with a logged reason — it is never loaded "best effort".
+
+Producing the artifacts (offline, from the connector dir):
+
+```bash
+node -e 'const{createHash}=require("crypto"),fs=require("fs");
+  const h="sha256-"+createHash("sha256").update(fs.readFileSync("index.js")).digest("base64");
+  const m=JSON.parse(fs.readFileSync("manifest.json"));m.integrity=h;
+  fs.writeFileSync("manifest.json",JSON.stringify(m,null,2)+"\n")'
+openssl pkeyutl -sign -inkey signing.key -rawin -in manifest.json | base64 > manifest.json.sig
+```
+
+The operator distributes only the **public** key as `PLUGIN_TRUST_ROOT`. The Helm chart sets `VERIFY_PLUGINS=true` and mounts the trust root for any non-builtin plugin (chart wiring is the next milestone). The future connector hub publishes the same `integrity` + detached signature per release, so the hub CLI reuses this exact check.
 
 ## The connector hub
 
@@ -151,7 +179,7 @@ These will be separate PRs so each can pass smoke independently:
 | 3  | Add `PLUGINS_DIR` env, document it. Plugin scan + manifest validation against a Zod schema. Per-plugin enable/disable. |
 | 4  | Publish `@thotischner/observability-mcp-sdk` to npm. Move the prometheus connector into its own package, mark the shim as deprecated. |
 | 5  | Loki connector → own package. |
-| 6  | Sigstore verification (`--verify-plugins`). Document the trust root setup. |
+| 6  | ✅ Offline verification (`VERIFY_PLUGINS` + local trust root) — fail-closed manifest signature + entry integrity. (Local trust root, not sigstore: airgapped sites can't reach a transparency log.) |
 | 7  | Helm chart: `plugins.image` + init container extraction. |
 | 8  | Connector hub catalog repo + minimal static site. |
 

--- a/mcp-server/src/connectors/loader.ts
+++ b/mcp-server/src/connectors/loader.ts
@@ -9,6 +9,13 @@ import { PrometheusConnector } from "./prometheus.js";
 import { LokiConnector } from "./loki.js";
 import { sanitizeForLog } from "../util/sanitize.js";
 import { instrumentConnector } from "../metrics/instrument-connector.js";
+import {
+  loadTrustRoot,
+  verifyIntegrity,
+  verifyManifestSignature,
+  PluginVerificationError,
+} from "./verify.js";
+import type { KeyObject } from "node:crypto";
 
 export interface LoadedConnector {
   /** Connector type id, e.g. "prometheus". Matches `source.type` in sources.yaml. */
@@ -36,7 +43,17 @@ export class PluginLoader {
 
   private disabled: Set<string>;
 
-  constructor(opts: { pluginsDir?: string; disabled?: string[] } = {}) {
+  // Fail-closed verification for filesystem plugins. Builtins are part
+  // of the trusted image and are never gated. Default off so existing
+  // deployments are unchanged; recommended on in prod/airgapped (the
+  // Helm chart sets it).
+  private verify: boolean;
+  private trustRootPath?: string;
+  private trustRoot?: KeyObject;
+
+  constructor(
+    opts: { pluginsDir?: string; disabled?: string[]; verify?: boolean; trustRoot?: string } = {}
+  ) {
     this.pluginsDir = opts.pluginsDir
       ?? process.env.PLUGINS_DIR
       ?? "/app/plugins";
@@ -46,10 +63,33 @@ export class PluginLoader {
       .map((s) => s.trim())
       .filter(Boolean);
     this.disabled = new Set([...(opts.disabled ?? []), ...envDisabled]);
+    this.verify = opts.verify ?? /^(1|true|yes)$/i.test(process.env.VERIFY_PLUGINS ?? "");
+    this.trustRootPath = opts.trustRoot ?? process.env.PLUGIN_TRUST_ROOT;
   }
 
   async load(): Promise<void> {
     this.loadBuiltins();
+    if (this.verify) {
+      if (!this.trustRootPath) {
+        console.warn(
+          "VERIFY_PLUGINS is on but PLUGIN_TRUST_ROOT is unset — refusing to load any filesystem plugins (fail-closed). Builtins remain available."
+        );
+        return;
+      }
+      try {
+        this.trustRoot = loadTrustRoot(this.trustRootPath);
+        console.log(
+          "Plugin verification enabled; trust root loaded from %s",
+          sanitizeForLog(this.trustRootPath)
+        );
+      } catch (err) {
+        console.warn(
+          "VERIFY_PLUGINS is on but trust root failed to load (%s) — refusing to load any filesystem plugins (fail-closed). Builtins remain available.",
+          sanitizeForLog(String(err))
+        );
+        return;
+      }
+    }
     await this.loadFilesystem();
   }
 
@@ -127,10 +167,13 @@ export class PluginLoader {
     if (!marker || marker.kind !== "connector" || !marker.name) return;
 
     let manifest: ConnectorManifest | undefined;
+    let manifestPath: string | undefined;
+    let manifestBytes: Buffer | undefined;
     if (marker.manifest) {
-      const manifestPath = resolve(pluginRoot, marker.manifest);
+      manifestPath = resolve(pluginRoot, marker.manifest);
       if (existsSync(manifestPath)) {
-        const raw = JSON.parse(readFileSync(manifestPath, "utf8"));
+        manifestBytes = readFileSync(manifestPath);
+        const raw = JSON.parse(manifestBytes.toString("utf8"));
         const parsed = manifestSchema.safeParse(raw);
         if (!parsed.success) {
           const issues = parsed.error.issues
@@ -161,6 +204,47 @@ export class PluginLoader {
       console.warn("Plugin %s missing entry file %s", sanitizeForLog(marker.name), sanitizeForLog(entryFile));
       return;
     }
+
+    // Fail-closed verification gate. A plugin only loads under
+    // VERIFY_PLUGINS if it ships a manifest whose `integrity` matches
+    // the entry file AND a detached `<manifest>.sig` that verifies
+    // against the trust root. Everything is local — airgapped-safe.
+    if (this.verify) {
+      if (!manifest || !manifestPath || !manifestBytes) {
+        console.warn(
+          "VERIFY_PLUGINS: plugin %s has no manifest.json — skipping (fail-closed)",
+          sanitizeForLog(marker.name)
+        );
+        return;
+      }
+      const sigPath = manifestPath + ".sig";
+      if (!existsSync(sigPath)) {
+        console.warn(
+          "VERIFY_PLUGINS: plugin %s missing manifest signature %s — skipping (fail-closed)",
+          sanitizeForLog(marker.name),
+          sanitizeForLog(marker.manifest + ".sig")
+        );
+        return;
+      }
+      try {
+        verifyManifestSignature(manifestBytes, readFileSync(sigPath), this.trustRoot!);
+        verifyIntegrity(entryPath, manifest.integrity);
+      } catch (err) {
+        const detail =
+          err instanceof PluginVerificationError ? err.message : String(err);
+        console.warn(
+          "VERIFY_PLUGINS: plugin %s failed verification (%s) — skipping (fail-closed)",
+          sanitizeForLog(marker.name),
+          sanitizeForLog(detail)
+        );
+        return;
+      }
+      console.log(
+        "VERIFY_PLUGINS: plugin %s signature + integrity OK",
+        sanitizeForLog(marker.name)
+      );
+    }
+
     const mod = await import(pathToFileURL(entryPath).href);
     const factory: ConnectorFactory | undefined = mod.default ?? mod.createConnector;
     if (typeof factory !== "function") {

--- a/mcp-server/src/connectors/verify.test.ts
+++ b/mcp-server/src/connectors/verify.test.ts
@@ -1,0 +1,86 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync, sign as cryptoSign, createPublicKey } from "node:crypto";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  sha256Integrity,
+  verifyIntegrity,
+  verifyManifestSignature,
+  loadTrustRoot,
+  PluginVerificationError,
+} from "./verify.js";
+
+function tmp(): string {
+  return mkdtempSync(join(tmpdir(), "verify-"));
+}
+
+test("sha256Integrity produces sha256-<base64> and round-trips", () => {
+  const digest = sha256Integrity(Buffer.from("hello"));
+  assert.match(digest, /^sha256-[A-Za-z0-9+/]+=*$/);
+  assert.equal(sha256Integrity(Buffer.from("hello")), digest);
+  assert.notEqual(sha256Integrity(Buffer.from("hellp")), digest);
+});
+
+test("verifyIntegrity passes on match, throws on mismatch and missing", () => {
+  const dir = tmp();
+  const entry = join(dir, "index.js");
+  writeFileSync(entry, "export default () => ({});\n");
+  const good = sha256Integrity(Buffer.from("export default () => ({});\n"));
+  assert.doesNotThrow(() => verifyIntegrity(entry, good));
+  assert.throws(() => verifyIntegrity(entry, "sha256-AAAA"), PluginVerificationError);
+  assert.throws(() => verifyIntegrity(entry, undefined), PluginVerificationError);
+  assert.throws(() => verifyIntegrity(join(dir, "nope.js"), good), PluginVerificationError);
+});
+
+test("Ed25519: valid signature verifies, tampered manifest is rejected", () => {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const manifest = Buffer.from('{"name":"prometheus","schemaVersion":1}');
+  const sig = cryptoSign(null, manifest, privateKey);
+  assert.doesNotThrow(() => verifyManifestSignature(manifest, sig, publicKey));
+  // base64-armored signature (the form `openssl ... | base64` emits)
+  const armored = Buffer.from(sig.toString("base64"));
+  assert.doesNotThrow(() => verifyManifestSignature(manifest, armored, publicKey));
+  // tampered bytes
+  assert.throws(
+    () => verifyManifestSignature(Buffer.from('{"name":"evil"}'), sig, publicKey),
+    PluginVerificationError
+  );
+});
+
+test("RSA trust root path (algorithm=sha256) verifies", () => {
+  const { publicKey, privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const manifest = Buffer.from('{"name":"loki"}');
+  const sig = cryptoSign("sha256", manifest, privateKey);
+  assert.doesNotThrow(() => verifyManifestSignature(manifest, sig, publicKey));
+});
+
+test("signature from a different key is rejected", () => {
+  const a = generateKeyPairSync("ed25519");
+  const b = generateKeyPairSync("ed25519");
+  const manifest = Buffer.from("payload");
+  const sig = cryptoSign(null, manifest, a.privateKey);
+  assert.throws(
+    () => verifyManifestSignature(manifest, sig, b.publicKey),
+    PluginVerificationError
+  );
+});
+
+test("loadTrustRoot parses PEM and rejects garbage", () => {
+  const dir = tmp();
+  const { publicKey } = generateKeyPairSync("ed25519");
+  const pem = publicKey.export({ type: "spki", format: "pem" }) as string;
+  const p = join(dir, "trust.pem");
+  writeFileSync(p, pem);
+  const loaded = loadTrustRoot(p);
+  assert.equal(
+    loaded.export({ type: "spki", format: "pem" }),
+    createPublicKey(pem).export({ type: "spki", format: "pem" })
+  );
+  const bad = join(dir, "bad.pem");
+  writeFileSync(bad, "not a key");
+  assert.throws(() => loadTrustRoot(bad), PluginVerificationError);
+  assert.throws(() => loadTrustRoot(join(dir, "missing.pem")), PluginVerificationError);
+});

--- a/mcp-server/src/connectors/verify.ts
+++ b/mcp-server/src/connectors/verify.ts
@@ -1,0 +1,95 @@
+import { createHash, createPublicKey, verify as cryptoVerify, type KeyObject } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+// Airgapped-friendly plugin verification.
+//
+// No network, no external binary (no cosign): a plugin is trusted when
+//   1. its entry file hashes to the manifest's `integrity` digest, and
+//   2. the manifest bytes carry a detached signature that verifies
+//      against a locally-configured trust-root public key.
+//
+// Ed25519 and RSA/EC (PKCS#8 / SPKI PEM) trust roots are supported.
+
+export class PluginVerificationError extends Error {}
+
+/** Parse a PEM public key into a KeyObject. Throws PluginVerificationError. */
+export function loadTrustRoot(pemPath: string): KeyObject {
+  let pem: string;
+  try {
+    pem = readFileSync(pemPath, "utf8");
+  } catch (err) {
+    throw new PluginVerificationError(`trust root unreadable at ${pemPath}: ${String(err)}`);
+  }
+  try {
+    return createPublicKey(pem);
+  } catch (err) {
+    throw new PluginVerificationError(`trust root is not a valid PEM public key: ${String(err)}`);
+  }
+}
+
+/** "sha256-<base64>" digest of a buffer, matching the manifest `integrity` form. */
+export function sha256Integrity(data: Buffer): string {
+  return "sha256-" + createHash("sha256").update(data).digest("base64");
+}
+
+/**
+ * Constant-time-ish compare of the entry file against the manifest's
+ * declared integrity digest. Throws on mismatch.
+ */
+export function verifyIntegrity(entryPath: string, integrity: string | undefined): void {
+  if (!integrity) {
+    throw new PluginVerificationError("manifest has no integrity digest");
+  }
+  let bytes: Buffer;
+  try {
+    bytes = readFileSync(entryPath);
+  } catch (err) {
+    throw new PluginVerificationError(`entry file unreadable: ${String(err)}`);
+  }
+  const actual = sha256Integrity(bytes);
+  if (actual.length !== integrity.length || actual !== integrity) {
+    throw new PluginVerificationError(
+      `entry file integrity mismatch (manifest=${integrity} actual=${actual})`
+    );
+  }
+}
+
+/**
+ * Verify a detached signature over the raw manifest bytes against the
+ * trust root. Signature is read as base64 (whitespace tolerated, e.g. a
+ * `manifest.json.sig` produced by `openssl dgst -sign ... | base64`).
+ * Throws PluginVerificationError if the signature does not verify.
+ */
+export function verifyManifestSignature(
+  manifestBytes: Buffer,
+  signatureBytes: Buffer,
+  trustRoot: KeyObject
+): void {
+  const sig = decodeSignature(signatureBytes);
+  // Ed25519/Ed448 take algorithm=null; RSA/EC sign over a SHA-256 digest.
+  const keyType = trustRoot.asymmetricKeyType;
+  const algorithm = keyType === "ed25519" || keyType === "ed448" ? null : "sha256";
+  let ok = false;
+  try {
+    ok = cryptoVerify(algorithm, manifestBytes, trustRoot, sig);
+  } catch (err) {
+    throw new PluginVerificationError(`signature verification errored: ${String(err)}`);
+  }
+  if (!ok) {
+    throw new PluginVerificationError("manifest signature does not match trust root");
+  }
+}
+
+// Accept either raw DER bytes or a base64/armored .sig file.
+function decodeSignature(raw: Buffer): Buffer {
+  const text = raw.toString("utf8").trim();
+  if (/^[A-Za-z0-9+/\s=]+$/.test(text) && text.length > 0) {
+    const compact = text.replace(/\s+/g, "");
+    const b = Buffer.from(compact, "base64");
+    // Round-trip check: if it re-encodes cleanly it was really base64.
+    if (b.length > 0 && b.toString("base64").replace(/=+$/, "") === compact.replace(/=+$/, "")) {
+      return b;
+    }
+  }
+  return raw;
+}

--- a/mcp-server/src/sdk/index.ts
+++ b/mcp-server/src/sdk/index.ts
@@ -66,6 +66,12 @@ export interface ConnectorManifest {
     /** Semver range of mcp-server versions this connector supports. */
     serverVersion?: string;
   };
+  /**
+   * Subresource-integrity-style digest of the entry file
+   * ("sha256-<base64>"). Required (and signature-checked) when the
+   * server runs with VERIFY_PLUGINS=true. See docs/plugin-architecture.md.
+   */
+  integrity?: string;
 }
 
 /**

--- a/mcp-server/src/sdk/manifest-schema.ts
+++ b/mcp-server/src/sdk/manifest-schema.ts
@@ -35,6 +35,17 @@ export const manifestSchema = z.object({
       serverVersion: z.string().optional(),
     })
     .optional(),
+  // Subresource-integrity-style digest of the plugin entry file
+  // ("sha256-<base64>"). When the server runs with VERIFY_PLUGINS=true
+  // this MUST be present and match the on-disk entry, and the manifest
+  // itself MUST carry a valid detached signature. Airgapped-friendly:
+  // verification is fully offline against a local trust-root key.
+  integrity: z
+    .string()
+    .regex(/^sha256-[A-Za-z0-9+/]+=*$/, {
+      message: 'integrity must be "sha256-<base64>"',
+    })
+    .optional(),
 });
 
 export type ValidatedConnectorManifest = z.infer<typeof manifestSchema>;


### PR DESCRIPTION
## Summary
Plugin-architecture roadmap step 6. Verification is fully **offline** — airgapped sites can't reach a sigstore transparency log, so the server checks a local trust root with Node's built-in crypto (no cosign, no network).

A filesystem plugin loads only when **both** hold:
1. **Integrity** — manifest `integrity` (`sha256-<base64>`) matches the on-disk entry file.
2. **Authenticity** — a detached `manifest.json.sig` verifies the manifest bytes against `PLUGIN_TRUST_ROOT` (Ed25519 or RSA/EC PEM).

Signing the manifest transitively authenticates the code (manifest pins the entry hash).

- New env: `VERIFY_PLUGINS` (default off), `PLUGIN_TRUST_ROOT` (PEM path).
- **Fail-closed**: missing/invalid trust root or signature → no filesystem plugin loads; builtin Prometheus/Loki (trusted image) stay available.
- Default off, so existing deployments are unchanged.
- `verify.test.ts` added to the CI unit-tests glob (the broader `connectors/` glob has unrelated pre-existing failures, so only the new file is added).
- `docs/plugin-architecture.md` updated with the trust-root model + how to produce `integrity` and the `.sig`.

## Test plan
- [x] `verify.test.ts` — 6 cases (Ed25519, RSA, tamper, wrong key, PEM parsing, integrity) pass in Docker
- [x] Exact CI unit-tests command green (57 pass)
- [x] `tsc --noEmit` clean
- [ ] Smoke: server still starts with `VERIFY_PLUGINS` unset (no behavior change)