### PR TITLE
feat(connector): Elasticsearch — third optional hub connector

### DIFF
--- a/.github/workflows/connector-install-it.yml
+++ b/.github/workflows/connector-install-it.yml
@@ -31,9 +31,15 @@ jobs:
       - name: Build CLI
         working-directory: ./mcp-server
         run: npm ci && npm run build
-      - name: Connector install flows (datadog + grafana)
+      - name: Connector install flows (every connectors/*)
         run: |
-          sh connectors/install-it.sh datadog
-          sh connectors/install-it.sh grafana
+          for d in connectors/*/; do
+            [ -f "$d/package.json" ] || continue
+            kind=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('$d/package.json')).observabilityMcp?.kind||'')}catch{console.log('')}")
+            [ "$kind" = "connector" ] || continue
+            name=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$d/package.json')).observabilityMcp.name)")
+            echo "=== install-it: $name ==="
+            sh connectors/install-it.sh "$name"
+          done
       - name: Loader functional smoke (connectors load & are callable)
         run: node connectors/loader-smoke.mjs

--- a/connectors/elasticsearch/contract/contract.mjs
+++ b/connectors/elasticsearch/contract/contract.mjs
@@ -1,0 +1,55 @@
+// The Elasticsearch API contract the connector must honour — single,
+// reviewable source of truth for the contract test. Same rationale as
+// the Datadog/Grafana contracts: in-process, deterministic, no ES
+// instance, no Prism. (encodeURIComponent leaves "logs-*" unchanged,
+// so the search path is stable.)
+
+export const CONTRACT = {
+  "GET /_cluster/health": {
+    requiredHeaders: ["Authorization"],
+    response: { status: "green", cluster_name: "es" },
+  },
+  "POST /logs-*/_search": {
+    requiredHeaders: ["Authorization", "Content-Type"],
+    // body is JSON; route the example response by what the body asks for
+    response: (body) => {
+      if (body && body.aggs && body.aggs.svc) {
+        return { aggregations: { svc: { buckets: [{ key: "checkout" }, { key: "payments" }] } } };
+      }
+      if (body && body.aggs && body.aggs.ts) {
+        return { aggregations: { ts: { buckets: [
+          { key: 1715760000000, doc_count: 30 },
+          { key: 1715760060000, doc_count: 12 },
+        ] } } };
+      }
+      return { hits: { hits: [
+        { _source: { "@timestamp": "2026-05-16T10:00:00.000Z", log: { level: "error" }, message: "boom", service: { name: "checkout" } } },
+        { _source: { "@timestamp": "2026-05-16T10:01:00.000Z", log: { level: "info" }, message: "ok", service: { name: "checkout" } } },
+      ] } };
+    },
+  },
+};
+
+export function checkRequest(method, url, headers, body) {
+  const u = new URL(url);
+  const key = `${method.toUpperCase()} ${u.pathname}`;
+  const rule = CONTRACT[key];
+  if (!rule) return `unexpected request: ${key} (not in the Elasticsearch contract)`;
+  for (const h of rule.requiredHeaders || []) {
+    const v = headers ? headers[h] : undefined;
+    if (v == null || v === "") return `${key}: missing required header ${h}`;
+    if (h === "Authorization" && !/^(ApiKey|Basic) .+/.test(v)) {
+      return `${key}: Authorization must be 'ApiKey <key>' or 'Basic <creds>'`;
+    }
+  }
+  if (method.toUpperCase() === "POST") {
+    let parsed;
+    try {
+      parsed = typeof body === "string" ? JSON.parse(body) : body;
+    } catch {
+      return `${key}: body is not valid JSON`;
+    }
+    if (!parsed || typeof parsed.query !== "object") return `${key}: body.query (bool filter) required`;
+  }
+  return null;
+}

