### PR TITLE
feat(connector): signed publish pipeline for hub connectors (slice 2)

### DIFF
--- a/.github/workflows/connector-publish.yml
+++ b/.github/workflows/connector-publish.yml
@@ -1,0 +1,74 @@
+name: Publish connectors
+
+# Packs every connector under connectors/* into a signed tarball and
+# publishes it as a GitHub Release asset at a deterministic URL
+# (connector-<name>-<version> / <name>-<version>.tgz) — the URL the hub
+# catalog already points at.
+#
+# Signing is best-effort/fail-open: a missing key publishes UNSIGNED
+# (operators then need --insecure, matching the server's fail-closed
+# default). The signature is over manifest.json and travels INSIDE the
+# tarball, verified by the same trust-root model as the server.
+
+on:
+  workflow_dispatch:
+  push:
+    tags: ['connector-*']
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Restore signing key
+        id: key
+        env:
+          KEY_B64: ${{ secrets.PLUGIN_SIGNING_KEY_B64 }}
+        run: |
+          set -euo pipefail
+          if [ -z "${KEY_B64:-}" ]; then
+            echo "::warning::PLUGIN_SIGNING_KEY_B64 unset — connectors publish UNSIGNED."
+            echo "key=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "$KEY_B64" | base64 -d > /tmp/plugin-signing.key
+          chmod 600 /tmp/plugin-signing.key
+          echo "key=/tmp/plugin-signing.key" >> "$GITHUB_OUTPUT"
+
+      - name: Pack + publish each connector
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SIGN_KEY: ${{ steps.key.outputs.key }}
+        run: |
+          set -euo pipefail
+          for d in connectors/*/; do
+            [ -f "$d/package.json" ] || continue
+            node -e "process.exit(JSON.parse(require('fs').readFileSync('$d/package.json')).observabilityMcp?.kind==='connector'?0:1)" || continue
+            name=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$d/package.json')).observabilityMcp.name)")
+            ver=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$d/manifest.json')).version)")
+            if [ -n "$SIGN_KEY" ]; then
+              node connectors/pack.mjs "$d" --out dist-connectors --key "$SIGN_KEY"
+            else
+              node connectors/pack.mjs "$d" --out dist-connectors
+            fi
+            tag="connector-${name}-${ver}"
+            asset="dist-connectors/${name}-${ver}.tgz"
+            if gh release view "$tag" >/dev/null 2>&1; then
+              gh release upload "$tag" "$asset" --clobber
+            else
+              gh release create "$tag" "$asset" \
+                --title "connector: ${name} ${ver}" \
+                --notes "Signed connector tarball for \`omcp plugin install ${name}\`. Verify with docs/plugin-signing.pub.pem."
+            fi
+          done
+
+      - name: Wipe signing key
+        if: always()
+        run: shred -u /tmp/plugin-signing.key 2>/dev/null || rm -f /tmp/plugin-signing.key

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -66,6 +66,8 @@ jobs:
             if(cat.versions[0].integrity!==i){console.error("catalog integrity stale");process.exit(1)}
             console.log("datadog integrity in sync");
           '
+      - name: Connector packer tests
+        run: node --test connectors/pack.test.mjs
 
   trivy:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ coverage/
 *.local
 .claude/
 TASKS.md
+
+# connector packing artifacts
+dist-connectors/
+connectors/*/manifest.json.sig

