### PR TITLE
feat(connector): Grafana — second optional hub connector

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -54,17 +54,23 @@ jobs:
         run: |
           node hub/build-catalog.mjs --check
           node --test hub/build-catalog.test.mjs
-      - name: Datadog connector (tests + manifest integrity in sync)
+      - name: Connectors (tests + manifest/catalog integrity in sync)
         run: |
-          node --test connectors/datadog/*.test.mjs connectors/datadog/contract/*.test.mjs
+          node --test connectors/*/*.test.mjs connectors/*/contract/*.test.mjs
           node -e '
-            const c=require("crypto"),fs=require("fs");
-            const i="sha256-"+c.createHash("sha256").update(fs.readFileSync("connectors/datadog/index.js")).digest("base64");
-            const m=JSON.parse(fs.readFileSync("connectors/datadog/manifest.json"));
-            if(m.integrity!==i){console.error("manifest.integrity stale: "+m.integrity+" != "+i);process.exit(1)}
-            const cat=JSON.parse(fs.readFileSync("hub/catalog/datadog.json"));
-            if(cat.versions[0].integrity!==i){console.error("catalog integrity stale");process.exit(1)}
-            console.log("datadog integrity in sync");
+            const c=require("crypto"),fs=require("fs"),p=require("path");
+            for (const d of fs.readdirSync("connectors",{withFileTypes:true})) {
+              if (!d.isDirectory()) continue;
+              const dir="connectors/"+d.name;
+              const pkg=JSON.parse(fs.readFileSync(p.join(dir,"package.json")));
+              if (pkg.observabilityMcp?.kind!=="connector") continue;
+              const i="sha256-"+c.createHash("sha256").update(fs.readFileSync(p.join(dir,"index.js"))).digest("base64");
+              const m=JSON.parse(fs.readFileSync(p.join(dir,"manifest.json")));
+              if(m.integrity!==i){console.error(d.name+": manifest.integrity stale "+m.integrity+" != "+i);process.exit(1)}
+              const cat=JSON.parse(fs.readFileSync("hub/catalog/"+d.name+".json"));
+              if(cat.versions[0].integrity!==i){console.error(d.name+": catalog integrity stale");process.exit(1)}
+              console.log(d.name+" integrity in sync");
+            }
           '
       - name: Connector packer tests
         run: node --test connectors/pack.test.mjs

--- a/connectors/grafana/contract/contract.mjs
+++ b/connectors/grafana/contract/contract.mjs
@@ -1,0 +1,69 @@
+// The Grafana API contract the connector must honour — single,
+// reviewable source of truth for the contract test. Same rationale as
+// the Datadog contract (see connectors/datadog/contract/contract.mjs):
+// in-process, deterministic, no Prism container, no Grafana instance.
+//
+// The proxy paths embed fixed test datasource UIDs (prom-uid / loki-uid)
+// so the contract can match on an exact pathname.
+
+const PROM = "/api/datasources/proxy/uid/prom-uid";
+const LOKI = "/api/datasources/proxy/uid/loki-uid";
+
+export const CONTRACT = {
+  "GET /api/health": {
+    requiredHeaders: ["Authorization"],
+    response: { database: "ok", version: "11.0.0" },
+  },
+  "GET /api/datasources": {
+    requiredHeaders: ["Authorization"],
+    response: [
+      { type: "prometheus", uid: "prom-uid", name: "Prometheus" },
+      { type: "loki", uid: "loki-uid", name: "Loki" },
+    ],
+  },
+  [`GET ${PROM}/api/v1/query_range`]: {
+    requiredHeaders: ["Authorization"],
+    requiredQuery: { query: "nonempty", start: "int", end: "int", step: "int" },
+    response: {
+      status: "success",
+      data: { resultType: "matrix", result: [{ metric: { service: "checkout" }, values: [[1715760000, "12.5"], [1715760060, "18.2"]] }] },
+    },
+  },
+  [`GET ${PROM}/api/v1/label/service/values`]: {
+    requiredHeaders: ["Authorization"],
+    response: { status: "success", data: ["checkout", "payments"] },
+  },
+  [`GET ${LOKI}/loki/api/v1/query_range`]: {
+    requiredHeaders: ["Authorization"],
+    requiredQuery: { query: "nonempty", start: "int", end: "int", limit: "int" },
+    response: {
+      status: "success",
+      data: {
+        resultType: "streams",
+        result: [
+          { stream: { service: "checkout", level: "error" }, values: [["1715760000000000000", "boom"]] },
+          { stream: { service: "checkout", level: "info" }, values: [["1715760060000000000", "ok"]] },
+        ],
+      },
+    },
+  },
+};
+
+export function checkRequest(method, url, headers) {
+  const u = new URL(url);
+  const key = `${method.toUpperCase()} ${u.pathname}`;
+  const rule = CONTRACT[key];
+  if (!rule) return `unexpected request: ${key} (not in the Grafana contract)`;
+  for (const h of rule.requiredHeaders || []) {
+    const v = headers ? headers[h] : undefined;
+    if (v == null || v === "") return `${key}: missing required header ${h}`;
+    if (h === "Authorization" && !/^Bearer .+/.test(v)) return `${key}: Authorization must be 'Bearer <token>'`;
+  }
+  for (const [q, kind] of Object.entries(rule.requiredQuery || {})) {
+    const v = u.searchParams.get(q);
+    if (v == null) return `${key}: missing required query param '${q}'`;
+    if (kind === "int" && !/^-?\d+$/.test(v)) return `${key}: query '${q}'='${v}' is not an integer`;
+    if (kind === "nonempty" && v.length === 0) return `${key}: query '${q}' is empty`;
+  }
+  return null;
+}

--- a/connectors/grafana/contract/contract.test.mjs
+++ b/connectors/grafana/contract/contract.test.mjs
@@ -1,0 +1,52 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import create from "../index.js";
+import { CONTRACT, checkRequest } from "./contract.mjs";
+
+function contractFetch(violations) {
+  return async (url, opts = {}) => {
+    const u = url.toString();
+    const method = (opts.method || "GET").toUpperCase();
+    const v = checkRequest(method, u, opts.headers || {});
+    if (v) violations.push(v);
+    const rule = CONTRACT[`${method} ${new URL(u).pathname}`];
+    return { ok: true, status: 200, json: async () => (rule ? rule.response : {}) };
+  };
+}
+
+test("checkRequest has teeth", () => {
+  assert.match(checkRequest("GET", "http://g/api/health", {}), /missing required header Authorization/);
+  assert.match(checkRequest("GET", "http://g/api/health", { Authorization: "Basic x" }), /must be 'Bearer/);
+  assert.match(
+    checkRequest("GET", "http://g/api/datasources/proxy/uid/prom-uid/api/v1/query_range?start=1&end=2&step=3", { Authorization: "Bearer t" }),
+    /missing required query param 'query'/
+  );
+  assert.match(checkRequest("GET", "http://g/api/v9/nope", { Authorization: "Bearer t" }), /unexpected request/);
+  assert.equal(checkRequest("GET", "http://g/api/health", { Authorization: "Bearer t" }), null);
+});
+
+test("connector honours the Grafana request contract end-to-end", async () => {
+  const violations = [];
+  globalThis.fetch = contractFetch(violations);
+  const c = create();
+  await c.connect({ url: "http://grafana.local", auth: { token: "svc-token" } });
+  assert.equal(c._promUid, "prom-uid");
+  assert.equal(c._lokiUid, "loki-uid");
+
+  const h = await c.healthCheck();
+  assert.equal(h.status, "up");
+
+  const m = await c.queryMetrics({ service: "checkout", metric: "cpu", duration: "1h" });
+  assert.equal(m.values.length, 2);
+  assert.equal(m.summary.current, 18.2);
+
+  const s = await c.listServices();
+  assert.deepEqual(s.map((x) => x.name), ["checkout", "payments"]);
+
+  const l = await c.queryLogs({ service: "checkout", duration: "15m" });
+  assert.equal(l.entries.length, 2);
+  assert.equal(l.summary.errorCount, 1);
+
+  assert.deepEqual(violations, [], `contract violations:\n${violations.join("\n")}`);
+});

--- a/connectors/grafana/index.js
+++ b/connectors/grafana/index.js
@@ -1,0 +1,217 @@
+// Grafana connector for observability-mcp. Grafana stores no telemetry
+// itself — it proxies to datasources. So this connector is a *gateway*:
+// it reaches a Prometheus-compatible datasource (metrics) and a Loki
+// datasource (logs) THROUGH Grafana's datasource proxy, behind
+// Grafana's auth — one pane, one token.
+//
+// Standalone dependency-free ESM (Node 20 fetch), duck-typed against
+// the ObservabilityConnector contract (no SDK import → self-contained,
+// airgapped-mirrorable tarball).
+//
+// Auth: a Grafana service-account token (Bearer). Datasource UIDs are
+// auto-resolved from /api/datasources (first prometheus / first loki),
+// overridable via GRAFANA_PROM_DS_UID / GRAFANA_LOKI_DS_UID.
+
+function parseTimeRange(duration) {
+  const m = String(duration || "").match(/^(\d+)([mhd])$/);
+  if (!m) throw new Error(`invalid duration: ${duration} (use 5m, 1h, 24h)`);
+  const n = parseInt(m[1], 10);
+  const secs = m[2] === "m" ? n * 60 : m[2] === "h" ? n * 3600 : n * 86400;
+  const end = Math.floor(Date.now() / 1000);
+  return { start: end - secs, end, stepSec: Math.max(Math.floor(secs / 100), 15) };
+}
+
+function computeTrend(values) {
+  if (values.length < 4) return "stable";
+  const mid = Math.floor(values.length / 2);
+  const a = values.slice(0, mid).reduce((x, y) => x + y, 0) / mid;
+  const b = values.slice(mid).reduce((x, y) => x + y, 0) / (values.length - mid);
+  const pct = ((b - a) / (a || 1)) * 100;
+  return pct > 10 ? "rising" : pct < -10 ? "falling" : "stable";
+}
+
+function summarize(values) {
+  if (values.length === 0) return { current: 0, average: 0, min: 0, max: 0, trend: "stable" };
+  return {
+    current: values[values.length - 1],
+    average: values.reduce((a, b) => a + b, 0) / values.length,
+    min: Math.min(...values),
+    max: Math.max(...values),
+    trend: computeTrend(values),
+  };
+}
+
+const DEFAULT_METRICS = [
+  { name: "cpu", query: 'rate(process_cpu_seconds_total{service="$service"}[5m])', unit: "percent", description: "CPU seconds rate for the service" },
+  { name: "memory", query: 'process_resident_memory_bytes{service="$service"}', unit: "bytes", description: "Resident memory for the service" },
+  { name: "latency", query: 'histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{service="$service"}[5m])) by (le))', unit: "seconds", description: "p99 request latency" },
+  { name: "errors", query: 'sum(rate(http_requests_total{service="$service",status=~"5.."}[5m]))', unit: "req/s", description: "5xx error rate" },
+];
+
+export class GrafanaConnector {
+  constructor() {
+    this.name = "grafana";
+    this.type = "grafana";
+    this.signalType = "metrics";
+    this._metrics = DEFAULT_METRICS;
+    this._base = "";
+    this._token = "";
+    this._promUid = "";
+    this._lokiUid = "";
+  }
+
+  async connect(config) {
+    this._base = (config && config.url) ? String(config.url).replace(/\/$/, "") : "";
+    if (!this._base) throw new Error("Grafana url is required");
+    const auth = (config && config.auth) || {};
+    this._token = auth.token || process.env.GRAFANA_TOKEN || "";
+    if (!this._token) throw new Error("Grafana service-account token missing (source auth bearer token, or GRAFANA_TOKEN)");
+    if (Array.isArray(config && config.metrics) && config.metrics.length > 0) {
+      this._metrics = config.metrics;
+    }
+    this._promUid = process.env.GRAFANA_PROM_DS_UID || "";
+    this._lokiUid = process.env.GRAFANA_LOKI_DS_UID || "";
+    // Auto-resolve datasource UIDs unless pinned via env. Best-effort:
+    // a discovery failure must not break connect — explicit env still works.
+    if (!this._promUid || !this._lokiUid) {
+      try {
+        const res = await fetch(`${this._base}/api/datasources`, { headers: this._headers() });
+        if (res.ok) {
+          const list = await res.json();
+          for (const ds of Array.isArray(list) ? list : []) {
+            if (!this._promUid && ds.type === "prometheus") this._promUid = ds.uid;
+            if (!this._lokiUid && ds.type === "loki") this._lokiUid = ds.uid;
+          }
+        }
+      } catch {
+        /* keep env-provided (possibly empty) uids */
+      }
+    }
+  }
+
+  async disconnect() {
+    /* stateless */
+  }
+
+  _headers() {
+    return { Authorization: `Bearer ${this._token}` };
+  }
+
+  _proxy(uid, path) {
+    return `${this._base}/api/datasources/proxy/uid/${uid}${path}`;
+  }
+
+  async healthCheck() {
+    const started = Date.now();
+    try {
+      const res = await fetch(`${this._base}/api/health`, { headers: this._headers() });
+      const latencyMs = Date.now() - started;
+      if (!res.ok) return { status: "down", latencyMs, message: `health HTTP ${res.status}` };
+      const b = await res.json().catch(() => ({}));
+      return b && (b.database === "ok" || b.status === "ok")
+        ? { status: "up", latencyMs }
+        : { status: "down", latencyMs, message: "grafana health not ok" };
+    } catch (e) {
+      return { status: "down", latencyMs: Date.now() - started, message: String(e) };
+    }
+  }
+
+  getDefaultMetrics() {
+    return DEFAULT_METRICS;
+  }
+
+  getMetrics() {
+    return this._metrics;
+  }
+
+  async listServices() {
+    if (!this._promUid) return [];
+    try {
+      const res = await fetch(this._proxy(this._promUid, "/api/v1/label/service/values"), {
+        headers: this._headers(),
+      });
+      if (!res.ok) return [];
+      const body = await res.json();
+      const vals = (body && body.data) || [];
+      return vals.map((name) => ({ name, source: this.name, signalType: "metrics" }));
+    } catch {
+      return [];
+    }
+  }
+
+  async queryMetrics(params) {
+    if (!this._promUid) throw new Error("no Prometheus datasource resolved (set GRAFANA_PROM_DS_UID)");
+    const def = this._metrics.find((m) => m.name === params.metric)
+      || DEFAULT_METRICS.find((m) => m.name === params.metric);
+    if (!def) throw new Error(`unknown metric '${params.metric}' for grafana`);
+    const { start, end, stepSec } = parseTimeRange(params.duration);
+    const q = def.query.replace(/\$service\b/g, params.service);
+    const u = new URL(this._proxy(this._promUid, "/api/v1/query_range"));
+    u.searchParams.set("query", q);
+    u.searchParams.set("start", String(start));
+    u.searchParams.set("end", String(end));
+    u.searchParams.set("step", String(stepSec));
+    const res = await fetch(u, { headers: this._headers() });
+    if (!res.ok) throw new Error(`Grafana proxy query HTTP ${res.status}`);
+    const body = await res.json();
+    const result = (body && body.data && body.data.result) || [];
+    const series = result[0] || null;
+    const dps = ((series && series.values) || [])
+      .map((p) => ({ timestamp: new Date(Number(p[0]) * 1000).toISOString(), value: Number(p[1]) }))
+      .filter((d) => !Number.isNaN(d.value));
+    return {
+      source: this.name,
+      service: params.service,
+      metric: params.metric,
+      unit: def.unit,
+      values: dps,
+      summary: summarize(dps.map((d) => d.value)),
+      resolvedSeries: q,
+    };
+  }
+
+  async queryLogs(params) {
+    if (!this._lokiUid) throw new Error("no Loki datasource resolved (set GRAFANA_LOKI_DS_UID)");
+    const { start, end } = parseTimeRange(params.duration);
+    let selector = `{service="${params.service}"}`;
+    if (params.level) selector += ` | level="${params.level}"`;
+    if (params.query) selector += ` |= "${params.query}"`;
+    const u = new URL(this._proxy(this._lokiUid, "/loki/api/v1/query_range"));
+    u.searchParams.set("query", selector);
+    u.searchParams.set("start", `${start}000000000`);
+    u.searchParams.set("end", `${end}000000000`);
+    u.searchParams.set("limit", String(Math.min(params.limit || 100, 1000)));
+    u.searchParams.set("direction", "backward");
+    const res = await fetch(u, { headers: this._headers() });
+    if (!res.ok) throw new Error(`Grafana Loki proxy HTTP ${res.status}`);
+    const body = await res.json();
+    const streams = (body && body.data && body.data.result) || [];
+    let errorCount = 0;
+    let warnCount = 0;
+    const entries = [];
+    for (const s of streams) {
+      const svc = (s.stream && (s.stream.service || s.stream.app)) || params.service;
+      const lvl = (s.stream && (s.stream.level || s.stream.detected_level) || "info").toLowerCase();
+      for (const [tsNano, line] of s.values || []) {
+        if (lvl === "error" || lvl === "critical") errorCount++;
+        else if (lvl === "warn" || lvl === "warning") warnCount++;
+        entries.push({
+          timestamp: new Date(Number(tsNano) / 1e6).toISOString(),
+          level: lvl,
+          message: String(line),
+          labels: { service: svc },
+        });
+      }
+    }
+    return {
+      source: this.name,
+      service: params.service,
+      entries,
+      summary: { total: entries.length, errorCount, warnCount, topPatterns: [] },
+    };
+  }
+}
+
+export default function create() {
+  return new GrafanaConnector();
+}

