### PR TITLE
feat(helm): plugin init-container extraction + VERIFY_PLUGINS wiring

### DIFF
--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,7 +4,7 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 0.7.0
+version: 0.8.0
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
@@ -54,6 +54,8 @@ annotations:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
+    - kind: added
+      description: plugins.image init-container extraction + plugins.verify (VERIFY_PLUGINS + trust-root) for airgapped connectors
     - kind: fixed
       description: Chart packages are now actually GPG-signed (.prov shipped) — signing key regenerated, CI import fixed
     - kind: fixed

--- a/helm/observability-mcp/README.md
+++ b/helm/observability-mcp/README.md
@@ -34,8 +34,15 @@ helm install obs-mcp ./helm/observability-mcp \
 | `persistence.enabled` | `false` | Persist `sources.yaml` updates from the Web UI |
 | `autoscaling.enabled` | `false` | HPA — only with sticky-session ingress |
 | `podSecurityContext.runAsNonRoot` | `true` | Hardened defaults |
+| `plugins.image` | `""` | OCI image with a `/plugins` tree; an init container extracts it into `/app/plugins` (no registry access from the main pod) |
+| `plugins.paths` | `[]` | Subdirs of `/plugins` to extract (empty = all) |
+| `plugins.verify.enabled` | `false` | Fail-closed connector verification (`VERIFY_PLUGINS`) — builtin Prometheus/Loki are never gated |
+| `plugins.verify.trustRootPem` | `""` | PEM public key trust root (rendered into a Secret) |
+| `plugins.verify.existingSecret` | `""` | Instead reference a Secret with key `trust-root.pem` |
 
-See [`values.yaml`](./values.yaml) for the full schema.
+See [`values.yaml`](./values.yaml) for the full schema and
+[`docs/plugin-architecture.md`](../../docs/plugin-architecture.md) for the
+airgapped plugin + verification model.
 
 ## Multi-replica deployments
 

--- a/helm/observability-mcp/templates/deployment.yaml
+++ b/helm/observability-mcp/templates/deployment.yaml
@@ -28,6 +28,33 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.plugins.image }}
+      initContainers:
+        # Copies connector plugins out of a dedicated OCI image into a
+        # shared emptyDir. The main container then needs no registry
+        # access — the airgapped "mounted volume" workflow from
+        # docs/plugin-architecture.md.
+        - name: extract-plugins
+          image: {{ .Values.plugins.image | quote }}
+          imagePullPolicy: {{ .Values.plugins.imagePullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              {{- if .Values.plugins.paths }}
+              for p in {{ .Values.plugins.paths | join " " }}; do
+                cp -a "/plugins/$p" /shared/
+              done
+              {{- else }}
+              cp -a /plugins/. /shared/
+              {{- end }}
+          volumeMounts:
+            - name: plugins
+              mountPath: /shared
+      {{- end }}
       containers:
         - name: mcp-server
           image: "{{ .Values.image.repository }}:{{ include "observability-mcp.imageTag" . }}"
@@ -58,6 +85,12 @@ spec:
                   name: {{ include "observability-mcp.authSecretName" . }}
                   key: token
             {{- end }}
+            {{- if .Values.plugins.verify.enabled }}
+            - name: VERIFY_PLUGINS
+              value: "true"
+            - name: PLUGIN_TRUST_ROOT
+              value: /app/trust/trust-root.pem
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -78,6 +111,16 @@ spec:
             - name: data
               mountPath: /app/config
             {{- end }}
+            {{- if .Values.plugins.image }}
+            - name: plugins
+              mountPath: /app/plugins
+              readOnly: true
+            {{- end }}
+            {{- if .Values.plugins.verify.enabled }}
+            - name: trust-root
+              mountPath: /app/trust
+              readOnly: true
+            {{- end }}
       volumes:
         {{- if .Values.sources.config }}
         - name: sources-config
@@ -88,6 +131,15 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "observability-mcp.fullname" . }}
+        {{- end }}
+        {{- if .Values.plugins.image }}
+        - name: plugins
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.plugins.verify.enabled }}
+        - name: trust-root
+          secret:
+            secretName: {{ .Values.plugins.verify.existingSecret | default (printf "%s-trust-root" (include "observability-mcp.fullname" .)) }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm/observability-mcp/templates/secret-trust-root.yaml
+++ b/helm/observability-mcp/templates/secret-trust-root.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.plugins.verify.enabled .Values.plugins.verify.trustRootPem (not .Values.plugins.verify.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "observability-mcp.fullname" . }}-trust-root
+  labels:
+    {{- include "observability-mcp.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  trust-root.pem: |
+    {{- .Values.plugins.verify.trustRootPem | nindent 4 }}
+{{- end }}

--- a/helm/observability-mcp/values.schema.json
+++ b/helm/observability-mcp/values.schema.json
@@ -64,6 +64,24 @@
         "required": ["name"]
       }
     },
+    "plugins": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "image": { "type": "string" },
+        "imagePullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+        "paths": { "type": "array", "items": { "type": "string" } },
+        "verify": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "trustRootPem": { "type": "string" },
+            "existingSecret": { "type": "string" }
+          }
+        }
+      }
+    },
     "service": {
       "type": "object",
       "properties": {

--- a/helm/observability-mcp/values.yaml
+++ b/helm/observability-mcp/values.yaml
@@ -62,6 +62,29 @@ extraEnv: []
   # - name: MCP_LOG_LEVEL
   #   value: info
 
+# Connector plugins. Builtin Prometheus/Loki need no configuration —
+# this block is only for additional / airgapped connectors. See
+# docs/plugin-architecture.md.
+plugins:
+  # OCI image containing ONLY a /plugins tree. An init container copies
+  # the selected paths into an emptyDir mounted at /app/plugins, so the
+  # main container never needs registry access (airgapped-friendly).
+  # Leave empty to disable the init container entirely.
+  image: ""
+  # e.g. registry.internal/observability-mcp-plugins:1.0.0
+  imagePullPolicy: IfNotPresent
+  # Subdirectories of /plugins to extract. Empty = copy everything.
+  paths: []
+  # Fail-closed signature + integrity verification (VERIFY_PLUGINS).
+  # Builtin connectors are part of the trusted image and are never gated.
+  verify:
+    enabled: false
+    # PEM public key used as the trust root. Provide it inline (rendered
+    # into a Secret) OR point existingSecret at a Secret that has the
+    # key `trust-root.pem`.
+    trustRootPem: ""
+    existingSecret: ""
+
 service:
   type: ClusterIP
   port: 3000


### PR DESCRIPTION
## Summary
Plugin-architecture roadmap step 7 — the Helm side of airgapped connectors.

- `plugins.image`: a plugins-only OCI image; an init container copies `plugins.paths` (or everything) into an emptyDir mounted read-only at `/app/plugins`. The main pod never pulls from a registry.
- `plugins.verify.enabled`: sets `VERIFY_PLUGINS=true` + `PLUGIN_TRUST_ROOT=/app/trust/trust-root.pem` and mounts the trust root — either inline `trustRootPem` (rendered into a Secret) or an `existingSecret` with key `trust-root.pem`. Pairs with the fail-closed verification shipped in #111.
- Default off → existing installs render identically.
- Chart `0.7.0` → `0.8.0`; `values.schema.json`, chart README, and `artifacthub.io/changes` updated.

## Test plan
- [x] `helm lint` clean
- [x] Templated: default (no init/verify), `plugins.image` only, verify+inline (Secret rendered), verify+existingSecret (no Secret, external ref), `plugins.paths` (per-path cp), CI smoke render (256 lines)
- [ ] kind integration test (CI) still green on default values