### PR TITLE
feat(cli): omcp helm install|upgrade (slice 6) + README CLI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,23 @@ curl -X POST http://localhost:8081/chaos/reset
 
 The agent ([docs/agent.md](docs/agent.md)) detects anomalies within 30 seconds and produces an LLM incident analysis if Ollama is running.
 
+## CLI (`omcp`)
+
+A Confluent-style control CLI ships in the same npm package (`omcp` bin):
+
+```bash
+omcp doctor                       # check docker / compose / helm / node
+omcp demo up                      # full demo stack (auto-picks free host ports)
+omcp plugin list                  # browse the connector hub catalog
+omcp plugin install tempo@1.2.0 --trust-root key.pem    # download + verify + extract
+omcp plugin verify ./plugins/tempo --trust-root key.pem # offline audit
+omcp helm upgrade obs -- -n monitoring --set sources.prometheusUrl=http://prom:9090
+```
+
+Plugin install/verify reuse the server's fail-closed signature + integrity
+checks (offline-capable; `--offline-dir` for airgapped). Extra `helm`
+flags pass through after a literal `--`.
+
 ## Docs
 
 - [Configuration](docs/configuration.md) — paths, env vars, `${VAR}` substitution, full `sources.yaml` reference

--- a/mcp-server/src/cli/index.ts
+++ b/mcp-server/src/cli/index.ts
@@ -24,6 +24,10 @@ import {
   formatPluginList,
   formatPluginInfo,
   resolveInstall,
+  splitPassthrough,
+  helmReleaseArgs,
+  HELM_REPO_NAME,
+  HELM_REPO_URL,
   HELP,
   type Catalog,
 } from "./lib.js";
@@ -338,13 +342,37 @@ async function demo(sub: string | undefined): Promise<void> {
   process.exit(code);
 }
 