--- a/connectors/grafana/index.test.mjs
+++ b/connectors/grafana/index.test.mjs
@@ -1,0 +1,127 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import create, { GrafanaConnector } from "./index.js";
+
+function mockFetch(routes) {
+  return async (url) => {
+    const u = url.toString();
+    for (const [pat, h] of routes) if (u.includes(pat)) return h(u);
+    return { ok: false, status: 404, json: async () => ({}) };
+  };
+}
+const ok = (b) => ({ ok: true, status: 200, json: async () => b });
+
+test("create() shape", () => {
+  const c = create();
+  assert.ok(c instanceof GrafanaConnector);
+  assert.equal(c.name, "grafana");
+  assert.equal(c.getDefaultMetrics().length, 4);
+});
+
+test("connect requires url + token, auto-resolves datasource uids", async () => {
+  await assert.rejects(() => create().connect({ auth: { token: "t" } }), /url is required/);
+  await assert.rejects(() => create().connect({ url: "http://g" }), /token missing/);
+  const c = create();
+  globalThis.fetch = mockFetch([
+    ["/api/datasources", () => ok([
+      { type: "prometheus", uid: "prom-1" },
+      { type: "loki", uid: "loki-1" },
+      { type: "prometheus", uid: "prom-2" },
+    ])],
+  ]);
+  await c.connect({ url: "http://g/", auth: { token: "t" } });
+  assert.equal(c._base, "http://g");
+  assert.equal(c._promUid, "prom-1");
+  assert.equal(c._lokiUid, "loki-1");
+});
+
+test("env uids override auto-resolution", async () => {
+  process.env.GRAFANA_PROM_DS_UID = "envprom";
+  process.env.GRAFANA_LOKI_DS_UID = "envloki";
+  const c = create();
+  globalThis.fetch = mockFetch([["/api/datasources", () => ok([{ type: "prometheus", uid: "x" }])]]);
+  await c.connect({ url: "http://g", auth: { token: "t" } });
+  assert.equal(c._promUid, "envprom");
+  assert.equal(c._lokiUid, "envloki");
+  delete process.env.GRAFANA_PROM_DS_UID;
+  delete process.env.GRAFANA_LOKI_DS_UID;
+});
+
+test("healthCheck up/down", async () => {
+  const c = create();
+  globalThis.fetch = mockFetch([["/api/datasources", () => ok([])]]);
+  await c.connect({ url: "http://g", auth: { token: "t" } });
+  globalThis.fetch = mockFetch([["/api/health", () => ok({ database: "ok" })]]);
+  assert.equal((await c.healthCheck()).status, "up");
+  globalThis.fetch = mockFetch([["/api/health", () => ({ ok: false, status: 502, json: async () => ({}) })]]);
+  assert.equal((await c.healthCheck()).status, "down");
+});
+
+test("queryMetrics proxies query_range, maps matrix, substitutes $service", async () => {
+  process.env.GRAFANA_PROM_DS_UID = "p1";
+  const c = create();
+  globalThis.fetch = mockFetch([["/api/datasources", () => ok([])]]);
+  await c.connect({ url: "http://g", auth: { token: "t" } });
+  let seen;
+  globalThis.fetch = mockFetch([
+    ["/api/datasources/proxy/uid/p1/api/v1/query_range", (u) => {
+      seen = new URL(u);
+      return ok({ data: { result: [{ values: [[1715760000, "1.5"], [1715760060, "2.5"]] }] } });
+    }],
+  ]);
+  const r = await c.queryMetrics({ service: "checkout", metric: "cpu", duration: "1h" });
+  assert.match(seen.searchParams.get("query"), /service="checkout"/);
+  assert.ok(seen.searchParams.get("start") && seen.searchParams.get("step"));
+  assert.equal(r.values.length, 2);
+  assert.equal(r.unit, "percent");
+  assert.equal(r.summary.current, 2.5);
+  delete process.env.GRAFANA_PROM_DS_UID;
+});
+
+test("queryMetrics errors without a prom uid + on unknown metric", async () => {
+  const c = create();
+  globalThis.fetch = mockFetch([["/api/datasources", () => ok([])]]);
+  await c.connect({ url: "http://g", auth: { token: "t" } });
+  await assert.rejects(() => c.queryMetrics({ service: "s", metric: "cpu", duration: "1h" }), /no Prometheus datasource/);
+  process.env.GRAFANA_PROM_DS_UID = "p1";
+  const c2 = create();
+  globalThis.fetch = mockFetch([["/api/datasources", () => ok([])]]);
+  await c2.connect({ url: "http://g", auth: { token: "t" } });
+  await assert.rejects(() => c2.queryMetrics({ service: "s", metric: "nope", duration: "1h" }), /unknown metric/);
+  delete process.env.GRAFANA_PROM_DS_UID;
+});
+
+test("listServices reads prom label values, never throws", async () => {
+  process.env.GRAFANA_PROM_DS_UID = "p1";
+  const c = create();
+  globalThis.fetch = mockFetch([["/api/datasources", () => ok([])]]);
+  await c.connect({ url: "http://g", auth: { token: "t" } });
+  globalThis.fetch = mockFetch([
+    ["/api/datasources/proxy/uid/p1/api/v1/label/service/values", () => ok({ data: ["api", "db"] })],
+  ]);
+  assert.deepEqual((await c.listServices()).map((s) => s.name), ["api", "db"]);
+  globalThis.fetch = async () => { throw new Error("down"); };
+  assert.deepEqual(await c.listServices(), []);
+  delete process.env.GRAFANA_PROM_DS_UID;
+});
+
+test("queryLogs proxies Loki, counts levels", async () => {
+  process.env.GRAFANA_LOKI_DS_UID = "l1";
+  const c = create();
+  globalThis.fetch = mockFetch([["/api/datasources", () => ok([])]]);
+  await c.connect({ url: "http://g", auth: { token: "t" } });
+  globalThis.fetch = mockFetch([
+    ["/api/datasources/proxy/uid/l1/loki/api/v1/query_range", () => ok({
+      data: { result: [
+        { stream: { service: "api", level: "error" }, values: [["1715760000000000000", "boom"]] },
+        { stream: { service: "api", level: "info" }, values: [["1715760060000000000", "ok"]] },
+      ] },
+    })],
+  ]);
+  const r = await c.queryLogs({ service: "api", duration: "15m" });
+  assert.equal(r.entries.length, 2);
+  assert.equal(r.summary.errorCount, 1);
+  assert.equal(r.entries[0].level, "error");
+  delete process.env.GRAFANA_LOKI_DS_UID;
+});

