### PR TITLE
feat(cli): omcp CLI — skeleton, doctor, demo up/down/status

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,7 +49,7 @@ jobs:
         run: npm ci
       - name: Run tests
         working-directory: ./mcp-server
-        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/connectors/verify.test.ts
+        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/connectors/verify.test.ts src/cli/*.test.ts
       - name: Connector hub catalog (validate + in-sync)
         run: |
           node hub/build-catalog.mjs --check

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -22,7 +22,8 @@
     "anomaly-detection"
   ],
   "bin": {
-    "observability-mcp": "./dist/index.js"
+    "observability-mcp": "./dist/index.js",
+    "omcp": "./dist/cli/index.js"
   },
   "files": [
     "dist",

--- a/mcp-server/src/cli/index.ts
+++ b/mcp-server/src/cli/index.ts
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { createConnection } from "node:net";
+import { existsSync, readFileSync, writeFileSync, mkdtempSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+import { parseArgs, pickFreePort, composeOverride, HELP } from "./lib.js";
+
+function pkgVersion(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    // dist/cli/index.js → ../../package.json
+    return JSON.parse(readFileSync(join(here, "..", "..", "package.json"), "utf8")).version;
+  } catch {
+    return "unknown";
+  }
+}
+
+function which(bin: string, args: string[] = ["--version"]): string | null {
+  const r = spawnSync(bin, args, { encoding: "utf8" });
+  if (r.status === 0) return (r.stdout || r.stderr || "").trim().split("\n")[0];
+  return null;
+}
+
+function dockerComposeVersion(): string | null {
+  const r = spawnSync("docker", ["compose", "version"], { encoding: "utf8" });
+  return r.status === 0 ? (r.stdout || "").trim().split("\n")[0] : null;
+}
+
+// Walk up from cwd looking for the repo's docker-compose.yml.
+function findComposeFile(): string | null {
+  let dir = process.cwd();
+  for (let i = 0; i < 8; i++) {
+    const f = join(dir, "docker-compose.yml");
+    if (existsSync(f)) return f;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+function portInUse(port: number, host = "127.0.0.1"): Promise<boolean> {
+  return new Promise((resolve) => {
+    const s = createConnection({ port, host });
+    const done = (v: boolean) => {
+      s.destroy();
+      resolve(v);
+    };
+    s.setTimeout(400);
+    s.once("connect", () => done(true));
+    s.once("timeout", () => done(false));
+    s.once("error", () => done(false));
+  });
+}
+
+function fail(msg: string): never {
+  console.error("error: " + msg);
+  process.exit(1);
+}
+
+async function doctor(json: boolean): Promise<void> {
+  const checks = {
+    node: process.version,
+    docker: which("docker"),
+    "docker compose": dockerComposeVersion(),
+    helm: which("helm", ["version", "--short"]),
+    "compose file": findComposeFile() ?? null,
+  };
+  if (json) {
+    console.log(JSON.stringify(checks, null, 2));
+  } else {
+    for (const [k, v] of Object.entries(checks)) {
+      const ok = v != null;
+      console.log(`${ok ? "ok  " : "MISS"}  ${k.padEnd(16)} ${ok ? v : "(not found)"}`);
+    }
+  }
+  const required = ["docker", "docker compose"];
+  if (required.some((k) => (checks as Record<string, unknown>)[k] == null)) {
+    fail("missing required tooling (docker + docker compose)");
+  }
+}
+
+async function demo(sub: string | undefined): Promise<void> {
+  const compose = findComposeFile();
+  if (!compose) fail("docker-compose.yml not found (run from an observability-mcp checkout)");
+  const root = dirname(compose!);
+  const baseArgs = ["compose", "-f", compose!];
+
+  if (sub === "status") {
+    run("docker", [...baseArgs, "--profile", "demo", "ps"], root);
+    return;
+  }
+  if (sub === "down") {
+    run("docker", [...baseArgs, "--profile", "demo", "down", "-v"], root);
+    return;
+  }
+  if (sub !== "up") fail(`unknown 'demo' subcommand: ${sub ?? "(none)"} (up|down|status)`);
+
+  // Auto-pick free host ports for the two services that commonly clash.
+  const wanted: Array<{ service: string; container: number }> = [
+    { service: "mcp-server", container: 3000 },
+    { service: "loki", container: 3100 },
+  ];
+  const remaps: Array<{ service: string; host: number; container: number }> = [];
+  for (const w of wanted) {
+    const busy = await portInUse(w.container);
+    let host = w.container;
+    if (busy) {
+      const used = new Set<number>();
+      host = pickFreePort(w.container + 1, (p) => used.has(p));
+      // Probe sequentially; mark scanned-busy ports so pickFreePort skips.
+      for (let p = w.container + 1; p < w.container + 50; p++) {
+        if (await portInUse(p)) used.add(p);
+        else {
+          host = p;
+          break;
+        }
+      }
+      console.log(`port ${w.container} busy → ${w.service} mapped to host ${host}`);
+    }
+    remaps.push({ service: w.service, host, container: w.container });
+  }
+
+  const args = [...baseArgs];
+  const mcp = remaps.find((r) => r.service === "mcp-server")!;
+  const needsOverride = remaps.some((r) => r.host !== r.container);
+  if (needsOverride) {
+    const dir = mkdtempSync(join(tmpdir(), "omcp-"));
+    const ovr = join(dir, "override.yml");
+    writeFileSync(ovr, composeOverride(remaps));
+    args.push("-f", ovr);
+  }
+  args.push("--profile", "demo", "up", "--build", "-d");
+  const code = run("docker", args, root);
+  if (code === 0) {
+    console.log(`\ndemo stack up. Web UI / MCP: http://localhost:${mcp.host}  (/mcp, /healthz)`);
+    console.log("Stop with: omcp demo down");
+  }
+  process.exit(code);
+}
+
+function run(cmd: string, args: string[], cwd: string): number {
+  const r = spawnSync(cmd, args, { cwd, stdio: "inherit" });
+  return r.status ?? 1;
+}
+
+async function main(): Promise<void> {
+  const { command, sub, flags } = parseArgs(process.argv.slice(2));
+  const json = flags.json === true;
+  switch (command) {
+    case "":
+    case "help":
+    case "--help":
+      console.log(HELP);
+      return;
+    case "version":
+    case "--version":
+      console.log(`omcp ${pkgVersion()}`);
+      return;
+    case "doctor":
+      return doctor(json);
+    case "demo":
+      return demo(sub);
+    default:
+      fail(`unknown command: ${command}\n\n${HELP}`);
+  }
+}
+
+main().catch((e) => fail(e instanceof Error ? e.message : String(e)));

--- a/mcp-server/src/cli/lib.test.ts
+++ b/mcp-server/src/cli/lib.test.ts
@@ -1,0 +1,51 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseArgs, pickFreePort, composeOverride } from "./lib.js";
+
+test("parseArgs: command, sub, positionals", () => {
+  const p = parseArgs(["demo", "up", "extra"]);
+  assert.equal(p.command, "demo");
+  assert.equal(p.sub, "up");
+  assert.deepEqual(p.positionals, ["extra"]);
+});
+
+test("parseArgs: --flag=val, --flag val, boolean, -f val", () => {
+  const p = parseArgs(["plugin", "install", "loki", "--from=/m", "--ver", "1.2.0", "--json", "-f", "x"]);
+  assert.equal(p.command, "plugin");
+  assert.equal(p.sub, "install");
+  assert.deepEqual(p.positionals, ["loki"]);
+  assert.equal(p.flags.from, "/m");
+  assert.equal(p.flags.ver, "1.2.0");
+  assert.equal(p.flags.json, true);
+  assert.equal(p.flags.f, "x");
+});
+
+test("parseArgs: empty argv", () => {
+  const p = parseArgs([]);
+  assert.equal(p.command, "");
+  assert.equal(p.sub, undefined);
+});
+
+test("pickFreePort returns desired when free", () => {
+  assert.equal(pickFreePort(3000, () => false), 3000);
+});
+
+test("pickFreePort skips used ports", () => {
+  const used = new Set([3000, 3001, 3002]);
+  assert.equal(pickFreePort(3000, (p) => used.has(p)), 3003);
+});
+
+test("pickFreePort throws when span exhausted", () => {
+  assert.throws(() => pickFreePort(3000, () => true, 5), /no free port/);
+});
+
+test("composeOverride emits !override port mappings", () => {
+  const y = composeOverride([
+    { service: "mcp-server", host: 3001, container: 3000 },
+    { service: "loki", host: 3101, container: 3100 },
+  ]);
+  assert.match(y, /^services:\n/);
+  assert.match(y, /  mcp-server:\n    ports: !override\n      - "3001:3000"/);
+  assert.match(y, /  loki:\n    ports: !override\n      - "3101:3100"/);
+});

--- a/mcp-server/src/cli/lib.ts
+++ b/mcp-server/src/cli/lib.ts
@@ -1,0 +1,76 @@
+// Pure, IO-free helpers for the omcp CLI so they can be unit-tested
+// without spawning docker or touching the filesystem.
+
+export interface ParsedArgs {
+  command: string;
+  sub?: string;
+  flags: Record<string, string | boolean>;
+  positionals: string[];
+}
+
+/** Minimal argv parser: `omcp <command> [sub] [positionals] [--flag[=val]] [-f val]`. */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const flags: Record<string, string | boolean> = {};
+  const rest: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const eq = a.indexOf("=");
+      if (eq !== -1) flags[a.slice(2, eq)] = a.slice(eq + 1);
+      else if (i + 1 < argv.length && !argv[i + 1].startsWith("-")) flags[a.slice(2)] = argv[++i];
+      else flags[a.slice(2)] = true;
+    } else if (a.startsWith("-") && a.length > 1) {
+      if (i + 1 < argv.length && !argv[i + 1].startsWith("-")) flags[a.slice(1)] = argv[++i];
+      else flags[a.slice(1)] = true;
+    } else {
+      rest.push(a);
+    }
+  }
+  return { command: rest[0] ?? "", sub: rest[1], flags, positionals: rest.slice(2) };
+}
+
+/**
+ * Given a desired port and a predicate that says whether a port is in
+ * use, return the first free port at or after `desired` (bounded scan).
+ */
+export function pickFreePort(
+  desired: number,
+  inUse: (p: number) => boolean,
+  span = 50
+): number {
+  for (let p = desired; p < desired + span; p++) {
+    if (!inUse(p)) return p;
+  }
+  throw new Error(`no free port in [${desired}, ${desired + span})`);
+}
+
+/**
+ * Build a docker-compose override that remaps the host side of the
+ * given service ports. Uses the `!override` tag so it replaces (not
+ * appends to) the base `ports:` list.
+ */
+export function composeOverride(
+  remaps: Array<{ service: string; host: number; container: number }>
+): string {
+  const services = remaps
+    .map(
+      (r) =>
+        `  ${r.service}:\n    ports: !override\n      - "${r.host}:${r.container}"`
+    )
+    .join("\n");
+  return `services:\n${services}\n`;
+}
+
+export const HELP = `omcp — observability-mcp control CLI
+
+Usage:
+  omcp version                 Print CLI + server package version
+  omcp doctor                  Check the local toolchain (docker, compose, helm, node)
+  omcp demo up                 Start the full demo stack (auto-picks free host ports)
+  omcp demo down               Stop and remove the demo stack
+  omcp demo status             Show demo container status
+  omcp help                    Show this help
+
+Flags:
+  --json                       Machine-readable output (doctor, status)
+`;


### PR DESCRIPTION
## Summary
Slices 1+2 of the Confluent-style `omcp` control CLI (roadmap in loop plan). Separate `omcp` bin; server entrypoint unchanged.

- `omcp version`, `omcp doctor` (checks docker / docker compose / helm / node + locates docker-compose.yml; fails if docker/compose missing).
- `omcp demo up|down|status` — wraps `docker compose --profile demo`. `up` auto-detects host port clashes on 3000 (mcp-server) and 3100 (loki) and generates a `!override` file mapping to the next free port (the exact clash I hit during the local smoke), then prints the chosen URL.
- Pure helpers (`parseArgs`, `pickFreePort`, `composeOverride`) in `lib.ts`; 7 unit tests; added `src/cli/*.test.ts` to the CI glob.
- Dependency-free (Node built-ins only).

Follow-up slices: `plugin list/info`, `plugin install` (download+verify via the existing verify logic), `plugin verify`, `helm install/upgrade`.

## Test plan
- [x] `tsc --noEmit` clean (Docker)
- [x] `tsx --test src/cli/lib.test.ts` → 7/7 pass
- [ ] Post-merge smoke: `omcp doctor`, `omcp demo up` on a checkout