### PR TITLE
feat(cli): omcp plugin install with fail-closed verify (slice 4)

### DIFF
--- a/mcp-server/src/cli/index.ts
+++ b/mcp-server/src/cli/index.ts
@@ -1,8 +1,18 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
 import { createConnection } from "node:net";
-import { existsSync, readFileSync, writeFileSync, mkdtempSync } from "node:fs";
-import { join, dirname } from "node:path";
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  readdirSync,
+  statSync,
+  cpSync,
+} from "node:fs";
+import { join, dirname, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
@@ -13,9 +23,16 @@ import {
   resolveCatalogSource,
   formatPluginList,
   formatPluginInfo,
+  resolveInstall,
   HELP,
   type Catalog,
 } from "./lib.js";
+import {
+  loadTrustRoot,
+  verifyIntegrity,
+  verifyManifestSignature,
+  PluginVerificationError,
+} from "../connectors/verify.js";
 
 function pkgVersion(): string {
   try {
@@ -91,7 +108,117 @@ async function plugin(sub: string | undefined, args: string[], flags: Record<str
     console.log(json ? JSON.stringify(c, null, 2) : formatPluginInfo(c));
     return;
   }
-  fail(`unknown 'plugin' subcommand: ${sub ?? "(none)"} (list|info)`);
+  if (sub === "install") {
+    return installPlugin(cat, args[0], flags);
+  }
+  fail(`unknown 'plugin' subcommand: ${sub ?? "(none)"} (list|info|install)`);
+}
+
+function tarExtract(tgz: string, dest: string): void {
+  const r = spawnSync("tar", ["-xzf", tgz, "-C", dest], { stdio: "inherit" });
+  if (r.status !== 0) fail(`tar extraction failed for ${tgz}`);
+}
+
+// Find the dir containing a package.json with the observabilityMcp
+// connector marker (npm pack nests under package/; airgapped tarballs
+// may not).
+function findPluginRoot(base: string): string | null {
+  const candidates = [base, ...readdirSync(base).map((e) => join(base, e))];
+  for (const dir of candidates) {
+    try {
+      if (!statSync(dir).isDirectory()) continue;
+      const pkgPath = join(dir, "package.json");
+      if (!existsSync(pkgPath)) continue;
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+      if (pkg.observabilityMcp?.kind === "connector") return dir;
+    } catch {
+      /* skip */
+    }
+  }
+  return null;
+}
+
+async function installPlugin(
+  cat: Catalog,
+  ref: string | undefined,
+  flags: Record<string, string | boolean>
+): Promise<void> {
+  if (!ref) fail("usage: omcp plugin install <name>[@version]");
+  let r;
+  try {
+    r = resolveInstall(cat, ref);
+  } catch (e) {
+    fail(e instanceof Error ? e.message : String(e));
+  }
+  if (r.builtin) {
+    console.log(`'${r.name}' is builtin — it ships in the server image, no install needed.`);
+    return;
+  }
+
+  const offlineDir = typeof flags["offline-dir"] === "string" ? (flags["offline-dir"] as string) : undefined;
+  const dest = resolve(
+    typeof flags.dest === "string" ? (flags.dest as string) : process.env.PLUGINS_DIR ?? "./plugins"
+  );
+  const targetDir = join(dest, r.name);
+  if (existsSync(targetDir) && flags.force !== true) {
+    fail(`${targetDir} already exists (pass --force to overwrite)`);
+  }
+
+  const work = mkdtempSync(join(tmpdir(), "omcp-inst-"));
+  const tgz = join(work, "plugin.tgz");
+
+  if (offlineDir) {
+    const local = join(offlineDir, `${r.name}-${r.version}.tgz`);
+    if (!existsSync(local)) fail(`offline tarball not found: ${local}`);
+    cpSync(local, tgz);
+  } else {
+    if (!r.tarballUrl) fail(`catalog entry for ${r.name}@${r.version} has no tarballUrl`);
+    const resp = await fetch(r.tarballUrl).catch((e) => fail(`download failed: ${String(e)}`));
+    if (!resp.ok) fail(`tarball HTTP ${resp.status}`);
+    writeFileSync(tgz, Buffer.from(await resp.arrayBuffer()));
+  }
+
+  const stage = join(work, "stage");
+  mkdirSync(stage);
+  tarExtract(tgz, stage);
+  const root = findPluginRoot(stage);
+  if (!root) fail("no connector package.json (observabilityMcp marker) in tarball");
+
+  const pkg = JSON.parse(readFileSync(join(root!, "package.json"), "utf8"));
+  const manifestRel = pkg.observabilityMcp?.manifest;
+  if (!manifestRel) fail("package.json has no observabilityMcp.manifest");
+  const manifestPath = resolve(root!, manifestRel);
+  if (!existsSync(manifestPath)) fail(`manifest not found: ${manifestRel}`);
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const entryPath = resolve(root!, pkg.main || "index.js");
+
+  if (flags.insecure === true) {
+    console.warn("WARNING: --insecure — skipping signature + integrity verification.");
+  } else {
+    const trustRootPath = typeof flags["trust-root"] === "string" ? (flags["trust-root"] as string) : undefined;
+    if (!trustRootPath) {
+      fail(
+        "verification required: pass --trust-root <pem> (or --insecure to explicitly opt out)"
+      );
+    }
+    const sigPath = manifestPath + ".sig";
+    if (!existsSync(sigPath)) fail(`missing manifest signature: ${manifestRel}.sig`);
+    try {
+      const trustRoot = loadTrustRoot(trustRootPath!);
+      verifyManifestSignature(readFileSync(manifestPath), readFileSync(sigPath), trustRoot);
+      verifyIntegrity(entryPath, manifest.integrity);
+    } catch (e) {
+      const msg = e instanceof PluginVerificationError ? e.message : String(e);
+      fail(`verification failed (fail-closed): ${msg}`);
+    }
+    console.log("signature + integrity OK");
+  }
+
+  mkdirSync(dest, { recursive: true });
+  if (existsSync(targetDir)) rmSync(targetDir, { recursive: true, force: true });
+  cpSync(root!, targetDir, { recursive: true });
+  rmSync(work, { recursive: true, force: true });
+  console.log(`installed ${r.name}@${r.version} → ${targetDir}`);
 }
 
 function portInUse(port: number, host = "127.0.0.1"): Promise<boolean> {

--- a/mcp-server/src/cli/lib.test.ts
+++ b/mcp-server/src/cli/lib.test.ts
@@ -111,3 +111,30 @@ test("formatPluginInfo: versions + integrity/signature surfaced", () => {
   assert.match(info, /integrity: sha256-AAAA=/);
   assert.match(info, /signature: https:\/\/x\/s\.sig/);
 });
+
+import { parsePluginRef, resolveInstall } from "./lib.js";
+
+test("parsePluginRef: name and name@version, rejects junk", () => {
+  assert.deepEqual(parsePluginRef("tempo"), { name: "tempo", version: undefined });
+  assert.deepEqual(parsePluginRef("tempo@1.2.3"), { name: "tempo", version: "1.2.3" });
+  assert.deepEqual(parsePluginRef("x@1.0.0-rc.1"), { name: "x", version: "1.0.0-rc.1" });
+  assert.throws(() => parsePluginRef("Bad Name"), /invalid plugin ref/);
+  assert.throws(() => parsePluginRef("tempo@v1"), /invalid plugin ref/);
+});
+
+test("resolveInstall: builtin short-circuits", () => {
+  const r = resolveInstall(CAT, "prometheus");
+  assert.equal(r.builtin, true);
+  assert.equal(r.name, "prometheus");
+});
+
+test("resolveInstall: picks latest then specific version", () => {
+  const def = resolveInstall(CAT, "tempo");
+  assert.equal(def.version, "1.0.0");
+  assert.equal(def.builtin, false);
+  assert.equal(def.integrity, "sha256-AAAA=");
+  const pinned = resolveInstall(CAT, "tempo@1.0.0");
+  assert.equal(pinned.version, "1.0.0");
+  assert.throws(() => resolveInstall(CAT, "tempo@9.9.9"), /not found/);
+  assert.throws(() => resolveInstall(CAT, "ghost"), /no connector/);
+});

--- a/mcp-server/src/cli/lib.ts
+++ b/mcp-server/src/cli/lib.ts
@@ -143,6 +143,48 @@ export function formatPluginInfo(c: CatalogConnector): string {
   return out.join("\n");
 }
 
+/** Split "name" or "name@1.2.3" into parts. Throws on a malformed ref. */
+export function parsePluginRef(ref: string): { name: string; version?: string } {
+  const m = ref.match(/^([a-z][a-z0-9-]*)(?:@(\d+\.\d+\.\d+(?:-[a-z0-9.-]+)?))?$/);
+  if (!m) throw new Error(`invalid plugin ref '${ref}' (expected name or name@x.y.z)`);
+  return { name: m[1], version: m[2] };
+}
+
+export interface ResolvedInstall {
+  name: string;
+  version: string;
+  builtin: boolean;
+  tarballUrl?: string;
+  signatureUrl?: string;
+  manifestUrl?: string;
+  integrity?: string;
+}
+
+/**
+ * Resolve a catalog + ref into the concrete artifact to install.
+ * Returns {builtin:true} for image-bundled connectors (caller should
+ * no-op). Throws if the connector/version is unknown.
+ */
+export function resolveInstall(cat: Catalog, ref: string): ResolvedInstall {
+  const { name, version } = parsePluginRef(ref);
+  const c = cat.connectors.find((x) => x.name === name);
+  if (!c) throw new Error(`no connector '${name}' in catalog (try: omcp plugin list)`);
+  if (c.builtin) return { name, version: version ?? c.latest ?? "", builtin: true };
+  const v = version
+    ? c.versions.find((x) => x.version === version)
+    : c.versions.find((x) => x.version === (c.latest ?? c.versions[0]?.version)) ?? c.versions[0];
+  if (!v) throw new Error(`version '${version}' not found for '${name}'`);
+  return {
+    name,
+    version: v.version,
+    builtin: false,
+    tarballUrl: v.tarballUrl,
+    signatureUrl: v.signatureUrl,
+    manifestUrl: v.manifestUrl,
+    integrity: v.integrity,
+  };
+}
+
 export const HELP = `omcp — observability-mcp control CLI
 
 Usage:
@@ -153,9 +195,15 @@ Usage:
   omcp demo status             Show demo container status
   omcp plugin list             List connectors from the hub catalog
   omcp plugin info <name>      Show one connector's versions + verification info
+  omcp plugin install <ref>    Install name[@version]: download, verify, extract
   omcp help                    Show this help
 
 Flags:
   --json                       Machine-readable output (doctor, status, plugin)
   --from <url|path>            Catalog source (default: local checkout or the public hub)
+  --offline-dir <dir>          Airgapped: read <name>-<ver>.tgz[.sig] + manifest from <dir>
+  --trust-root <pem>           Verify signature+integrity against this PEM (fail-closed)
+  --insecure                   Skip verification (NOT recommended; explicit opt-out)
+  --dest <dir>                 Install target (default: $PLUGINS_DIR or ./plugins)
+  --force                      Overwrite an existing install dir
 `;


### PR DESCRIPTION
## Summary
Slice 4 — the core Confluent-Hub-analog: `omcp plugin install <name>[@version]`.

- Resolves the catalog entry; downloads the tarball, or reads `<name>-<ver>.tgz` from `--offline-dir` (airgapped).
- Extracts, locates the connector package, then **reuses `connectors/verify.ts`** (the exact server verification) to check the manifest signature against `--trust-root` and the entry-file integrity.
- **Fail-closed**: refuses without `--trust-root` (explicit `--insecure` to opt out); tampered content is rejected. Builtins short-circuit (no-op).
- Installs into `$PLUGINS_DIR/<name>` (or `--dest`), `--force` to overwrite.

## Test plan
- [x] `tsc --noEmit` clean (Docker)
- [x] 13/13 unit tests (parsePluginRef, resolveInstall added)
- [x] E2E in Docker: ed25519-signed tarball installs (sig+integrity OK); tampered entry rejected fail-closed; missing `--trust-root` refused