--- a/connectors/grafana/manifest.json
+++ b/connectors/grafana/manifest.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "name": "grafana",
+  "displayName": "Grafana",
+  "version": "1.0.0",
+  "description": "Grafana connector — queries a Prometheus-compatible datasource (metrics) and a Loki datasource (logs) through Grafana's datasource proxy, behind Grafana auth. Auth with a Grafana service-account token.",
+  "signalTypes": ["metrics", "logs"],
+  "homepage": "https://github.com/ThoTischner/observability-mcp",
+  "license": "MIT",
+  "capabilities": {
+    "queryMetrics": true,
+    "queryLogs": true,
+    "listServices": true
+  },
+  "compat": {
+    "serverVersion": ">=1.4.0"
+  },
+  "integrity": "sha256-zEaoTRdorQYbNvSKTjo4iDYNCfCogWG3m6nS28zeBjA="
+}

--- a/connectors/grafana/package.json
+++ b/connectors/grafana/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@observability-mcp/connector-grafana",
+  "version": "1.0.0",
+  "description": "Grafana connector for observability-mcp — metrics + logs through Grafana's datasource proxy.",
+  "type": "module",
+  "main": "./index.js",
+  "license": "MIT",
+  "files": ["index.js", "manifest.json"],
+  "observabilityMcp": {
+    "kind": "connector",
+    "name": "grafana",
+    "manifest": "./manifest.json"
+  }
+}

