### PR TITLE
feat(hub): connector hub catalog contract (roadmap step 8)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -50,6 +50,10 @@ jobs:
       - name: Run tests
         working-directory: ./mcp-server
         run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/connectors/verify.test.ts
+      - name: Connector hub catalog (validate + in-sync)
+        run: |
+          node hub/build-catalog.mjs --check
+          node --test hub/build-catalog.test.mjs
 
   trivy:
     runs-on: ubuntu-latest

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -154,9 +154,12 @@ The operator distributes only the **public** key as `PLUGIN_TRUST_ROOT`. The Hel
 
 ## The connector hub
 
-Long-term — out of v1 scope but the architecture above is shaped by it.
+The catalog contract now exists in-repo at [`hub/`](../hub/README.md): a
+schema-validated `catalog/<name>.json` per connector aggregated into a
+static `catalog/index.json` (CI keeps it in sync). The web UI / install
+CLI below are still future work, but they consume this format as-is.
 
-- A static catalog (think `helm/charts` repo): a Git repo where each connector's manifest, signed tarball URL, screenshots, and changelog live.
+- A static catalog (think `helm/charts` repo): each connector's manifest, signed tarball URL, screenshots, and changelog live as `hub/catalog/<name>.json`; `hub/build-catalog.mjs` validates and aggregates them.
 - A web UI at `hub.observability-mcp.dev` (or similar) that browses the catalog. Search by signal type, capability, vendor.
 - A CLI command `observability-mcp install <name>` that:
   1. Fetches the manifest from the catalog