--- a/connectors/pack.mjs
+++ b/connectors/pack.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// Pack (and optionally sign) a connector directory into the tarball the
+// hub serves and `omcp plugin install` consumes.
+//
+//   node connectors/pack.mjs <connectorDir> --out <dir> [--key <pkcs8.pem>]
+//
+// Steps:
+//   1. Validate manifest.integrity === sha256(entry file) — fail-closed,
+//      so a stale manifest never ships.
+//   2. If --key: sign the raw manifest.json bytes (ed25519) and write
+//      manifest.json.sig (base64) INTO the connector dir, so it travels
+//      inside the tarball (exactly what verifyPluginDir expects).
+//   3. tar -czf <out>/<name>-<version>.tgz -C <connectorDir> .
+//
+// Dependency-free: Node crypto + system tar. No catalog mutation here —
+// catalog URLs are deterministic (release tag scheme) and committed.
+
+import { createHash, createPrivateKey, sign as edSign } from "node:crypto";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+export function parsePackArgs(argv) {
+  const out = { dir: undefined, outDir: "dist-connectors", key: undefined };
+  const rest = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--out") out.outDir = argv[++i];
+    else if (argv[i] === "--key") out.key = argv[++i];
+    else rest.push(argv[i]);
+  }
+  out.dir = rest[0];
+  return out;
+}
+
+export function sha256Integrity(buf) {
+  return "sha256-" + createHash("sha256").update(buf).digest("base64");
+}
+
+export function tarballName(name, version) {
+  return `${name}-${version}.tgz`;
+}
+
+// Pure: derive the facts the packer needs from a connector dir's files.
+export function planPack(pkgJson, manifestJson, entryBytes) {
+  const marker = pkgJson.observabilityMcp;
+  if (!marker || marker.kind !== "connector" || !marker.name) {
+    throw new Error("package.json has no observabilityMcp connector marker");
+  }
+  if (manifestJson.name !== marker.name) {
+    throw new Error(`manifest.name (${manifestJson.name}) != marker.name (${marker.name})`);
+  }
+  const actual = sha256Integrity(entryBytes);
+  if (manifestJson.integrity !== actual) {
+    throw new Error(`integrity stale: manifest=${manifestJson.integrity} actual=${actual}`);
+  }
+  return {
+    name: marker.name,
+    version: manifestJson.version,
+    tarball: tarballName(marker.name, manifestJson.version),
+  };
+}
+
+function main() {
+  const { dir, outDir, key } = parsePackArgs(process.argv.slice(2));
+  if (!dir) {
+    console.error("usage: pack.mjs <connectorDir> --out <dir> [--key <pkcs8.pem>]");
+    process.exit(1);
+  }
+  const root = resolve(dir);
+  const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+  const manifestRel = pkg.observabilityMcp?.manifest || "./manifest.json";
+  const manifestPath = resolve(root, manifestRel);
+  const manifestBytes = readFileSync(manifestPath);
+  const manifest = JSON.parse(manifestBytes.toString("utf8"));
+  const entryPath = resolve(root, pkg.main || "index.js");
+  const plan = planPack(pkg, manifest, readFileSync(entryPath));
+
+  if (key) {
+    const priv = createPrivateKey(readFileSync(key, "utf8"));
+    const sig = edSign(null, manifestBytes, priv);
+    writeFileSync(manifestPath + ".sig", sig.toString("base64") + "\n");
+    console.log(`signed ${plan.name}: wrote manifest.json.sig`);
+  } else {
+    console.log(`WARNING: no --key — packing ${plan.name} UNSIGNED`);
+  }
+
+  mkdirSync(resolve(outDir), { recursive: true });
+  const tgz = join(resolve(outDir), plan.tarball);
+  const r = spawnSync("tar", ["-czf", tgz, "-C", root, "."], { stdio: "inherit" });
+  if (r.status !== 0) {
+    console.error("tar failed");
+    process.exit(1);
+  }
+  console.log(`packed ${tgz}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/connectors/pack.test.mjs
+++ b/connectors/pack.test.mjs
@@ -1,0 +1,36 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { parsePackArgs, sha256Integrity, tarballName, planPack } from "./pack.mjs";
+
+test("parsePackArgs", () => {
+  assert.deepEqual(parsePackArgs(["connectors/datadog", "--out", "o", "--key", "k.pem"]), {
+    dir: "connectors/datadog",
+    outDir: "o",
+    key: "k.pem",
+  });
+  const d = parsePackArgs(["connectors/datadog"]);
+  assert.equal(d.dir, "connectors/datadog");
+  assert.equal(d.outDir, "dist-connectors");
+  assert.equal(d.key, undefined);
+});
+
+test("sha256Integrity / tarballName", () => {
+  assert.match(sha256Integrity(Buffer.from("x")), /^sha256-[A-Za-z0-9+/]+=*$/);
+  assert.equal(tarballName("datadog", "1.0.0"), "datadog-1.0.0.tgz");
+});
+
+test("planPack ok + fail-closed on stale integrity / marker mismatch", () => {
+  const entry = Buffer.from("export default()=>({})\n");
+  const integ = sha256Integrity(entry);
+  const pkg = { observabilityMcp: { kind: "connector", name: "datadog", manifest: "./manifest.json" } };
+  const man = { name: "datadog", version: "1.0.0", integrity: integ };
+  assert.deepEqual(planPack(pkg, man, entry), {
+    name: "datadog",
+    version: "1.0.0",
+    tarball: "datadog-1.0.0.tgz",
+  });
+  assert.throws(() => planPack(pkg, { ...man, integrity: "sha256-bad" }, entry), /integrity stale/);
+  assert.throws(() => planPack(pkg, { ...man, name: "other" }, entry), /!= marker.name/);
+  assert.throws(() => planPack({}, man, entry), /connector marker/);
+});

--- a/docs/plugin-signing.pub.pem
+++ b/docs/plugin-signing.pub.pem
@@ -1,0 +1,3 @@
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEA7FxC2gxrrj9MQA4t+EPiQP73tCEJvy1yitBoj6f+J40=
+-----END PUBLIC KEY-----

--- a/docs/security.md
+++ b/docs/security.md
@@ -29,6 +29,42 @@ The repo runs a self-driving security pipeline so issues get caught and patched 
 - **Non-root user** in the Docker image (`USER node`).
 - **npm provenance** on every published version (SLSA build attestation).
 
+## Connector signing
+
+Hub-distributed connectors (e.g. Datadog) ship a detached signature of
+their `manifest.json` *inside* the tarball. The server and `omcp plugin
+install/verify` check it fail-closed against a trust root — fully
+offline, no transparency log (airgapped-safe).
+
+- **Public key (trust root)**: [`docs/plugin-signing.pub.pem`](plugin-signing.pub.pem)
+  (Ed25519). Operators pass it as `PLUGIN_TRUST_ROOT` / `--trust-root`.
+- **Private key**: only the `PLUGIN_SIGNING_KEY_B64` repo secret (base64
+  PKCS#8). CI-only, scoped to connector signing. Never in git.
+- **Pipeline**: `.github/workflows/connector-publish.yml` runs
+  `connectors/pack.mjs` (validates `manifest.integrity` ==
+  sha256(entry), signs `manifest.json`, tars the dir) and uploads
+  `<name>-<version>.tgz` to the `connector-<name>-<version>` release —
+  the URL the hub catalog points at. Signing is fail-open (missing key
+  → unsigned tarball; install then needs `--insecure`).
+- **Verify manually**:
+  ```bash
+  omcp plugin verify ./plugins/datadog --trust-root docs/plugin-signing.pub.pem
+  ```
+
+### Rotation / revocation
+
+The key has no expiry; rotate if exposure is suspected.
+
+1. `node -e 'c=require("crypto");k=c.generateKeyPairSync("ed25519");
+   require("fs").writeFileSync("docs/plugin-signing.pub.pem",
+   k.publicKey.export({type:"spki",format:"pem"}));
+   process.stdout.write(Buffer.from(k.privateKey.export({type:"pkcs8",
+   format:"pem"})).toString("base64"))'` → set the output as
+   `PLUGIN_SIGNING_KEY_B64`.
+2. Commit the regenerated `docs/plugin-signing.pub.pem`, bump connector
+   versions, re-run the publish workflow. Already-published tarballs
+   stay verifiable with the previous public key from git history.
+
 ## Helm chart signing
 
 Released Helm charts are GPG-signed. Each `observability-mcp-X.Y.Z.tgz` ships

--- a/hub/catalog/datadog.json
+++ b/hub/catalog/datadog.json
@@ -12,6 +12,7 @@
       "version": "1.0.0",
       "releasedAt": "2026-05-15",
       "serverCompat": ">=1.4.0",
+      "tarballUrl": "https://github.com/ThoTischner/observability-mcp/releases/download/connector-datadog-1.0.0/datadog-1.0.0.tgz",
       "integrity": "sha256-dTTTxcNMEiHv6sbkMf9UQu7tUDZrt45bd1JKvoiymxI=",
       "changelog": "Initial release: metrics + logs, API/Application key auth, service discovery via the service tag."
     }

--- a/hub/catalog/index.json
+++ b/hub/catalog/index.json
@@ -17,6 +17,7 @@
           "version": "1.0.0",
           "releasedAt": "2026-05-15",
           "serverCompat": ">=1.4.0",
+          "tarballUrl": "https://github.com/ThoTischner/observability-mcp/releases/download/connector-datadog-1.0.0/datadog-1.0.0.tgz",
           "integrity": "sha256-dTTTxcNMEiHv6sbkMf9UQu7tUDZrt45bd1JKvoiymxI=",
           "changelog": "Initial release: metrics + logs, API/Application key auth, service discovery via the service tag."
         }


