### PR TITLE
feat(connectors): official signed plugins bundle OCI image

### DIFF
--- a/.github/workflows/connector-bundle-image.yml
+++ b/.github/workflows/connector-bundle-image.yml
@@ -1,0 +1,89 @@
+name: Publish plugins bundle image
+
+# Builds and pushes the official multi-connector plugins OCI image to
+# GHCR: ghcr.io/<repo>-plugins. The Helm chart's plugins.image can point
+# straight at it (init-container extracts the requested connectors) — no
+# hand-built image, and it doubles as the airgapped "bundled image".
+#
+# Connectors are packed + signed with the SAME pack.mjs + signing key as
+# the per-connector hub tarballs (fail-open if the key is absent).
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'connectors/**'
+      - '.github/workflows/connector-bundle-image.yml'
+    tags: ['connector-*']
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Image name (lowercase) + restore signing key
+        id: prep
+        env:
+          KEY_B64: ${{ secrets.PLUGIN_SIGNING_KEY_B64 }}
+        run: |
+          set -euo pipefail
+          echo "image=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')-plugins" >> "$GITHUB_OUTPUT"
+          if [ -n "${KEY_B64:-}" ]; then
+            echo "$KEY_B64" | base64 -d > /tmp/plugin-signing.key
+            chmod 600 /tmp/plugin-signing.key
+            echo "key=/tmp/plugin-signing.key" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::PLUGIN_SIGNING_KEY_B64 unset — bundle ships UNSIGNED."
+            echo "key=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Stage signed plugins
+        run: |
+          if [ -n "${{ steps.prep.outputs.key }}" ]; then
+            sh connectors/build-bundle.sh /tmp/bundle "${{ steps.prep.outputs.key }}"
+          else
+            sh connectors/build-bundle.sh /tmp/bundle
+          fi
+
+      - name: Wipe signing key
+        if: always()
+        run: shred -u /tmp/plugin-signing.key 2>/dev/null || rm -f /tmp/plugin-signing.key
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ steps.prep.outputs.image }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
+            type=raw,value=bundle
+
+      - name: Build and push (multi-arch)
+        uses: docker/build-push-action@v7
+        with:
+          context: /tmp/bundle
+          file: /tmp/bundle/Dockerfile.bundle
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/connectors/Dockerfile.bundle
+++ b/connectors/Dockerfile.bundle
@@ -1,0 +1,15 @@
+# Official multi-connector plugins image. NOT a runnable service — it
+# only carries signed connector dirs under /plugins/<name>/. The Helm
+# chart's init-container (sh + cp) extracts the requested paths into an
+# emptyDir, so the base needs a shell + coreutils (busybox), not scratch.
+#
+# Build context is the staged tree produced by connectors/build-bundle.sh
+# (plugins/<name>/{index.js,package.json,manifest.json,manifest.json.sig}).
+FROM busybox:1.36
+LABEL org.opencontainers.image.source="https://github.com/ThoTischner/observability-mcp" \
+      org.opencontainers.image.description="observability-mcp connectors (signed) for the Helm chart plugins.image / airgapped mounts"
+COPY plugins /plugins
+# Sanity: fail the build if a connector is missing its signed manifest.
+RUN set -eu; for d in /plugins/*/; do \
+      [ -f "$d/manifest.json" ] || { echo "missing manifest in $d"; exit 1; }; \
+    done; echo "bundled: $(ls -1 /plugins | tr '\n' ' ')"

--- a/connectors/build-bundle.sh
+++ b/connectors/build-bundle.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+# Assembles the build context for the official plugins OCI image:
+# every connectors/<name> is packed + (optionally) signed via the same
+# connectors/pack.mjs the hub tarballs use, then extracted into
+# <out>/plugins/<name>/ alongside the bundle Dockerfile.
+#
+#   connectors/build-bundle.sh <out-dir> [signing-key.pem]
+#
+# Identical artifacts to the per-connector hub tarballs (same pack.mjs,
+# same signature) — the bundle is just a convenience packaging of them.
+set -eu
+OUT="${1:?usage: build-bundle.sh <out-dir> [key.pem]}"
+KEY="${2:-}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+rm -rf "$OUT"
+mkdir -p "$OUT/plugins" "$OUT/tgz"
+cp "$ROOT/connectors/Dockerfile.bundle" "$OUT/Dockerfile.bundle"
+
+count=0
+for d in "$ROOT"/connectors/*/; do
+  [ -f "$d/package.json" ] || continue
+  node -e "process.exit(JSON.parse(require('fs').readFileSync('$d/package.json')).observabilityMcp&&JSON.parse(require('fs').readFileSync('$d/package.json')).observabilityMcp.kind==='connector'?0:1)" || continue
+  name=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$d/package.json')).observabilityMcp.name)")
+  ver=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$d/manifest.json')).version)")
+  if [ -n "$KEY" ]; then
+    node "$ROOT/connectors/pack.mjs" "$d" --out "$OUT/tgz" --key "$KEY"
+  else
+    node "$ROOT/connectors/pack.mjs" "$d" --out "$OUT/tgz"
+  fi
+  mkdir -p "$OUT/plugins/$name"
+  tar -xzf "$OUT/tgz/$name-$ver.tgz" -C "$OUT/plugins/$name"
+  count=$((count + 1))
+done
+rm -rf "$OUT/tgz"
+echo "staged $count connector(s) into $OUT/plugins"

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -107,12 +107,12 @@ The pain point of airgapped setups is **no `npm install` at runtime**, no GitHub
 
 Three supported workflows:
 
