### PR TITLE
feat(cli): omcp plugin list|info (slice 3)

### DIFF
--- a/mcp-server/src/cli/index.ts
+++ b/mcp-server/src/cli/index.ts
@@ -6,7 +6,16 @@ import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
-import { parseArgs, pickFreePort, composeOverride, HELP } from "./lib.js";
+import {
+  parseArgs,
+  pickFreePort,
+  composeOverride,
+  resolveCatalogSource,
+  formatPluginList,
+  formatPluginInfo,
+  HELP,
+  type Catalog,
+} from "./lib.js";
 
 function pkgVersion(): string {
   try {
@@ -40,6 +49,49 @@ function findComposeFile(): string | null {
     dir = parent;
   }
   return null;
+}
+
+// Walk up from cwd for a checkout's generated catalog.
+function findLocalCatalog(): string | null {
+  let dir = process.cwd();
+  for (let i = 0; i < 8; i++) {
+    const f = join(dir, "hub", "catalog", "index.json");
+    if (existsSync(f)) return f;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+async function loadCatalog(from: string | undefined): Promise<Catalog> {
+  const src = resolveCatalogSource(from, findLocalCatalog());
+  if (src.kind === "file") {
+    if (!existsSync(src.location)) fail(`catalog not found: ${src.location}`);
+    return JSON.parse(readFileSync(src.location, "utf8")) as Catalog;
+  }
+  const r = await fetch(src.location).catch((e) => fail(`fetch failed: ${String(e)}`));
+  if (!r.ok) fail(`catalog HTTP ${r.status} from ${src.location}`);
+  return (await r.json()) as Catalog;
+}
+
+async function plugin(sub: string | undefined, args: string[], flags: Record<string, string | boolean>): Promise<void> {
+  const from = typeof flags.from === "string" ? flags.from : undefined;
+  const json = flags.json === true;
+  const cat = await loadCatalog(from);
+  if (sub === "list") {
+    console.log(json ? JSON.stringify(cat, null, 2) : formatPluginList(cat));
+    return;
+  }
+  if (sub === "info") {
+    const name = args[0];
+    if (!name) fail("usage: omcp plugin info <name>");
+    const c = cat.connectors.find((x) => x.name === name);
+    if (!c) fail(`no connector '${name}' in catalog (try: omcp plugin list)`);
+    console.log(json ? JSON.stringify(c, null, 2) : formatPluginInfo(c));
+    return;
+  }
+  fail(`unknown 'plugin' subcommand: ${sub ?? "(none)"} (list|info)`);
 }
 
 function portInUse(port: number, host = "127.0.0.1"): Promise<boolean> {
@@ -148,7 +200,7 @@ function run(cmd: string, args: string[], cwd: string): number {
 }
 
 async function main(): Promise<void> {
-  const { command, sub, flags } = parseArgs(process.argv.slice(2));
+  const { command, sub, flags, positionals } = parseArgs(process.argv.slice(2));
   const json = flags.json === true;
   switch (command) {
     case "":
@@ -164,6 +216,8 @@ async function main(): Promise<void> {
       return doctor(json);
     case "demo":
       return demo(sub);
+    case "plugin":
+      return plugin(sub, positionals, flags);
     default:
       fail(`unknown command: ${command}\n\n${HELP}`);
   }

--- a/mcp-server/src/cli/lib.test.ts
+++ b/mcp-server/src/cli/lib.test.ts
@@ -1,7 +1,42 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { parseArgs, pickFreePort, composeOverride } from "./lib.js";
+import {
+  parseArgs,
+  pickFreePort,
+  composeOverride,
+  resolveCatalogSource,
+  formatPluginList,
+  formatPluginInfo,
+  DEFAULT_CATALOG_URL,
+  type Catalog,
+} from "./lib.js";
+
+const CAT: Catalog = {
+  catalogVersion: 1,
+  connectors: [
+    {
+      name: "prometheus",
+      displayName: "Prometheus",
+      description: "PromQL metrics.",
+      tier: "official",
+      builtin: true,
+      signalTypes: ["metrics"],
+      latest: "1.4.0",
+      versions: [{ version: "1.4.0", releasedAt: "2026-05-15", serverCompat: ">=1.4.0" }],
+    },
+    {
+      name: "tempo",
+      displayName: "Grafana Tempo",
+      description: "TraceQL.",
+      tier: "third-party",
+      signalTypes: ["traces"],
+      versions: [
+        { version: "1.0.0", releasedAt: "2026-05-15", integrity: "sha256-AAAA=", signatureUrl: "https://x/s.sig" },
+      ],
+    },
+  ],
+};
 
 test("parseArgs: command, sub, positionals", () => {
   const p = parseArgs(["demo", "up", "extra"]);
@@ -48,4 +83,31 @@ test("composeOverride emits !override port mappings", () => {
   assert.match(y, /^services:\n/);
   assert.match(y, /  mcp-server:\n    ports: !override\n      - "3001:3000"/);
   assert.match(y, /  loki:\n    ports: !override\n      - "3101:3100"/);
+});
+
+test("resolveCatalogSource: explicit url, explicit path, local, default", () => {
+  assert.deepEqual(resolveCatalogSource("https://h/x.json", null), { kind: "url", location: "https://h/x.json" });
+  assert.deepEqual(resolveCatalogSource("/tmp/c.json", null), { kind: "file", location: "/tmp/c.json" });
+  assert.deepEqual(resolveCatalogSource(undefined, "/repo/hub/catalog/index.json"), { kind: "file", location: "/repo/hub/catalog/index.json" });
+  assert.deepEqual(resolveCatalogSource(undefined, null), { kind: "url", location: DEFAULT_CATALOG_URL });
+});
+
+test("formatPluginList: header, sorted rows, builtin+tier flags", () => {
+  const out = formatPluginList(CAT);
+  const lines = out.split("\n");
+  assert.match(lines[0], /^NAME\s+LATEST\s+SIGNALS\s+TIER$/);
+  // sorted: prometheus before tempo
+  assert.ok(lines[1].startsWith("prometheus"));
+  assert.match(lines[1], /builtin,official/);
+  assert.ok(lines[2].startsWith("tempo"));
+  assert.match(lines[2], /third-party/);
+});
+
+test("formatPluginInfo: versions + integrity/signature surfaced", () => {
+  const info = formatPluginInfo(CAT.connectors[1]);
+  assert.match(info, /Grafana Tempo {2}\(tempo\)/);
+  assert.match(info, /tier: {6}third-party/);
+  assert.match(info, /1\.0\.0 \(2026-05-15\)/);
+  assert.match(info, /integrity: sha256-AAAA=/);
+  assert.match(info, /signature: https:\/\/x\/s\.sig/);
 });

--- a/mcp-server/src/cli/lib.ts
+++ b/mcp-server/src/cli/lib.ts
@@ -61,6 +61,88 @@ export function composeOverride(
   return `services:\n${services}\n`;
 }
 
+export const DEFAULT_CATALOG_URL =
+  "https://thotischner.github.io/observability-mcp/hub/index.json";
+
+export interface CatalogVersion {
+  version: string;
+  releasedAt?: string;
+  serverCompat?: string;
+  tarballUrl?: string;
+  signatureUrl?: string;
+  manifestUrl?: string;
+  integrity?: string;
+  changelog?: string;
+}
+export interface CatalogConnector {
+  name: string;
+  displayName: string;
+  description: string;
+  tier: string;
+  builtin?: boolean;
+  signalTypes: string[];
+  latest?: string;
+  versions: CatalogVersion[];
+}
+export interface Catalog {
+  catalogVersion: number;
+  connectors: CatalogConnector[];
+}
+
+/**
+ * Decide where to read the catalog from, in priority order:
+ *   1. explicit `from` (a URL or a filesystem path)
+ *   2. a local checkout's hub/catalog/index.json (when localPath exists)
+ *   3. the public Pages catalog
+ */
+export function resolveCatalogSource(
+  from: string | undefined,
+  localPath: string | null
+): { kind: "url" | "file"; location: string } {
+  if (from) {
+    return /^https?:\/\//.test(from)
+      ? { kind: "url", location: from }
+      : { kind: "file", location: from };
+  }
+  if (localPath) return { kind: "file", location: localPath };
+  return { kind: "url", location: DEFAULT_CATALOG_URL };
+}
+
+export function formatPluginList(cat: Catalog): string {
+  const rows = cat.connectors
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((c) => {
+      const latest = c.latest ?? c.versions[0]?.version ?? "—";
+      const flags = [c.builtin ? "builtin" : "", c.tier].filter(Boolean).join(",");
+      return [c.name, latest, c.signalTypes.join("+"), flags];
+    });
+  const head = ["NAME", "LATEST", "SIGNALS", "TIER"];
+  const widths = head.map((h, i) =>
+    Math.max(h.length, ...rows.map((r) => r[i].length))
+  );
+  const line = (cols: string[]) =>
+    cols.map((c, i) => c.padEnd(widths[i])).join("  ").trimEnd();
+  return [line(head), ...rows.map(line)].join("\n");
+}
+
+export function formatPluginInfo(c: CatalogConnector): string {
+  const out: string[] = [];
+  out.push(`${c.displayName}  (${c.name})`);
+  out.push(`  tier:      ${c.tier}${c.builtin ? " · builtin (ships in the server image)" : ""}`);
+  out.push(`  signals:   ${c.signalTypes.join(", ")}`);
+  out.push(`  ${c.description}`);
+  out.push(`  versions:`);
+  for (const v of c.versions) {
+    out.push(`    - ${v.version}${v.releasedAt ? ` (${v.releasedAt})` : ""}${v.serverCompat ? ` · server ${v.serverCompat}` : ""}`);
+    if (v.integrity) out.push(`      integrity: ${v.integrity}`);
+    if (v.signatureUrl) out.push(`      signature: ${v.signatureUrl}`);
+    if (v.tarballUrl) out.push(`      tarball:   ${v.tarballUrl}`);
+    if (v.changelog) out.push(`      changelog: ${v.changelog}`);
+  }
+  return out.join("\n");
+}
+
 export const HELP = `omcp — observability-mcp control CLI
 
 Usage:
@@ -69,8 +151,11 @@ Usage:
   omcp demo up                 Start the full demo stack (auto-picks free host ports)
   omcp demo down               Stop and remove the demo stack
   omcp demo status             Show demo container status
+  omcp plugin list             List connectors from the hub catalog
+  omcp plugin info <name>      Show one connector's versions + verification info
   omcp help                    Show this help
 
 Flags:
-  --json                       Machine-readable output (doctor, status)
+  --json                       Machine-readable output (doctor, status, plugin)
+  --from <url|path>            Catalog source (default: local checkout or the public hub)
 `;


### PR DESCRIPTION
## Summary
Slice 3 of the `omcp` CLI — the Confluent-Hub-analogous discovery commands.

- `omcp plugin list` — aligned table (name, latest, signals, tier/builtin).
- `omcp plugin info <name>` — versions with `integrity` / `signatureUrl` / `serverCompat` / changelog.
- Source resolution: `--from <url|path>` → local checkout `hub/catalog/index.json` → public Pages hub (`https://thotischner.github.io/observability-mcp/hub/index.json`). `--json` for machine output.
- Pure formatting + source-resolution in `lib.ts`; +3 tests (10 total).

## Test plan
- [x] `tsc --noEmit` clean (Docker)
- [x] `tsx --test src/cli/lib.test.ts` → 10/10
- [x] End-to-end against the live hub: `plugin list` + `plugin info loki` render correctly