### PR DESCRIPTION
## Summary
Slice 2 — makes the Datadog connector actually installable via the hub, signed & fail-closed.

- **`connectors/pack.mjs`**: validates `manifest.integrity` == sha256(entry) (fail-closed), ed25519-signs `manifest.json` → `manifest.json.sig` *inside* the tarball, `tar`s it. 3 unit tests.
- **`.github/workflows/connector-publish.yml`**: packs every `connectors/*`, signs with the `PLUGIN_SIGNING_KEY_B64` secret (**fail-open** if unset — unsigned, matching server's fail-closed default), uploads `<name>-<ver>.tgz` to the deterministic `connector-<name>-<ver>` GitHub Release the catalog already points at. Key wiped `if: always()`.
- **`docs/plugin-signing.pub.pem`**: Ed25519 trust root (public key only — private key never in git).
- **`hub/catalog/datadog.json`**: `tarballUrl` wired to the release URL; `index.json` regenerated.
- **`docs/security.md`**: connector-signing + rotation/revocation section.
- CI runs the packer tests; `.gitignore` for packing artifacts.

Verified end-to-end in Docker: `pack.mjs --key` → `omcp plugin install datadog --trust-root docs/plugin-signing.pub.pem` → "signature + integrity OK", installed; tampered tarball rejected fail-closed.

> Requires the `PLUGIN_SIGNING_KEY_B64` repo secret to produce *signed* releases (instructions handed to the maintainer separately — private key kept out of git/logs).

## Test plan
- [x] `node --test connectors/pack.test.mjs` 3/3
- [x] Catalog `--check` in sync (3 connectors)
- [x] E2E: signed pack → omcp install verifies; tamper rejected
- [ ] Post-merge: run `Publish connectors` workflow → release asset live → `omcp plugin install datadog` from the real URL