--- a/connectors/elasticsearch/contract/contract.test.mjs
+++ b/connectors/elasticsearch/contract/contract.test.mjs
@@ -1,0 +1,52 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import create from "../index.js";
+import { CONTRACT, checkRequest } from "./contract.mjs";
+
+function contractFetch(violations) {
+  return async (url, opts = {}) => {
+    const u = url.toString();
+    const method = (opts.method || "GET").toUpperCase();
+    const v = checkRequest(method, u, opts.headers || {}, opts.body);
+    if (v) violations.push(v);
+    const rule = CONTRACT[`${method} ${new URL(u).pathname}`];
+    let resp = {};
+    if (rule) {
+      const body = opts.body ? JSON.parse(opts.body) : {};
+      resp = typeof rule.response === "function" ? rule.response(body) : rule.response;
+    }
+    return { ok: true, status: 200, json: async () => resp };
+  };
+}
+
+test("checkRequest has teeth", () => {
+  assert.match(checkRequest("GET", "http://e/_cluster/health", {}), /missing required header Authorization/);
+  assert.match(checkRequest("GET", "http://e/_cluster/health", { Authorization: "Token x" }), /must be 'ApiKey/);
+  assert.match(checkRequest("POST", "http://e/logs-*/_search", { Authorization: "ApiKey k", "Content-Type": "application/json" }, "{}"), /body.query .* required/);
+  assert.match(checkRequest("GET", "http://e/_nope", { Authorization: "ApiKey k" }), /unexpected request/);
+  assert.equal(checkRequest("GET", "http://e/_cluster/health", { Authorization: "ApiKey k" }), null);
+});
+
+test("connector honours the Elasticsearch contract end-to-end", async () => {
+  const violations = [];
+  globalThis.fetch = contractFetch(violations);
+  const c = create();
+  await c.connect({ url: "http://es.local:9200", auth: { token: "the-api-key" } });
+
+  assert.equal((await c.healthCheck()).status, "up");
+
+  const m = await c.queryMetrics({ service: "checkout", metric: "log_rate", duration: "1h" });
+  assert.equal(m.values.length, 2);
+  assert.equal(m.unit, "doc/s");
+
+  const s = await c.listServices();
+  assert.deepEqual(s.map((x) => x.name), ["checkout", "payments"]);
+
+  const l = await c.queryLogs({ service: "checkout", duration: "15m" });
+  assert.equal(l.entries.length, 2);
+  assert.equal(l.summary.errorCount, 1);
+  assert.equal(l.entries[0].level, "error");
+
+  assert.deepEqual(violations, [], `contract violations:\n${violations.join("\n")}`);
+});

--- a/connectors/elasticsearch/index.js
+++ b/connectors/elasticsearch/index.js
@@ -1,0 +1,218 @@
+// Elasticsearch connector for observability-mcp. ES is primarily a
+// log/document store; this connector exposes logs via _search and
+// log-derived metrics via date_histogram aggregations (doc rate,
+// error rate, …) so it fits the metrics+logs contract.
+//
+// Standalone dependency-free ESM (Node 20 fetch), duck-typed against
+// the ObservabilityConnector contract — self-contained, airgapped-
+// mirrorable tarball.
+//
+// Auth: API key (Authorization: ApiKey <base64 id:key>) via the source
+// bearer token / ES_API_KEY, or HTTP basic (username+password).
+// Index pattern via ES_INDEX (default "logs-*"). Assumes ECS-ish
+// fields: @timestamp, service.name, log.level, message.
+
+const DEFAULT_METRICS = [
+  { name: "log_rate", query: "*", unit: "doc/s", description: "Document (log) rate for the service" },
+  { name: "error_rate", query: "log.level:error", unit: "doc/s", description: "Error-level document rate for the service" },
+];
+
+function parseTimeRange(duration) {
+  const m = String(duration || "").match(/^(\d+)([mhd])$/);
+  if (!m) throw new Error(`invalid duration: ${duration} (use 5m, 1h, 24h)`);
+  const n = parseInt(m[1], 10);
+  const secs = m[2] === "m" ? n * 60 : m[2] === "h" ? n * 3600 : n * 86400;
+  const endMs = Date.now();
+  return { fromMs: endMs - secs * 1000, toMs: endMs, secs };
+}
+
+function computeTrend(values) {
+  if (values.length < 4) return "stable";
+  const mid = Math.floor(values.length / 2);
+  const a = values.slice(0, mid).reduce((x, y) => x + y, 0) / mid;
+  const b = values.slice(mid).reduce((x, y) => x + y, 0) / (values.length - mid);
+  const pct = ((b - a) / (a || 1)) * 100;
+  return pct > 10 ? "rising" : pct < -10 ? "falling" : "stable";
+}
+
+function summarize(values) {
+  if (values.length === 0) return { current: 0, average: 0, min: 0, max: 0, trend: "stable" };
+  return {
+    current: values[values.length - 1],
+    average: values.reduce((a, b) => a + b, 0) / values.length,
+    min: Math.min(...values),
+    max: Math.max(...values),
+    trend: computeTrend(values),
+  };
+}
+
+export class ElasticsearchConnector {
+  constructor() {
+    this.name = "elasticsearch";
+    this.type = "elasticsearch";
+    this.signalType = "logs";
+    this._metrics = DEFAULT_METRICS;
+    this._base = "";
+    this._authHeader = "";
+    this._index = process.env.ES_INDEX || "logs-*";
+  }
+
+  async connect(config) {
+    this._base = (config && config.url) ? String(config.url).replace(/\/$/, "") : "";
+    if (!this._base) throw new Error("Elasticsearch url is required");
+    const auth = (config && config.auth) || {};
+    const apiKey = auth.token || process.env.ES_API_KEY || "";
+    if (apiKey) {
+      this._authHeader = `ApiKey ${apiKey}`;
+    } else if (auth.username) {
+      const b = Buffer.from(`${auth.username}:${auth.password || ""}`).toString("base64");
+      this._authHeader = `Basic ${b}`;
+    } else {
+      this._authHeader = "";
+    }
+    if (Array.isArray(config && config.metrics) && config.metrics.length > 0) {
+      this._metrics = config.metrics;
+    }
+  }
+
+  async disconnect() {
+    /* stateless */
+  }
+
+  _headers() {
+    const h = { "Content-Type": "application/json" };
+    if (this._authHeader) h.Authorization = this._authHeader;
+    return h;
+  }
+
+  async _search(body) {
+    const res = await fetch(`${this._base}/${encodeURIComponent(this._index)}/_search`, {
+      method: "POST",
+      headers: this._headers(),
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error(`Elasticsearch _search HTTP ${res.status}`);
+    return res.json();
+  }
+
+  async healthCheck() {
+    const started = Date.now();
+    try {
+      const res = await fetch(`${this._base}/_cluster/health`, { headers: this._headers() });
+      const latencyMs = Date.now() - started;
+      if (!res.ok) return { status: "down", latencyMs, message: `cluster health HTTP ${res.status}` };
+      const b = await res.json().catch(() => ({}));
+      return b && (b.status === "green" || b.status === "yellow" || b.status === "red")
+        ? { status: b.status === "red" ? "down" : "up", latencyMs, message: `cluster ${b.status}` }
+        : { status: "down", latencyMs, message: "unexpected cluster health" };
+    } catch (e) {
+      return { status: "down", latencyMs: Date.now() - started, message: String(e) };
+    }
+  }
+
+  getDefaultMetrics() {
+    return DEFAULT_METRICS;
+  }
+
+  getMetrics() {
+    return this._metrics;
+  }
+
+  _range(fromMs, toMs) {
+    return { range: { "@timestamp": { gte: new Date(fromMs).toISOString(), lte: new Date(toMs).toISOString() } } };
+  }
+
+  async listServices() {
+    try {
+      const { fromMs, toMs } = parseTimeRange("1h");
+      const body = await this._search({
+        size: 0,
+        query: { bool: { filter: [this._range(fromMs, toMs)] } },
+        aggs: { svc: { terms: { field: "service.name", size: 200 } } },
+      });
+      const buckets = (((body || {}).aggregations || {}).svc || {}).buckets || [];
+      return buckets.map((b) => ({ name: String(b.key), source: this.name, signalType: "logs" }));
+    } catch {
+      return [];
+    }
+  }
+
+  async queryMetrics(params) {
+    const def = this._metrics.find((m) => m.name === params.metric)
+      || DEFAULT_METRICS.find((m) => m.name === params.metric);
+    if (!def) throw new Error(`unknown metric '${params.metric}' for elasticsearch`);
+    const { fromMs, toMs, secs } = parseTimeRange(params.duration);
+    const intervalSec = Math.max(Math.floor(secs / 100), 15);
+    const filter = [
+      { term: { "service.name": params.service } },
+      this._range(fromMs, toMs),
+    ];
+    if (def.query && def.query !== "*") {
+      filter.push({ query_string: { query: def.query } });
+    }
+    const body = await this._search({
+      size: 0,
+      query: { bool: { filter } },
+      aggs: {
+        ts: {
+          date_histogram: { field: "@timestamp", fixed_interval: `${intervalSec}s`, min_doc_count: 0 },
+        },
+      },
+    });
+    const buckets = (((body || {}).aggregations || {}).ts || {}).buckets || [];
+    const dps = buckets.map((b) => ({
+      timestamp: new Date(b.key).toISOString(),
+      value: (b.doc_count || 0) / intervalSec,
+    }));
+    return {
+      source: this.name,
+      service: params.service,
+      metric: params.metric,
+      unit: def.unit,
+      values: dps,
+      summary: summarize(dps.map((d) => d.value)),
+      resolvedSeries: `index=${this._index} q=${def.query}`,
+    };
+  }
+
+  async queryLogs(params) {
+    const { fromMs, toMs } = parseTimeRange(params.duration);
+    const filter = [
+      { term: { "service.name": params.service } },
+      this._range(fromMs, toMs),
+    ];
+    if (params.level) filter.push({ term: { "log.level": params.level } });
+    if (params.query) filter.push({ query_string: { query: params.query } });
+    const body = await this._search({
+      size: Math.min(params.limit || 100, 1000),
+      sort: [{ "@timestamp": "desc" }],
+      query: { bool: { filter } },
+    });
+    const hits = (((body || {}).hits || {}).hits) || [];
+    let errorCount = 0;
+    let warnCount = 0;
+    const entries = hits.map((h) => {
+      const s = h._source || {};
+      const level = String((s.log && s.log.level) || s["log.level"] || "info").toLowerCase();
+      if (level === "error" || level === "fatal" || level === "critical") errorCount++;
+      else if (level === "warn" || level === "warning") warnCount++;
+      const svc = (s.service && s.service.name) || s["service.name"] || params.service;
+      return {
+        timestamp: s["@timestamp"] ? new Date(s["@timestamp"]).toISOString() : new Date().toISOString(),
+        level,
+        message: String(s.message != null ? s.message : ""),
+        labels: { service: svc },
+      };
+    });
+    return {
+      source: this.name,
+      service: params.service,
+      entries,
+      summary: { total: entries.length, errorCount, warnCount, topPatterns: [] },
+    };
+  }
+}
+
+export default function create() {
+  return new ElasticsearchConnector();
+}

--- a/connectors/elasticsearch/index.test.mjs
+++ b/connectors/elasticsearch/index.test.mjs
@@ -1,0 +1,104 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import create, { ElasticsearchConnector } from "./index.js";
+
+function mockFetch(routes) {
+  return async (url, opts) => {
+    const u = url.toString();
+    for (const [pat, h] of routes) if (u.includes(pat)) return h(u, opts);
+    return { ok: false, status: 404, json: async () => ({}) };
+  };
+}
+const ok = (b) => ({ ok: true, status: 200, json: async () => b });
+
+test("create() shape", () => {
+  const c = create();
+  assert.ok(c instanceof ElasticsearchConnector);
+  assert.equal(c.name, "elasticsearch");
+  assert.equal(c.getDefaultMetrics().length, 2);
+});
+
+test("connect requires url; api-key vs basic auth", async () => {
+  await assert.rejects(() => create().connect({ auth: { token: "k" } }), /url is required/);
+  const k = create();
+  await k.connect({ url: "http://es:9200/", auth: { token: "abc" } });
+  assert.equal(k._base, "http://es:9200");
+  assert.equal(k._authHeader, "ApiKey abc");
+  const b = create();
+  await b.connect({ url: "http://es:9200", auth: { username: "u", password: "p" } });
+  assert.equal(b._authHeader, "Basic " + Buffer.from("u:p").toString("base64"));
+});
+
+test("healthCheck maps cluster status", async () => {
+  const c = create();
+  await c.connect({ url: "http://es:9200", auth: { token: "k" } });
+  globalThis.fetch = mockFetch([["/_cluster/health", () => ok({ status: "green" })]]);
+  assert.equal((await c.healthCheck()).status, "up");
+  globalThis.fetch = mockFetch([["/_cluster/health", () => ok({ status: "yellow" })]]);
+  assert.equal((await c.healthCheck()).status, "up");
+  globalThis.fetch = mockFetch([["/_cluster/health", () => ok({ status: "red" })]]);
+  assert.equal((await c.healthCheck()).status, "down");
+  globalThis.fetch = mockFetch([["/_cluster/health", () => ({ ok: false, status: 401, json: async () => ({}) })]]);
+  assert.equal((await c.healthCheck()).status, "down");
+});
+
+test("listServices reads terms agg, never throws", async () => {
+  const c = create();
+  await c.connect({ url: "http://es:9200", auth: { token: "k" } });
+  globalThis.fetch = mockFetch([
+    ["/_search", () => ok({ aggregations: { svc: { buckets: [{ key: "api" }, { key: "db" }] } } })],
+  ]);
+  assert.deepEqual((await c.listServices()).map((s) => s.name), ["api", "db"]);
+  globalThis.fetch = async () => { throw new Error("down"); };
+  assert.deepEqual(await c.listServices(), []);
+});
+
+test("queryMetrics builds date_histogram, normalizes by interval", async () => {
+  const c = create();
+  await c.connect({ url: "http://es:9200", auth: { token: "k" } });
+  let body;
+  globalThis.fetch = mockFetch([
+    ["/_search", (_u, o) => {
+      body = JSON.parse(o.body);
+      return ok({ aggregations: { ts: { buckets: [
+        { key: 1715760000000, doc_count: 30 },
+        { key: 1715760060000, doc_count: 0 },
+      ] } } });
+    }],
+  ]);
+  const r = await c.queryMetrics({ service: "checkout", metric: "error_rate", duration: "1h" });
+  // service filter + error query_string present
+  const fstr = JSON.stringify(body.query.bool.filter);
+  assert.match(fstr, /"service.name":"checkout"/);
+  assert.match(fstr, /log.level:error/);
+  assert.ok(body.aggs.ts.date_histogram.fixed_interval);
+  assert.equal(r.unit, "doc/s");
+  assert.equal(r.values.length, 2);
+  assert.ok(r.values[0].value > 0);
+});
+
+test("queryMetrics rejects unknown metric + bad duration", async () => {
+  const c = create();
+  await c.connect({ url: "http://es:9200", auth: { token: "k" } });
+  await assert.rejects(() => c.queryMetrics({ service: "s", metric: "nope", duration: "1h" }), /unknown metric/);
+  await assert.rejects(() => c.queryMetrics({ service: "s", metric: "log_rate", duration: "x" }), /invalid duration/);
+});
+
+test("queryLogs maps hits + counts levels", async () => {
+  const c = create();
+  await c.connect({ url: "http://es:9200", auth: { token: "k" } });
+  globalThis.fetch = mockFetch([
+    ["/_search", () => ok({ hits: { hits: [
+      { _source: { "@timestamp": "2026-05-16T10:00:00Z", log: { level: "error" }, message: "boom", service: { name: "api" } } },
+      { _source: { "@timestamp": "2026-05-16T10:01:00Z", log: { level: "warn" }, message: "slow" } },
+      { _source: { "@timestamp": "2026-05-16T10:02:00Z", message: "ok" } },
+    ] } })],
+  ]);
+  const r = await c.queryLogs({ service: "api", duration: "15m", level: "error" });
+  assert.equal(r.entries.length, 3);
+  assert.equal(r.summary.errorCount, 1);
+  assert.equal(r.summary.warnCount, 1);
+  assert.equal(r.entries[0].level, "error");
+  assert.equal(r.entries[0].labels.service, "api");
+});

--- a/connectors/elasticsearch/manifest.json
+++ b/connectors/elasticsearch/manifest.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "name": "elasticsearch",
+  "displayName": "Elasticsearch",
+  "version": "1.0.0",
+  "description": "Elasticsearch connector — logs via _search and log-derived metrics (doc/error rate) via date_histogram aggregations. ECS-style fields; API-key or basic auth; index pattern via ES_INDEX.",
+  "signalTypes": ["logs", "metrics"],
+  "homepage": "https://github.com/ThoTischner/observability-mcp",
+  "license": "MIT",
+  "capabilities": {
+    "queryMetrics": true,
+    "queryLogs": true,
+    "listServices": true
+  },
+  "compat": {
+    "serverVersion": ">=1.4.0"
+  },
+  "integrity": "sha256-US/Lpr1+/P+2vmRcL910WiPIc2k9jxrbvChF4DVH8Us="
+}

--- a/connectors/elasticsearch/package.json
+++ b/connectors/elasticsearch/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@observability-mcp/connector-elasticsearch",
+  "version": "1.0.0",
+  "description": "Elasticsearch connector for observability-mcp — logs via _search and log-derived metrics via aggregations.",
+  "type": "module",
+  "main": "./index.js",
+  "license": "MIT",
+  "files": ["index.js", "manifest.json"],
+  "observabilityMcp": {
+    "kind": "connector",
+    "name": "elasticsearch",
+    "manifest": "./manifest.json"
+  }
+}

--- a/hub/catalog/elasticsearch.json
+++ b/hub/catalog/elasticsearch.json
@@ -1,0 +1,20 @@
+{
+  "catalogVersion": 1,
+  "name": "elasticsearch",
+  "displayName": "Elasticsearch",
+  "description": "Elasticsearch connector — logs via _search and log-derived metrics (doc/error rate) via date_histogram aggregations. ECS-style fields, API-key or basic auth.",
+  "vendor": "observability-mcp",
+  "homepage": "https://github.com/ThoTischner/observability-mcp",
+  "tier": "official",
+  "signalTypes": ["logs", "metrics"],
+  "versions": [
+    {
+      "version": "1.0.0",
+      "releasedAt": "2026-05-16",
+      "serverCompat": ">=1.4.0",
+      "tarballUrl": "https://github.com/ThoTischner/observability-mcp/releases/download/connector-elasticsearch-1.0.0/elasticsearch-1.0.0.tgz",
+      "integrity": "sha256-US/Lpr1+/P+2vmRcL910WiPIc2k9jxrbvChF4DVH8Us=",
+      "changelog": "Initial release: _search logs + date_histogram log-derived metrics, service-name aggregation discovery, API-key/basic auth, ES_INDEX pattern."
+    }
+  ]
+}

--- a/hub/catalog/index.json
+++ b/hub/catalog/index.json
@@ -24,6 +24,28 @@
       ]
     },
     {
+      "name": "elasticsearch",
+      "displayName": "Elasticsearch",
+      "description": "Elasticsearch connector — logs via _search and log-derived metrics (doc/error rate) via date_histogram aggregations. ECS-style fields, API-key or basic auth.",
+      "tier": "official",
+      "builtin": false,
+      "signalTypes": [
+        "logs",
+        "metrics"
+      ],
+      "latest": "1.0.0",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "releasedAt": "2026-05-16",
+          "serverCompat": ">=1.4.0",
+          "tarballUrl": "https://github.com/ThoTischner/observability-mcp/releases/download/connector-elasticsearch-1.0.0/elasticsearch-1.0.0.tgz",
+          "integrity": "sha256-US/Lpr1+/P+2vmRcL910WiPIc2k9jxrbvChF4DVH8Us=",
+          "changelog": "Initial release: _search logs + date_histogram log-derived metrics, service-name aggregation discovery, API-key/basic auth, ES_INDEX pattern."
+        }
+      ]
+    },
+    {
       "name": "grafana",
       "displayName": "Grafana",
       "description": "Grafana connector — metrics from a Prometheus-compatible datasource and logs from a Loki datasource, queried through Grafana's datasource proxy behind Grafana auth.",


### PR DESCRIPTION
## Summary
Third hub connector: **Elasticsearch**. Logs via `_search`, log-derived metrics (doc/error rate) via `date_histogram` aggregations, service discovery via a `service.name` terms agg. API-key or basic auth, ECS-style fields, `ES_INDEX` pattern. Standalone dependency-free ESM, duck-typed, self-contained tarball.

- 7 unit tests (mocked fetch) + 2 contract tests.
- Catalog entry + regenerated `index.json` (5 connectors).
- **`connector-install-it` generalized to loop every `connectors/*`** — the full chain test (pack→sign→install→verify→tamper-reject→trust-root + loader smoke) now auto-covers new connectors with no hardcoded list.
- Verified locally: install-it + loader smoke green for elasticsearch; integrity in sync.

## Test plan
- [x] 7/7 unit + 2/2 contract
- [x] install-it (install/verify/tamper/trust-root) PASS
- [x] loader smoke: datadog+elasticsearch+grafana load & callable
- [x] catalog `--check` in sync (5 connectors)