### PR TITLE
fix(smithery): correct Dockerfile path; add npm homepage/bugs

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -9,6 +9,10 @@
     "type": "git",
     "url": "https://github.com/ThoTischner/observability-mcp"
   },
+  "homepage": "https://github.com/ThoTischner/observability-mcp#readme",
+  "bugs": {
+    "url": "https://github.com/ThoTischner/observability-mcp/issues"
+  },
   "keywords": [
     "mcp",
     "observability",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -8,7 +8,10 @@
 
 runtime: container
 build:
-  dockerfile: mcp-server/Dockerfile
+  # dockerfile is resolved relative to context, so with context
+  # ./mcp-server the Dockerfile is just "Dockerfile" (matches the
+  # docker-publish workflow's build context exactly).
+  dockerfile: Dockerfile
   context: ./mcp-server
 
 startCommand:


### PR DESCRIPTION
## Summary
Listing-readiness sweep (agenda item 6 prep).

- **Bug**: `smithery.yaml` had `dockerfile: mcp-server/Dockerfile` under `context: ./mcp-server`. Smithery resolves `dockerfile` relative to `context`, so it looked for `./mcp-server/mcp-server/Dockerfile` — the one-click catalog build would fail. Fixed to `dockerfile: Dockerfile`, which is exactly the context the `docker-publish`/`trivy` jobs build daily. Verified with `docker build --check`.
- Added `homepage` + `bugs` to `mcp-server/package.json` (were absent → npmjs.com/catalog listings now render the repo links).
- Separately set the GitHub repo homepage URL to the npm package page (repo setting, applied directly).

## Test plan
- [x] `docker build --check -f Dockerfile .` in `mcp-server/` → "Check complete, no warnings"
- [x] `package.json` valid JSON
- [ ] Smithery import succeeds once merged (external, post-merge)