### PR TITLE
fix(ci): hub-pages git identity in cloned repo

### DIFF
--- a/.github/workflows/hub-pages.yml
+++ b/.github/workflows/hub-pages.yml
@@ -53,11 +53,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           tmp="$(mktemp -d)"
           git clone --depth 1 --branch gh-pages \
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$tmp"
+          # Identity must be set INSIDE the freshly cloned repo (the
+          # actions/checkout workspace config does not carry over).
+          git -C "$tmp" config user.name  "github-actions[bot]"
+          git -C "$tmp" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           rm -rf "$tmp/hub"
           mkdir -p "$tmp/hub"
           cp -r /tmp/site/. "$tmp/hub/"


### PR DESCRIPTION
## Summary
The "Publish connector hub site" workflow failed on the post-merge run of #115:
`fatal: empty ident name ... not allowed` (exit 128).

`git config user.name/email` was set in the actions/checkout workspace, but the commit happens in a separate `git clone` directory which inherits no identity. Fixed by setting identity with `git -C "$tmp" config` right after the clone.

## Test plan
- [x] YAML reviewed; identity now set inside the cloned gh-pages repo before commit
- [ ] Post-merge: "Publish connector hub site" succeeds, `/hub/` goes live, Helm `index.yaml` still 200