@@ -181,7 +184,7 @@ These will be separate PRs so each can pass smoke independently:
 | 5  | Loki connector → own package. |
 | 6  | ✅ Offline verification (`VERIFY_PLUGINS` + local trust root) — fail-closed manifest signature + entry integrity. (Local trust root, not sigstore: airgapped sites can't reach a transparency log.) |
 | 7  | Helm chart: `plugins.image` + init container extraction. |
-| 8  | Connector hub catalog repo + minimal static site. |
+| 8  | ✅ Catalog contract in `hub/` (schema + validated `index.json` + generator + CI). Hosted static site / install CLI remain future work on top of this format. |
 
 The first three PRs unlock airgapped deployments. Everything after is incremental polish.
 

--- a/hub/README.md
+++ b/hub/README.md
@@ -1,0 +1,48 @@
+# Connector hub catalog
+
+A **static** catalog of observability-mcp connectors (think the `helm/charts`
+index, or Confluent Hub). No server, no telemetry: a single
+`catalog/index.json` that a static site or the future
+`observability-mcp install <name>` CLI fetches. Tarballs and signatures
+are pulled directly from the URLs in each entry and verified with the
+same trust-root model the server uses (see
+[`../docs/plugin-architecture.md`](../docs/plugin-architecture.md)).
+
+## Layout
+
+```
+hub/
+├── catalog-schema.json     # JSON Schema for one catalog entry
+├── catalog/
+│   ├── <name>.json         # one file per connector (source of truth)
+│   └── index.json          # generated, do not hand-edit
+├── build-catalog.mjs       # validate + (re)generate index.json
+└── build-catalog.test.mjs  # node --test
+```
+
+## Adding / updating a connector
+
+1. Add or edit `catalog/<name>.json` (filename must equal the entry
+   `name`). Validate against `catalog-schema.json`. Newest version first.
+2. Regenerate the index:
+   ```bash
+   node hub/build-catalog.mjs
+   ```
+3. Commit both the entry and `catalog/index.json`. CI runs
+   `node hub/build-catalog.mjs --check` and the test suite — a stale
+   `index.json` or invalid entry fails the build.
+
+Each version pins `integrity` (sha256 of the plugin entry file) and a
+`signatureUrl` (detached signature of the manifest). An installer is
+expected to verify both before loading — verification is offline and
+mirror-friendly, so airgapped sites can `rsync` the whole `hub/` tree.
+
+## Tiers
+
+- **official** — maintained in this repo.
+- **certified** — third-party, reviewed by maintainers.
+- **third-party** — community, unreviewed; installers should warn.
+
+The two builtin connectors (Prometheus, Loki) are listed with
+`"builtin": true` for discoverability — they ship in the server image
+and need no install step.

--- a/hub/build-catalog.mjs
+++ b/hub/build-catalog.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+// Validates every hub/catalog/<name>.json against catalog-schema.json and
+// aggregates them into hub/catalog/index.json (the single file a static
+// hub site / the future CLI fetches). Dependency-free: a focused
+// validator covering exactly the JSON Schema constructs the schema uses
+// (const, enum, pattern, type, required, additionalProperties:false,
+// minItems/minLength, nested objects/arrays, uri/date format). No ajv so
+// this runs in an airgapped checkout with bare `node`.
+
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CATALOG_DIR = join(HERE, "catalog");
+const SCHEMA_PATH = join(HERE, "catalog-schema.json");
+const INDEX_PATH = join(CATALOG_DIR, "index.json");
+
+const URI_RE = /^[a-z][a-z0-9+.-]*:\/\/[^\s]+$/i;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function validate(node, schema, path = "") {
+  const errs = [];
+  const at = path || "<root>";
+
+  if (schema.const !== undefined && node !== schema.const) {
+    errs.push(`${at}: must equal ${JSON.stringify(schema.const)}`);
+    return errs;
+  }
+  if (schema.enum && !schema.enum.includes(node)) {
+    errs.push(`${at}: must be one of ${JSON.stringify(schema.enum)}`);
+    return errs;
+  }
+
+  const type = schema.type;
+  if (type === "object") {
+    if (node === null || typeof node !== "object" || Array.isArray(node)) {
+      errs.push(`${at}: expected object`);
+      return errs;
+    }
+    for (const req of schema.required ?? []) {
+      if (!(req in node)) errs.push(`${at}: missing required "${req}"`);
+    }
+    if (schema.additionalProperties === false) {
+      for (const k of Object.keys(node)) {
+        if (!(k in (schema.properties ?? {}))) errs.push(`${at}: unknown property "${k}"`);
+      }
+    }
+    for (const [k, sub] of Object.entries(schema.properties ?? {})) {
+      if (k in node) errs.push(...validate(node[k], sub, path ? `${path}.${k}` : k));
+    }
+    return errs;
+  }
+  if (type === "array") {
+    if (!Array.isArray(node)) {
+      errs.push(`${at}: expected array`);
+      return errs;
+    }
+    if (schema.minItems != null && node.length < schema.minItems) {
+      errs.push(`${at}: needs >= ${schema.minItems} items`);
+    }
+    node.forEach((el, i) => errs.push(...validate(el, schema.items, `${at}[${i}]`)));
+    return errs;
+  }
+  if (type === "string") {
+    if (typeof node !== "string") {
+      errs.push(`${at}: expected string`);
+      return errs;
+    }
+    if (schema.minLength != null && node.length < schema.minLength) {
+      errs.push(`${at}: shorter than ${schema.minLength}`);
+    }
+    if (schema.pattern && !new RegExp(schema.pattern).test(node)) {
+      errs.push(`${at}: does not match /${schema.pattern}/`);
+    }
+    if (schema.format === "uri" && !URI_RE.test(node)) errs.push(`${at}: not a URI`);
+    if (schema.format === "date" && !DATE_RE.test(node)) errs.push(`${at}: not a YYYY-MM-DD date`);
+    return errs;
+  }
+  if (type === "boolean" && typeof node !== "boolean") errs.push(`${at}: expected boolean`);
+  return errs;
+}
+
+export function buildIndex(entries) {
+  const connectors = entries
+    .map((e) => ({
+      name: e.name,
+      displayName: e.displayName,
+      description: e.description,
+      tier: e.tier,
+      builtin: e.builtin === true,
+      signalTypes: e.signalTypes,
+      latest: e.versions[0].version,
+      versions: e.versions,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  return { catalogVersion: 1, connectors };
+}
+
+export function loadEntries() {
+  const schema = JSON.parse(readFileSync(SCHEMA_PATH, "utf8"));
+  const files = readdirSync(CATALOG_DIR)
+    .filter((f) => f.endsWith(".json") && f !== "index.json")
+    .sort();
+  const entries = [];
+  const problems = [];
+  for (const f of files) {
+    const entry = JSON.parse(readFileSync(join(CATALOG_DIR, f), "utf8"));
+    const errs = validate(entry, schema);
+    if (f !== `${entry.name}.json`) {
+      errs.push(`<root>: filename must be "${entry.name}.json"`);
+    }
+    if (errs.length) problems.push(`${f}:\n  - ${errs.join("\n  - ")}`);
+    else entries.push(entry);
+  }
+  return { entries, problems };
+}
+
+// CLI: validate + (re)write index.json. `--check` fails if out of sync.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const { entries, problems } = loadEntries();
+  if (problems.length) {
+    console.error("Catalog validation failed:\n" + problems.join("\n"));
+    process.exit(1);
+  }
+  const index = buildIndex(entries);
+  const serialized = JSON.stringify(index, null, 2) + "\n";
+  if (process.argv.includes("--check")) {
+    const current = readFileSync(INDEX_PATH, "utf8");
+    if (current !== serialized) {
+      console.error("hub/catalog/index.json is stale — run `node hub/build-catalog.mjs`");
+      process.exit(1);
+    }
+    console.log(`Catalog OK (${entries.length} connectors), index.json in sync.`);
+  } else {
+    writeFileSync(INDEX_PATH, serialized);
+    console.log(`Wrote ${INDEX_PATH} (${entries.length} connectors).`);
+  }
+}

--- a/hub/build-catalog.test.mjs
+++ b/hub/build-catalog.test.mjs
@@ -1,0 +1,67 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { validate, buildIndex, loadEntries } from "./build-catalog.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const schema = JSON.parse(readFileSync(join(HERE, "catalog-schema.json"), "utf8"));
+
+const good = {
+  catalogVersion: 1,
+  name: "tempo",
+  displayName: "Grafana Tempo",
+  description: "TraceQL backend.",
+  tier: "third-party",
+  signalTypes: ["traces"],
+  versions: [{ version: "1.0.0", releasedAt: "2026-05-15", integrity: "sha256-AAAA=" }],
+};
+
+test("a well-formed entry validates", () => {
+  assert.deepEqual(validate(good, schema), []);
+});
+
+test("rejects unknown property (additionalProperties:false)", () => {
+  const e = validate({ ...good, oops: 1 }, schema);
+  assert.ok(e.some((m) => m.includes('unknown property "oops"')));
+});
+
+test("rejects bad name pattern, bad tier, bad version, bad integrity", () => {
+  assert.ok(validate({ ...good, name: "Bad_Name" }, schema).some((m) => m.includes("name")));
+  assert.ok(validate({ ...good, tier: "gold" }, schema).some((m) => m.includes("tier")));
+  assert.ok(
+    validate({ ...good, versions: [{ version: "v1", releasedAt: "2026-05-15" }] }, schema).some(
+      (m) => m.includes("version")
+    )
+  );
+  assert.ok(
+    validate(
+      { ...good, versions: [{ version: "1.0.0", releasedAt: "2026-05-15", integrity: "md5-x" }] },
+      schema
+    ).some((m) => m.includes("integrity"))
+  );
+});
+
+test("rejects missing required field and bad date", () => {
+  const { versions, ...noVer } = good;
+  assert.ok(validate(noVer, schema).some((m) => m.includes('missing required "versions"')));
+  assert.ok(
+    validate({ ...good, versions: [{ version: "1.0.0", releasedAt: "May 2026" }] }, schema).some(
+      (m) => m.includes("date")
+    )
+  );
+});
+
+test("all committed catalog entries are valid", () => {
+  const { problems } = loadEntries();
+  assert.deepEqual(problems, [], problems.join("\n"));
+});
+
+test("committed index.json is in sync with the entries", () => {
+  const { entries } = loadEntries();
+  const expected = JSON.stringify(buildIndex(entries), null, 2) + "\n";
+  const actual = readFileSync(join(HERE, "catalog", "index.json"), "utf8");
+  assert.equal(actual, expected, "run `node hub/build-catalog.mjs` to regenerate");
+});

--- a/hub/catalog-schema.json
+++ b/hub/catalog-schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "observability-mcp connector hub — catalog entry",
+  "description": "One file per connector under hub/catalog/<name>.json. build-catalog.mjs validates each against this schema and aggregates them into hub/catalog/index.json. The hub is a static catalog (no server): tarballs + signatures are fetched directly from the URLs below and verified with the same trust-root model the server uses (see docs/plugin-architecture.md).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["catalogVersion", "name", "displayName", "description", "tier", "signalTypes", "versions"],
+  "properties": {
+    "catalogVersion": { "const": 1 },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "description": "Connector type id; matches the plugin manifest `name` and `sources.yaml` type."
+    },
+    "displayName": { "type": "string", "minLength": 1 },
+    "description": { "type": "string", "minLength": 1 },
+    "vendor": { "type": "string" },
+    "homepage": { "type": "string", "format": "uri" },
+    "tier": {
+      "enum": ["official", "certified", "third-party"],
+      "description": "official = maintained in this repo; certified = reviewed; third-party = community, unreviewed."
+    },
+    "builtin": {
+      "type": "boolean",
+      "description": "True for connectors bundled in the server image (prometheus, loki). Listed for discoverability; no install step needed."
+    },
+    "signalTypes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "enum": ["metrics", "logs", "traces"] }
+    },
+    "screenshots": {
+      "type": "array",
+      "items": { "type": "string", "format": "uri" }
+    },
+    "versions": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Newest first. Each entry is independently verifiable.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["version", "releasedAt"],
+        "properties": {
+          "version": { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+(-[a-z0-9.-]+)?$" },
+          "releasedAt": { "type": "string", "format": "date" },
+          "serverCompat": { "type": "string", "description": "Semver range of mcp-server versions." },
+          "tarballUrl": { "type": "string", "format": "uri" },
+          "signatureUrl": { "type": "string", "format": "uri", "description": "Detached signature of the manifest (manifest.json.sig)." },
+          "manifestUrl": { "type": "string", "format": "uri" },
+          "integrity": {
+            "type": "string",
+            "pattern": "^sha256-[A-Za-z0-9+/]+=*$",
+            "description": "sha256 of the plugin entry file; mirrors the manifest `integrity`."
+          },
+          "changelog": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/hub/catalog/index.json
+++ b/hub/catalog/index.json
@@ -1,0 +1,43 @@
+{
+  "catalogVersion": 1,
+  "connectors": [
+    {
+      "name": "loki",
+      "displayName": "Grafana Loki",
+      "description": "LogQL-based logs backend. Service discovery from log streams and label-scoped log queries.",
+      "tier": "official",
+      "builtin": true,
+      "signalTypes": [
+        "logs"
+      ],
+      "latest": "1.4.0",
+      "versions": [
+        {
+          "version": "1.4.0",
+          "releasedAt": "2026-05-15",
+          "serverCompat": ">=1.4.0",
+          "changelog": "Bundled with the server image — no install step. Listed for discoverability and to anchor the catalog format."
+        }
+      ]
+    },
+    {
+      "name": "prometheus",
+      "displayName": "Prometheus",
+      "description": "PromQL-based metrics backend. Service discovery, default metric set, and ad-hoc range/instant queries.",
+      "tier": "official",
+      "builtin": true,
+      "signalTypes": [
+        "metrics"
+      ],
+      "latest": "1.4.0",
+      "versions": [
+        {
+          "version": "1.4.0",
+          "releasedAt": "2026-05-15",
+          "serverCompat": ">=1.4.0",
+          "changelog": "Bundled with the server image — no install step. Listed for discoverability and to anchor the catalog format."
+        }
+      ]
+    }
+  ]
+}

--- a/hub/catalog/loki.json
+++ b/hub/catalog/loki.json
@@ -1,0 +1,19 @@
+{
+  "catalogVersion": 1,
+  "name": "loki",
+  "displayName": "Grafana Loki",
+  "description": "LogQL-based logs backend. Service discovery from log streams and label-scoped log queries.",
+  "vendor": "observability-mcp",
+  "homepage": "https://github.com/ThoTischner/observability-mcp",
+  "tier": "official",
+  "builtin": true,
+  "signalTypes": ["logs"],
+  "versions": [
+    {
+      "version": "1.4.0",
+      "releasedAt": "2026-05-15",
+      "serverCompat": ">=1.4.0",
+      "changelog": "Bundled with the server image — no install step. Listed for discoverability and to anchor the catalog format."
+    }
+  ]
+}

--- a/hub/catalog/prometheus.json
+++ b/hub/catalog/prometheus.json
@@ -1,0 +1,19 @@
+{
+  "catalogVersion": 1,
+  "name": "prometheus",
+  "displayName": "Prometheus",
+  "description": "PromQL-based metrics backend. Service discovery, default metric set, and ad-hoc range/instant queries.",
+  "vendor": "observability-mcp",
+  "homepage": "https://github.com/ThoTischner/observability-mcp",
+  "tier": "official",
+  "builtin": true,
+  "signalTypes": ["metrics"],
+  "versions": [
+    {
+      "version": "1.4.0",
+      "releasedAt": "2026-05-15",
+      "serverCompat": ">=1.4.0",
+      "changelog": "Bundled with the server image — no install step. Listed for discoverability and to anchor the catalog format."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Final plugin-architecture roadmap item — the connector hub catalog **contract** (not the hosted site yet).

- `hub/catalog-schema.json` — JSON Schema for one connector entry (tiers official/certified/third-party, per-version `integrity` + `signatureUrl` + `serverCompat`).
- `hub/catalog/<name>.json` — source of truth, one per connector; seeded with the two builtins (`builtin: true`, listed for discoverability).
- `hub/build-catalog.mjs` — dependency-free validator + `index.json` generator (runs on bare `node`, so airgapped checkouts and `rsync` mirrors work). `--check` mode fails on a stale index.
- `hub/build-catalog.test.mjs` — 6 `node --test` cases.
- CI: a validate + in-sync + test step added **inside the existing `unit-tests` job** — no new required-check context, no ruleset change.
- Docs + `hub/README.md` updated; hosted static site / `install` CLI explicitly scoped as future work on top of this format.

## Test plan
- [x] `node hub/build-catalog.mjs --check` → in sync
- [x] `node --test hub/build-catalog.test.mjs` → 6/6 pass
- [x] Entry rejected on unknown prop / bad name / bad tier / bad semver / bad integrity / missing required / bad date