### PR TITLE
docs: link the Connector Hub site (README + ArtifactHub)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ normalizes the data, adds intelligent analysis, and provides a web UI for config
 [![Helm chart](https://img.shields.io/badge/helm-observability--mcp-0F1689?logo=helm&logoColor=white)](./helm/observability-mcp)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/observability-mcp)](https://artifacthub.io/packages/search?repo=observability-mcp)
 [![Provenance](https://img.shields.io/badge/npm-provenance-success?logo=npm)](https://docs.npmjs.com/generating-provenance-statements)
+[![Connector Hub](https://img.shields.io/badge/connector-hub-38bdf8?logo=googlechrome&logoColor=white)](https://thotischner.github.io/observability-mcp/hub/)
 
 ![Web UI Dashboard](docs/dashboard.png)
 
@@ -291,6 +292,7 @@ The agent ([docs/agent.md](docs/agent.md)) detects anomalies within 30 seconds a
 - [Troubleshooting](docs/troubleshooting.md) — common pitfalls and fixes
 - [Security](docs/security.md) — automation pipeline, vulnerability reporting, built-in protections
 - [Airgapped deployment](docs/airgapped-deployment.md) — mirroring images, private plugins, GitOps-friendly config
+- [Connector Hub](https://thotischner.github.io/observability-mcp/hub/) — browse versioned, signed connectors (catalog: [`hub/`](hub/README.md))
 - [Use cases](USECASES.md) — five scenarios with the prompts that drive them
 
 ## Endpoints

--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,7 +4,7 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 0.8.0
+version: 0.8.1
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
@@ -41,6 +41,8 @@ annotations:
       url: https://github.com/ThoTischner/observability-mcp/pkgs/container/observability-mcp
     - name: npm
       url: https://www.npmjs.com/package/@thotischner/observability-mcp
+    - name: Connector Hub
+      url: https://thotischner.github.io/observability-mcp/hub/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/operator: "false"
   artifacthub.io/prerelease: "false"
@@ -54,6 +56,8 @@ annotations:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
+    - kind: added
+      description: Connector Hub link (https://thotischner.github.io/observability-mcp/hub/)
     - kind: added
       description: plugins.image init-container extraction + plugins.verify (VERIFY_PLUGINS + trust-root) for airgapped connectors
     - kind: fixed

--- a/helm/observability-mcp/README.md
+++ b/helm/observability-mcp/README.md
@@ -2,6 +2,8 @@
 
 Deploys [observability-mcp](https://github.com/ThoTischner/observability-mcp) — a Model Context Protocol server that gives AI agents unified access to Prometheus, Loki, and other observability backends.
 
+Browse available connectors in the **[Connector Hub](https://thotischner.github.io/observability-mcp/hub/)** — pair it with the chart's `plugins.image` / `plugins.verify` values for signed, airgapped connector delivery.
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
## Summary
Per request — surface the live Connector Hub everywhere it matters.

- **Main README**: hub badge in the badge bar + entry in the Docs list.
- **ArtifactHub**: link in the chart README intro (ArtifactHub renders this) and a `Connector Hub` entry in `artifacthub.io/links`. Chart `0.8.0 → 0.8.1` so ArtifactHub re-renders on the next chart publish.

Live: https://thotischner.github.io/observability-mcp/hub/

## Test plan
- [x] `helm lint` clean
- [ ] Post-merge: chart 0.8.1 publishes, ArtifactHub shows the new link