+function helm(sub: string | undefined, release: string, passthrough: string[]): void {
+  if (sub !== "install" && sub !== "upgrade") {
+    fail(`unknown 'helm' subcommand: ${sub ?? "(none)"} (install|upgrade)`);
+  }
+  if (!which("helm", ["version", "--short"])) {
+    fail("helm not found on PATH (see: https://helm.sh/docs/intro/install/)");
+  }
+  const cwd = process.cwd();
+  // Idempotent: --force-update tolerates an existing repo entry.
+  if (run("helm", ["repo", "add", HELM_REPO_NAME, HELM_REPO_URL, "--force-update"], cwd) !== 0) {
+    fail("helm repo add failed");
+  }
+  if (run("helm", ["repo", "update", HELM_REPO_NAME], cwd) !== 0) {
+    fail("helm repo update failed");
+  }
+  const args = helmReleaseArgs(sub, release, passthrough);
+  const code = run("helm", args, cwd);
+  if (code === 0) {
+    console.log(`\nhelm ${sub} ok: release '${release}' from the signed ${HELM_REPO_NAME} chart.`);
+  }
+  process.exit(code);
+}
+
 function run(cmd: string, args: string[], cwd: string): number {
   const r = spawnSync(cmd, args, { cwd, stdio: "inherit" });
   return r.status ?? 1;
 }
 
 async function main(): Promise<void> {
-  const { command, sub, flags, positionals } = parseArgs(process.argv.slice(2));
+  const { argv: pre, passthrough } = splitPassthrough(process.argv.slice(2));
+  const { command, sub, flags, positionals } = parseArgs(pre);
   const json = flags.json === true;
   switch (command) {
     case "":
@@ -362,6 +390,8 @@ async function main(): Promise<void> {
       return demo(sub);
     case "plugin":
       return plugin(sub, positionals, flags);
+    case "helm":
+      return helm(sub, positionals[0] ?? "observability-mcp", passthrough);
     default:
       fail(`unknown command: ${command}\n\n${HELP}`);
   }

--- a/mcp-server/src/cli/lib.test.ts
+++ b/mcp-server/src/cli/lib.test.ts
@@ -138,3 +138,28 @@ test("resolveInstall: picks latest then specific version", () => {
   assert.throws(() => resolveInstall(CAT, "tempo@9.9.9"), /not found/);
   assert.throws(() => resolveInstall(CAT, "ghost"), /no connector/);
 });
+
+import { splitPassthrough, helmReleaseArgs, HELM_CHART } from "./lib.js";
+
+test("splitPassthrough: splits at first -- ", () => {
+  assert.deepEqual(splitPassthrough(["helm", "install", "obs"]), {
+    argv: ["helm", "install", "obs"],
+    passthrough: [],
+  });
+  assert.deepEqual(
+    splitPassthrough(["helm", "upgrade", "obs", "--", "-n", "mon", "--set", "a=b"]),
+    { argv: ["helm", "upgrade", "obs"], passthrough: ["-n", "mon", "--set", "a=b"] }
+  );
+});
+
+test("helmReleaseArgs: install vs upgrade --install, passthrough appended", () => {
+  assert.deepEqual(helmReleaseArgs("install", "obs", []), ["install", "obs", HELM_CHART]);
+  assert.deepEqual(helmReleaseArgs("upgrade", "obs", ["-n", "mon"]), [
+    "upgrade",
+    "--install",
+    "obs",
+    HELM_CHART,
+    "-n",
+    "mon",
+  ]);
+});

--- a/mcp-server/src/cli/lib.ts
+++ b/mcp-server/src/cli/lib.ts
@@ -185,6 +185,34 @@ export function resolveInstall(cat: Catalog, ref: string): ResolvedInstall {
   };
 }
 
+export const HELM_REPO_NAME = "observability-mcp";
+export const HELM_REPO_URL = "https://thotischner.github.io/observability-mcp/";
+export const HELM_CHART = "observability-mcp/observability-mcp";
+
+/**
+ * Split argv at the first standalone "--": everything after it is
+ * passed verbatim to the wrapped tool (helm). Keeps omcp from having to
+ * re-implement helm's flag grammar (repeatable --set, -n, -f, ...).
+ */
+export function splitPassthrough(argv: string[]): { argv: string[]; passthrough: string[] } {
+  const i = argv.indexOf("--");
+  if (i === -1) return { argv, passthrough: [] };
+  return { argv: argv.slice(0, i), passthrough: argv.slice(i + 1) };
+}
+
+/** The helm argv for the install/upgrade step (repo add/update are fixed). */
+export function helmReleaseArgs(
+  action: "install" | "upgrade",
+  release: string,
+  passthrough: string[]
+): string[] {
+  const head =
+    action === "upgrade"
+      ? ["upgrade", "--install", release, HELM_CHART]
+      : ["install", release, HELM_CHART];
+  return [...head, ...passthrough];
+}
+
 export const HELP = `omcp — observability-mcp control CLI
 
 Usage:
@@ -197,7 +225,12 @@ Usage:
   omcp plugin info <name>      Show one connector's versions + verification info
   omcp plugin install <ref>    Install name[@version]: download, verify, extract
   omcp plugin verify <dir>     Verify an installed plugin dir against a trust root
+  omcp helm install [release]  helm repo add+update, then install the signed chart
+  omcp helm upgrade [release]  Same, as 'helm upgrade --install'
   omcp help                    Show this help
+
+Pass extra helm flags after a literal --, e.g.:
+  omcp helm upgrade obs -- -n monitoring --set sources.prometheusUrl=http://prom:9090
 
 Flags:
   --json                       Machine-readable output (doctor, status, plugin)


### PR DESCRIPTION
## Summary
Final `omcp` CLI slice — the Helm wrapper, plus README docs for the now-complete CLI.

- `omcp helm install|upgrade [release]`: idempotent `helm repo add --force-update` + `repo update`, then `install` (or `upgrade --install`) of the **signed** chart.
- Extra helm flags pass through verbatim after a literal `--` (repeatable `--set`, `-n`, `-f`, `--version` — no re-implementing helm's grammar). Guards on missing `helm`.
- README gains a concise `## CLI (omcp)` section now that all 6 slices (doctor/demo/plugin list·info·install·verify/helm) are done.

## Test plan
- [x] `tsc --noEmit` clean; 15/15 unit tests (splitPassthrough, helmReleaseArgs added)
- [x] Functional (Docker): no-sub + bad-sub error correctly; missing-helm guard fires; `help` lists the helm commands