-- **Bundled image.** The Dockerfile copies a `plugins/` dir into the image. Operators rebuild the image when they want a new connector. CI builds an `:airgap-bundle` tag that includes every blessed connector.
+- **Bundled image.** CI publishes an official multi-connector image — `ghcr.io/thotischner/observability-mcp-plugins:latest` (`.github/workflows/connector-bundle-image.yml`; connectors signed with the same key as the hub tarballs). Operators just reference or mirror it — no hand-built image.
 
 - **Mounted volume (k8s).** The Helm chart accepts:
   ```yaml
   plugins:
-    image: registry.internal/observability-mcp-plugins:1.0.0   # an OCI image that *only* contains plugins/
+    image: ghcr.io/thotischner/observability-mcp-plugins:latest   # official signed bundle (or a mirror)
     paths:
       - prometheus
       - loki
@@ -183,7 +183,7 @@ These will be separate PRs so each can pass smoke independently:
 | 4  | Publish `@thotischner/observability-mcp-sdk` to npm. Move the prometheus connector into its own package, mark the shim as deprecated. |
 | 5  | Loki connector → own package. |
 | 6  | ✅ Offline verification (`VERIFY_PLUGINS` + local trust root) — fail-closed manifest signature + entry integrity. (Local trust root, not sigstore: airgapped sites can't reach a transparency log.) |
-| 7  | Helm chart: `plugins.image` + init container extraction. |
+| 7  | ✅ Helm `plugins.image` + init-container extraction, plus an official signed multi-connector bundle image (`observability-mcp-plugins`) so no image build is needed. |
 | 8  | ✅ Catalog contract in `hub/` (schema + validated `index.json` + generator + CI). Hosted static site / install CLI remain future work on top of this format. |
 
 The first three PRs unlock airgapped deployments. Everything after is incremental polish.

--- a/helm/observability-mcp/values.yaml
+++ b/helm/observability-mcp/values.yaml
@@ -69,9 +69,11 @@ plugins:
   # OCI image containing ONLY a /plugins tree. An init container copies
   # the selected paths into an emptyDir mounted at /app/plugins, so the
   # main container never needs registry access (airgapped-friendly).
-  # Leave empty to disable the init container entirely.
+  # Leave empty to disable the init container entirely. The official
+  # signed image bundles every connector:
+  #   ghcr.io/thotischner/observability-mcp-plugins:latest
+  # (mirror it for airgapped; pair with plugins.verify + paths).
   image: ""
-  # e.g. registry.internal/observability-mcp-plugins:1.0.0
   imagePullPolicy: IfNotPresent
   # Subdirectories of /plugins to extract. Empty = copy everything.
   paths: []

--- a/hub/site/index.html
+++ b/hub/site/index.html
@@ -202,24 +202,24 @@ curl -fsSL -O ${TRUST_ROOT_URL}
 # --- On the AIR-GAPPED host ----------------------------------------
 omcp plugin install ${c.name}@${ver} \\
   --offline-dir . --trust-root plugin-signing.pub.pem`],