--- a/hub/catalog/grafana.json
+++ b/hub/catalog/grafana.json
@@ -1,0 +1,20 @@
+{
+  "catalogVersion": 1,
+  "name": "grafana",
+  "displayName": "Grafana",
+  "description": "Grafana connector — metrics from a Prometheus-compatible datasource and logs from a Loki datasource, queried through Grafana's datasource proxy behind Grafana auth.",
+  "vendor": "observability-mcp",
+  "homepage": "https://github.com/ThoTischner/observability-mcp",
+  "tier": "official",
+  "signalTypes": ["metrics", "logs"],
+  "versions": [
+    {
+      "version": "1.0.0",
+      "releasedAt": "2026-05-15",
+      "serverCompat": ">=1.4.0",
+      "tarballUrl": "https://github.com/ThoTischner/observability-mcp/releases/download/connector-grafana-1.0.0/grafana-1.0.0.tgz",
+      "integrity": "sha256-zEaoTRdorQYbNvSKTjo4iDYNCfCogWG3m6nS28zeBjA=",
+      "changelog": "Initial release: Prometheus-proxied metrics + Loki-proxied logs via Grafana datasource proxy, auto datasource-UID resolution, service-account token auth."
+    }
+  ]
+}

--- a/hub/catalog/index.json
+++ b/hub/catalog/index.json
@@ -24,6 +24,28 @@
       ]
     },
     {
+      "name": "grafana",
+      "displayName": "Grafana",
+      "description": "Grafana connector — metrics from a Prometheus-compatible datasource and logs from a Loki datasource, queried through Grafana's datasource proxy behind Grafana auth.",
+      "tier": "official",
+      "builtin": false,
+      "signalTypes": [
+        "metrics",
+        "logs"
+      ],
+      "latest": "1.0.0",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "releasedAt": "2026-05-15",
+          "serverCompat": ">=1.4.0",
+          "tarballUrl": "https://github.com/ThoTischner/observability-mcp/releases/download/connector-grafana-1.0.0/grafana-1.0.0.tgz",
+          "integrity": "sha256-zEaoTRdorQYbNvSKTjo4iDYNCfCogWG3m6nS28zeBjA=",
+          "changelog": "Initial release: Prometheus-proxied metrics + Loki-proxied logs via Grafana datasource proxy, auto datasource-UID resolution, service-account token auth."
+        }
+      ]
+    },
+    {
       "name": "loki",
       "displayName": "Grafana Loki",
       "description": "LogQL-based logs backend. Service discovery from log streams and label-scoped log queries.",


### PR DESCRIPTION
## Summary
Second hub-installable connector: **Grafana**.

Grafana stores no telemetry itself, so this connector is a **gateway** — it queries a Prometheus-compatible datasource (metrics) and a Loki datasource (logs) **through Grafana's datasource proxy**, behind a Grafana service-account token (one pane, one token). Datasource UIDs auto-resolve from `/api/datasources` (overridable via `GRAFANA_PROM_DS_UID` / `GRAFANA_LOKI_DS_UID`).

- Standalone dependency-free ESM, duck-typed, self-contained tarball.
- `package.json` marker + `manifest.json` (sha256 integrity).
- 8 unit tests (mocked fetch) + 2 contract tests (independent request-shape contract — same pattern as Datadog).
- `hub/catalog/grafana.json` + regenerated `index.json` (4 connectors).
- **CI generalized**: the per-connector step now loops `connectors/*` (tests + manifest + catalog integrity) — no more duplication as connectors are added.
- Verified loadable via the real `PluginLoader`.

Publishing is automatic via the existing generic `connector-publish` workflow; the catalog `tarballUrl` already points at the deterministic `connector-grafana-1.0.0` release.

## Test plan
- [x] 20/20 connector tests (datadog + grafana, unit + contract)
- [x] Generalized integrity check green for both
- [x] Real `PluginLoader` loads grafana
- [ ] Post-merge: run `connector-publish` → release asset → `omcp plugin install grafana --trust-root docs/plugin-signing.pub.pem`