### PR TITLE
feat(helm): default plugins.image to the official signed bundle

### DIFF
--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,7 +4,7 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 0.8.1
+version: 0.9.0
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
@@ -56,6 +56,8 @@ annotations:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
+    - kind: changed
+      description: plugins.image now defaults to the official signed bundle (ghcr.io/thotischner/observability-mcp-plugins:latest) — connectors available on a plain helm install; set plugins.image="" to opt out
     - kind: added
       description: Connector Hub link (https://thotischner.github.io/observability-mcp/hub/)
     - kind: added

--- a/helm/observability-mcp/README.md
+++ b/helm/observability-mcp/README.md
@@ -36,7 +36,7 @@ helm install obs-mcp ./helm/observability-mcp \
 | `persistence.enabled` | `false` | Persist `sources.yaml` updates from the Web UI |
 | `autoscaling.enabled` | `false` | HPA — only with sticky-session ingress |
 | `podSecurityContext.runAsNonRoot` | `true` | Hardened defaults |
-| `plugins.image` | `""` | OCI image with a `/plugins` tree; an init container extracts it into `/app/plugins` (no registry access from the main pod) |
+| `plugins.image` | `ghcr.io/thotischner/observability-mcp-plugins:latest` | Official signed connector bundle; an init container extracts it into `/app/plugins` (no registry access from the main pod). Connectors stay inert until a matching source is configured. `""` disables it (builtin Prometheus/Loki only) |
 | `plugins.paths` | `[]` | Subdirs of `/plugins` to extract (empty = all) |
 | `plugins.verify.enabled` | `false` | Fail-closed connector verification (`VERIFY_PLUGINS`) — builtin Prometheus/Loki are never gated |
 | `plugins.verify.trustRootPem` | `""` | PEM public key trust root (rendered into a Secret) |

--- a/helm/observability-mcp/values.yaml
+++ b/helm/observability-mcp/values.yaml
@@ -69,11 +69,13 @@ plugins:
   # OCI image containing ONLY a /plugins tree. An init container copies
   # the selected paths into an emptyDir mounted at /app/plugins, so the
   # main container never needs registry access (airgapped-friendly).
-  # Leave empty to disable the init container entirely. The official
-  # signed image bundles every connector:
-  #   ghcr.io/thotischner/observability-mcp-plugins:latest
-  # (mirror it for airgapped; pair with plugins.verify + paths).
-  image: ""
+  #
+  # Defaults to the official signed multi-connector bundle so a plain
+  # `helm install` already has the optional connectors available (they
+  # stay inert until a matching source is configured). For airgapped
+  # clusters mirror this image and override with the mirror. Set to ""
+  # to disable the init container entirely (builtin Prometheus/Loki only).
+  image: "ghcr.io/thotischner/observability-mcp-plugins:latest"
   imagePullPolicy: IfNotPresent
   # Subdirectories of /plugins to extract. Empty = copy everything.
   paths: []


### PR DESCRIPTION
## Summary
Per request — `helm install` now uses the connector image by default.

- `plugins.image` default `""` → `ghcr.io/thotischner/observability-mcp-plugins:latest` (the official signed bundle published by `connector-bundle-image`).
- A plain `helm install` now runs the init-container and makes datadog/grafana/… available out of the box. They're **inert until a matching source is configured**, so this is a safe default.
- `plugins.image=""` opts out (builtin Prometheus/Loki only); override with a mirror for airgapped.
- Chart `0.8.1 → 0.9.0`; values comment, README default cell, and `artifacthub.io/changes` updated.

## Test plan
- [x] Published image pulls from GHCR; chart init-container (`cp -a /plugins/. /shared/`) yields datadog+grafana
- [x] `helm lint` clean
- [x] Default renders the `extract-plugins` init-container with the official image; `--set plugins.image=""` → 0 init-container; CI smoke render OK