-    ["Helm", `# Bake the connector into a plugins-only OCI image, then let the
-# chart's init-container extract it (no registry pull from the app pod).
+    ["Helm", `# The official signed plugins image already bundles every
+# connector — point plugins.image at it; the chart's init-container
+# extracts only what you list, the app pod pulls no registry itself.
+#
+# Airgapped: mirror the image once
+#   skopeo copy docker://ghcr.io/thotischner/observability-mcp-plugins:latest \\
+#     docker://registry.internal/observability-mcp-plugins:latest
 
-mkdir -p plugins/${c.name} && tar -xzf ${file} -C plugins/${c.name}
-printf 'FROM scratch\\nCOPY plugins /plugins\\n' > Dockerfile.plugins
-docker build -f Dockerfile.plugins -t registry.example.com/obs-mcp-plugins:1 .
-docker push registry.example.com/obs-mcp-plugins:1
-
-# values.yaml — mount it, fail-closed verified against the trust root:
-cat <<'YAML'
+cat > values.yaml <<'YAML'
 plugins:
-  image: registry.example.com/obs-mcp-plugins:1
+  image: ghcr.io/thotischner/observability-mcp-plugins:latest
   paths: ["${c.name}"]
   verify:
     enabled: true
     trustRootPem: |
 $(curl -fsSL ${TRUST_ROOT_URL} | sed 's/^/      /')
 YAML
+helm repo add observability-mcp https://thotischner.github.io/observability-mcp/
 helm upgrade --install obs observability-mcp/observability-mcp -f values.yaml`],
     ["Manual", `# Plain filesystem install into PLUGINS_DIR (default /app/plugins)
 curl -fsSL -O ${tgz}


### PR DESCRIPTION
## Summary
Per your suggestion — ship an **official** multi-connector OCI image instead of telling operators to build one.

- CI publishes `ghcr.io/thotischner/observability-mcp-plugins:latest` (+ `sha-…`, `:bundle`, multi-arch amd64/arm64).
- `connectors/build-bundle.sh` packs + signs **every** `connectors/*` with the **same `pack.mjs` + key** as the per-connector hub tarballs → identical signed artifacts, just bundled.
- `connectors/Dockerfile.bundle` uses a **busybox** base on purpose: the chart's init-container runs `sh -c` + `cp -a` *inside* this image, so `FROM scratch` (no shell) would break it — this also **fixes the earlier hub Helm snippet** that suggested scratch.
- Hub site Helm box now points `plugins.image` at the official image (+ a `skopeo copy` mirror one-liner for airgapped) — no `docker build` step.
- `values.yaml` comment + `plugin-architecture.md` updated; roadmap step 7 marked done.
- Fail-open: no signing key → unsigned bundle (consistent with the tarball pipeline).

## Test plan
- [x] `build-bundle.sh` stages datadog+grafana (signed dirs)
- [x] `Dockerfile.bundle` image builds (busybox)
- [x] Chart's exact init-container command (`sh -c; cp -a /plugins/$p /shared/`) extracts from the image
- [x] Hub site embedded JS `node --check` clean
- [ ] Post-merge: `connector-bundle-image` workflow pushes to GHCR; pull + chart deploy