### PR TITLE
feat(connector): Datadog — first optional hub-installable connector

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -54,6 +54,18 @@ jobs:
         run: |
           node hub/build-catalog.mjs --check
           node --test hub/build-catalog.test.mjs
+      - name: Datadog connector (tests + manifest integrity in sync)
+        run: |
+          node --test connectors/datadog/*.test.mjs
+          node -e '
+            const c=require("crypto"),fs=require("fs");
+            const i="sha256-"+c.createHash("sha256").update(fs.readFileSync("connectors/datadog/index.js")).digest("base64");
+            const m=JSON.parse(fs.readFileSync("connectors/datadog/manifest.json"));
+            if(m.integrity!==i){console.error("manifest.integrity stale: "+m.integrity+" != "+i);process.exit(1)}
+            const cat=JSON.parse(fs.readFileSync("hub/catalog/datadog.json"));
+            if(cat.versions[0].integrity!==i){console.error("catalog integrity stale");process.exit(1)}
+            console.log("datadog integrity in sync");
+          '
 
   trivy:
     runs-on: ubuntu-latest

--- a/connectors/datadog/index.js
+++ b/connectors/datadog/index.js
@@ -1,0 +1,220 @@
+// Datadog connector for observability-mcp — the first optional,
+// hub-distributable connector. Standalone ESM, zero dependencies
+// (Node 20+ global fetch), so it ships as a self-contained tarball and
+// runs airgapped once mirrored.
+//
+// Implements the structural ObservabilityConnector contract (duck-typed
+// by the server's PluginLoader — no SDK import needed).
+//
+// Auth: Datadog needs TWO keys. Map them onto SourceConfig as basic
+// auth — username = API key, password = Application key — or fall back
+// to DD_API_KEY / DD_APP_KEY env vars (handy behind an egress proxy).
+
+const DEFAULT_SITE = "https://api.datadoghq.com";
+
+function parseTimeRange(duration) {
+  const m = String(duration || "").match(/^(\d+)([mhd])$/);
+  if (!m) throw new Error(`invalid duration: ${duration} (use 5m, 1h, 24h)`);
+  const n = parseInt(m[1], 10);
+  const secs = m[2] === "m" ? n * 60 : m[2] === "h" ? n * 3600 : n * 86400;
+  const end = Math.floor(Date.now() / 1000);
+  return { from: end - secs, to: end };
+}
+
+function computeTrend(values) {
+  if (values.length < 4) return "stable";
+  const mid = Math.floor(values.length / 2);
+  const a = values.slice(0, mid).reduce((x, y) => x + y, 0) / mid;
+  const b = values.slice(mid).reduce((x, y) => x + y, 0) / (values.length - mid);
+  const pct = ((b - a) / (a || 1)) * 100;
+  return pct > 10 ? "rising" : pct < -10 ? "falling" : "stable";
+}
+
+function summarize(values) {
+  if (values.length === 0) return { current: 0, average: 0, min: 0, max: 0, trend: "stable" };
+  return {
+    current: values[values.length - 1],
+    average: values.reduce((a, b) => a + b, 0) / values.length,
+    min: Math.min(...values),
+    max: Math.max(...values),
+    trend: computeTrend(values),
+  };
+}
+
+const DEFAULT_METRICS = [
+  { name: "cpu", query: "avg:system.cpu.user{service:$service}", unit: "percent", description: "CPU user time for the service" },
+  { name: "memory", query: "avg:system.mem.used{service:$service}", unit: "bytes", description: "Used memory for the service" },
+  { name: "latency", query: "avg:trace.http.request.duration{service:$service}", unit: "seconds", description: "APM request latency (p50 avg)" },
+  { name: "errors", query: "sum:trace.http.request.errors{service:$service}.as_count()", unit: "count", description: "APM request error count" },
+];
+
+export class DatadogConnector {
+  constructor() {
+    this.name = "datadog";
+    this.type = "datadog";
+    this.signalType = "metrics";
+    this._metrics = DEFAULT_METRICS;
+    this._base = DEFAULT_SITE;
+    this._apiKey = "";
+    this._appKey = "";
+  }
+
+  async connect(config) {
+    // config.url may be a full API base (e.g. https://api.datadoghq.eu).
+    this._base = (config && config.url) ? String(config.url).replace(/\/$/, "") : DEFAULT_SITE;
+    const auth = (config && config.auth) || {};
+    this._apiKey = auth.username || process.env.DD_API_KEY || "";
+    this._appKey = auth.password || process.env.DD_APP_KEY || "";
+    if (Array.isArray(config && config.metrics) && config.metrics.length > 0) {
+      this._metrics = config.metrics;
+    }
+    if (!this._apiKey) {
+      throw new Error("Datadog API key missing (set source auth username = API key, or DD_API_KEY)");
+    }
+  }
+
+  async disconnect() {
+    /* stateless: nothing to tear down */
+  }
+
+  _headers(needsApp) {
+    const h = { "DD-API-KEY": this._apiKey };
+    if (needsApp && this._appKey) h["DD-APPLICATION-KEY"] = this._appKey;
+    return h;
+  }
+
+  async healthCheck() {
+    const started = Date.now();
+    try {
+      const res = await fetch(`${this._base}/api/v1/validate`, { headers: this._headers(false) });
+      const latencyMs = Date.now() - started;
+      if (!res.ok) return { status: "down", latencyMs, message: `validate HTTP ${res.status}` };
+      const body = await res.json().catch(() => ({}));
+      return body && body.valid
+        ? { status: "up", latencyMs }
+        : { status: "down", latencyMs, message: "API key rejected" };
+    } catch (e) {
+      return { status: "down", latencyMs: Date.now() - started, message: String(e) };
+    }
+  }
+
+  getDefaultMetrics() {
+    return DEFAULT_METRICS;
+  }
+
+  getMetrics() {
+    return this._metrics;
+  }
+
+  async _query(q, from, to) {
+    const u = new URL(`${this._base}/api/v1/query`);
+    u.searchParams.set("from", String(from));
+    u.searchParams.set("to", String(to));
+    u.searchParams.set("query", q);
+    const res = await fetch(u, { headers: this._headers(true) });
+    if (!res.ok) throw new Error(`Datadog query HTTP ${res.status}`);
+    return res.json();
+  }
+
+  async listServices() {
+    // Derive services from a broad metric grouped by the service tag.
+    // Best-effort: never throw — discovery failure shouldn't break the
+    // server, the user can still query by explicit service name.
+    try {
+      const { from, to } = parseTimeRange("1h");
+      const body = await this._query("avg:system.cpu.user{*} by {service}", from, to);
+      const names = new Set();
+      for (const s of (body && body.series) || []) {
+        const scope = String(s.scope || "");
+        const m = scope.match(/service:([^,]+)/);
+        if (m) names.add(m[1]);
+      }
+      return [...names].map((name) => ({
+        name,
+        source: this.name,
+        signalType: "metrics",
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  async queryMetrics(params) {
+    const def = this._metrics.find((m) => m.name === params.metric)
+      || DEFAULT_METRICS.find((m) => m.name === params.metric);
+    if (!def) throw new Error(`unknown metric '${params.metric}' for datadog`);
+    const { from, to } = parseTimeRange(params.duration);
+    const q = def.query.replace(/\$service\b/g, params.service);
+    const body = await this._query(q, from, to);
+    const series = (body && body.series && body.series[0]) || null;
+    const points = (series && series.pointlist) || [];
+    const dps = points
+      .filter((p) => Array.isArray(p) && p[1] != null && !Number.isNaN(p[1]))
+      .map((p) => ({
+        // Datadog pointlist timestamps are epoch milliseconds.
+        timestamp: new Date(p[0]).toISOString(),
+        value: Number(p[1]),
+      }));
+    return {
+      source: this.name,
+      service: params.service,
+      metric: params.metric,
+      unit: def.unit,
+      values: dps,
+      summary: summarize(dps.map((d) => d.value)),
+      resolvedSeries: q,
+    };
+  }
+
+  async queryLogs(params) {
+    const { from, to } = parseTimeRange(params.duration);
+    const filterParts = [`service:${params.service}`];
+    if (params.level) filterParts.push(`status:${params.level}`);
+    if (params.query) filterParts.push(params.query);
+    const res = await fetch(`${this._base}/api/v2/logs/events/search`, {
+      method: "POST",
+      headers: { ...this._headers(true), "Content-Type": "application/json" },
+      body: JSON.stringify({
+        filter: {
+          query: filterParts.join(" "),
+          from: `${from}000`,
+          to: `${to}000`,
+        },
+        page: { limit: Math.min(params.limit || 100, 1000) },
+        sort: "-timestamp",
+      }),
+    });
+    if (!res.ok) throw new Error(`Datadog logs HTTP ${res.status}`);
+    const body = await res.json();
+    const events = (body && body.data) || [];
+    let errorCount = 0;
+    let warnCount = 0;
+    const entries = events.map((ev) => {
+      const a = (ev && ev.attributes) || {};
+      const level = String(a.status || "info").toLowerCase();
+      if (level === "error" || level === "critical" || level === "emergency") errorCount++;
+      else if (level === "warn" || level === "warning") warnCount++;
+      return {
+        timestamp: a.timestamp ? new Date(a.timestamp).toISOString() : new Date().toISOString(),
+        level,
+        message: String(a.message || ""),
+        labels: { service: (a.service || params.service) },
+      };
+    });
+    return {
+      source: this.name,
+      service: params.service,
+      entries,
+      summary: {
+        total: entries.length,
+        errorCount,
+        warnCount,
+        topPatterns: [],
+      },
+    };
+  }
+}
+
+export default function create() {
+  return new DatadogConnector();
+}

--- a/connectors/datadog/index.test.mjs
+++ b/connectors/datadog/index.test.mjs
@@ -1,0 +1,104 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import create, { DatadogConnector } from "./index.js";
+
+function mockFetch(routes) {
+  return async (url, opts) => {
+    const u = typeof url === "string" ? url : url.toString();
+    for (const [pat, handler] of routes) {
+      if (u.includes(pat)) return handler(u, opts);
+    }
+    return { ok: false, status: 404, json: async () => ({}) };
+  };
+}
+const ok = (body) => ({ ok: true, status: 200, json: async () => body });
+
+test("create() returns a DatadogConnector with the right shape", () => {
+  const c = create();
+  assert.ok(c instanceof DatadogConnector);
+  assert.equal(c.name, "datadog");
+  assert.equal(c.signalType, "metrics");
+  assert.equal(c.getDefaultMetrics().length, 4);
+});
+
+test("connect requires an API key", async () => {
+  const c = create();
+  await assert.rejects(() => c.connect({ url: "https://api.datadoghq.eu", auth: {} }), /API key missing/);
+  delete process.env.DD_API_KEY;
+});
+
+test("connect honors config.url and basic-auth key mapping", async () => {
+  const c = create();
+  await c.connect({ url: "https://api.datadoghq.eu/", auth: { username: "API", password: "APP" } });
+  assert.equal(c._base, "https://api.datadoghq.eu");
+  assert.equal(c._apiKey, "API");
+  assert.equal(c._appKey, "APP");
+});
+
+test("healthCheck up / down", async () => {
+  const c = create();
+  await c.connect({ auth: { username: "k" } });
+  globalThis.fetch = mockFetch([["/api/v1/validate", () => ok({ valid: true })]]);
+  assert.equal((await c.healthCheck()).status, "up");
+  globalThis.fetch = mockFetch([["/api/v1/validate", () => ({ ok: true, status: 200, json: async () => ({ valid: false }) })]]);
+  assert.equal((await c.healthCheck()).status, "down");
+  globalThis.fetch = mockFetch([["/api/v1/validate", () => ({ ok: false, status: 403, json: async () => ({}) })]]);
+  assert.equal((await c.healthCheck()).status, "down");
+});
+
+test("queryMetrics maps pointlist, substitutes $service, summarizes", async () => {
+  const c = create();
+  await c.connect({ auth: { username: "k", password: "a" } });
+  let seenQuery = "";
+  globalThis.fetch = mockFetch([
+    ["/api/v1/query", (u) => {
+      seenQuery = new URL(u).searchParams.get("query");
+      return ok({ series: [{ pointlist: [[1000, 10], [2000, null], [3000, 30]] }] });
+    }],
+  ]);
+  const r = await c.queryMetrics({ service: "checkout", metric: "cpu", duration: "1h" });
+  assert.match(seenQuery, /service:checkout/);
+  assert.equal(r.values.length, 2); // null point filtered
+  assert.equal(r.unit, "percent");
+  assert.equal(r.summary.current, 30);
+  assert.equal(r.values[0].timestamp, new Date(1000).toISOString());
+});
+
+test("queryMetrics rejects unknown metric and bad duration", async () => {
+  const c = create();
+  await c.connect({ auth: { username: "k" } });
+  await assert.rejects(() => c.queryMetrics({ service: "s", metric: "nope", duration: "1h" }), /unknown metric/);
+  await assert.rejects(() => c.queryMetrics({ service: "s", metric: "cpu", duration: "bogus" }), /invalid duration/);
+});
+
+test("listServices parses service tags, never throws", async () => {
+  const c = create();
+  await c.connect({ auth: { username: "k" } });
+  globalThis.fetch = mockFetch([
+    ["/api/v1/query", () => ok({ series: [{ scope: "service:api,env:prod" }, { scope: "service:db" }] })],
+  ]);
+  const svcs = await c.listServices();
+  assert.deepEqual(svcs.map((s) => s.name).sort(), ["api", "db"]);
+  globalThis.fetch = async () => { throw new Error("network down"); };
+  assert.deepEqual(await c.listServices(), []);
+});
+
+test("queryLogs maps events + counts levels", async () => {
+  const c = create();
+  await c.connect({ auth: { username: "k", password: "a" } });
+  globalThis.fetch = mockFetch([
+    ["/api/v2/logs/events/search", () => ok({
+      data: [
+        { attributes: { timestamp: "2026-05-15T10:00:00Z", status: "error", message: "boom", service: "api" } },
+        { attributes: { timestamp: "2026-05-15T10:01:00Z", status: "warn", message: "slow" } },
+        { attributes: { timestamp: "2026-05-15T10:02:00Z", status: "info", message: "ok" } },
+      ],
+    })],
+  ]);
+  const r = await c.queryLogs({ service: "api", duration: "15m", level: "error" });
+  assert.equal(r.entries.length, 3);
+  assert.equal(r.summary.errorCount, 1);
+  assert.equal(r.summary.warnCount, 1);
+  assert.equal(r.entries[0].level, "error");
+});

--- a/connectors/datadog/manifest.json
+++ b/connectors/datadog/manifest.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "name": "datadog",
+  "displayName": "Datadog",
+  "version": "1.0.0",
+  "description": "Datadog connector — metrics via the v1 query API and logs via the v2 logs search API. Auth with a Datadog API key (+ Application key for queries).",
+  "signalTypes": ["metrics", "logs"],
+  "homepage": "https://github.com/ThoTischner/observability-mcp",
+  "license": "MIT",
+  "capabilities": {
+    "queryMetrics": true,
+    "queryLogs": true,
+    "listServices": true
+  },
+  "compat": {
+    "serverVersion": ">=1.4.0"
+  },
+  "integrity": "sha256-dTTTxcNMEiHv6sbkMf9UQu7tUDZrt45bd1JKvoiymxI="
+}

--- a/connectors/datadog/package.json
+++ b/connectors/datadog/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@observability-mcp/connector-datadog",
+  "version": "1.0.0",
+  "description": "Datadog connector for observability-mcp — metrics + logs via the Datadog API.",
+  "type": "module",
+  "main": "./index.js",
+  "license": "MIT",
+  "files": ["index.js", "manifest.json"],
+  "observabilityMcp": {
+    "kind": "connector",
+    "name": "datadog",
+    "manifest": "./manifest.json"
+  }
+}

--- a/hub/catalog/datadog.json
+++ b/hub/catalog/datadog.json
@@ -1,0 +1,19 @@
+{
+  "catalogVersion": 1,
+  "name": "datadog",
+  "displayName": "Datadog",
+  "description": "Datadog connector — metrics via the v1 query API and logs via the v2 logs search API. The first optional, hub-installable connector.",
+  "vendor": "observability-mcp",
+  "homepage": "https://github.com/ThoTischner/observability-mcp",
+  "tier": "official",
+  "signalTypes": ["metrics", "logs"],
+  "versions": [
+    {
+      "version": "1.0.0",
+      "releasedAt": "2026-05-15",
+      "serverCompat": ">=1.4.0",
+      "integrity": "sha256-dTTTxcNMEiHv6sbkMf9UQu7tUDZrt45bd1JKvoiymxI=",
+      "changelog": "Initial release: metrics + logs, API/Application key auth, service discovery via the service tag."
+    }
+  ]
+}

--- a/hub/catalog/index.json
+++ b/hub/catalog/index.json
@@ -2,6 +2,27 @@
   "catalogVersion": 1,
   "connectors": [
     {
+      "name": "datadog",
+      "displayName": "Datadog",
+      "description": "Datadog connector — metrics via the v1 query API and logs via the v2 logs search API. The first optional, hub-installable connector.",
+      "tier": "official",
+      "builtin": false,
+      "signalTypes": [
+        "metrics",
+        "logs"
+      ],
+      "latest": "1.0.0",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "releasedAt": "2026-05-15",
+          "serverCompat": ">=1.4.0",
+          "integrity": "sha256-dTTTxcNMEiHv6sbkMf9UQu7tUDZrt45bd1JKvoiymxI=",
+          "changelog": "Initial release: metrics + logs, API/Application key auth, service discovery via the service tag."
+        }
+      ]
+    },
+    {
       "name": "loki",
       "displayName": "Grafana Loki",
       "description": "LogQL-based logs backend. Service discovery from log streams and label-scoped log queries.",


### PR DESCRIPTION
## Summary
The first **optional, hub-distributable** connector: Datadog.

- `connectors/datadog/` — standalone dependency-free ESM (Node 20 `fetch`), duck-typed against the `ObservabilityConnector` contract (no SDK import → self-contained tarball, airgapped-mirrorable).
  - **Metrics**: Datadog v1 `/api/v1/query` (pointlist → unified `MetricResult`, `$service` substitution, summary/trend).
  - **Logs**: v2 `/api/v2/logs/events/search` (level counting).
  - **Service discovery**: from the `service` tag (best-effort, never throws).
  - **Auth**: API key + Application key (basic-auth username/password mapping, or `DD_API_KEY`/`DD_APP_KEY`).
- `package.json` connector marker + `manifest.json` with `sha256` integrity over `index.js`.
- Hub catalog entry (`hub/catalog/datadog.json`) + regenerated `index.json`.
- 8 unit tests (mocked fetch) + CI step asserting manifest/catalog integrity stay in sync with `index.js`.

Verified loadable via the **real `PluginLoader`** (`registered: true`, instance exposes `healthCheck`/`queryLogs`, appears in `supportedTypes`).

Slice 1 of 2 — slice 2 adds the signed publish pipeline (release tarball + `manifest.json.sig` + catalog `tarballUrl`/`signatureUrl`) so `omcp plugin install datadog --trust-root …` resolves end-to-end.

## Test plan
- [x] `node --test connectors/datadog` → 8/8
- [x] Hub catalog `--check` + tests green (3 connectors)
- [x] Real `PluginLoader` loads it (Docker)
- [ ] Post-merge: hub site lists Datadog