### PR TITLE
feat(server): optional stdio MCP transport (--stdio)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,8 @@ flags pass through after a literal `--`.
 
 In the docker-compose demo: Prometheus on `:9090`, Loki on `:3100`, services on `:8080–:8082`.
 
+**Transports:** Streamable HTTP by default (`/mcp`). For stdio-based clients/catalogs (Claude Desktop, Glama's `mcp-proxy`, etc.) run with `--stdio` (or `MCP_TRANSPORT=stdio`) — one MCP server over stdin/stdout, all logs on stderr so the protocol stream stays clean.
+
 ## Tech Stack
 
 TypeScript + Node 20, `@modelcontextprotocol/sdk` (Streamable HTTP), Express, Zod, js-yaml, prom-client (example services), Prometheus, Loki, Promtail, Docker Compose, optional Ollama.

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -3,6 +3,7 @@ import express from "express";
 import { randomUUID } from "node:crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { loadConfig, saveConfig, DEFAULT_HEALTH_THRESHOLDS, DEFAULT_SETTINGS } from "./config/loader.js";
 import { ConnectorRegistry, getSupportedTypes } from "./connectors/registry.js";
@@ -72,6 +73,18 @@ function validateSourceUrl(url: string): string | null {
 }
 
 async function main() {
+  // Stdio transport mode (MCP catalogs / desktop clients / Glama's
+  // mcp-proxy spawn a stdio MCP server and read JSON-RPC from stdout).
+  // The protocol stream MUST be the only thing on stdout, so route all
+  // console.log to stderr before anything logs.
+  const STDIO =
+    process.argv.includes("--stdio") ||
+    process.env.MCP_TRANSPORT === "stdio" ||
+    !!process.env.MCP_STDIO;
+  if (STDIO) {
+    console.log = (...a: unknown[]) => console.error(...a);
+  }
+
   let config = loadConfig();
   await getPluginLoader().load();
   const registry = new ConnectorRegistry();
@@ -485,6 +498,19 @@ async function main() {
     saveConfig(config);
     res.json({ ok: true });
   });
+
+  // Stdio transport: one server over stdin/stdout, no HTTP listener.
+  if (STDIO) {
+    const server = createMcpServer();
+    await server.connect(new StdioServerTransport());
+    console.error(
+      `observability-mcp running on stdio transport · connectors: ${registry
+        .getAll()
+        .map((c) => c.name)
+        .join(", ")}`
+    );
+    return;
+  }
 
   // MCP Streamable HTTP transport — stateful sessions
   const transports = new Map<string, StreamableHTTPServerTransport>();


### PR DESCRIPTION
## Summary
Fixes the reported Glama build failure (`spawn http://localhost:3000/mcp ENOENT`).

Glama's `mcp-proxy` spawns the CMD as a **stdio** MCP server and reads JSON-RPC from stdout — it cannot point at an HTTP URL. observability-mcp was Streamable-HTTP-only, so no CMD could satisfy it.

- `--stdio` (or `MCP_TRANSPORT=stdio` / `MCP_STDIO`) → connect a single `StdioServerTransport`, skip the HTTP listener.
- `console.log` is redirected to **stderr** as the very first thing in `main()`, so the stdout stream is pure JSON-RPC (the startup banner + plugin-loader logs previously corrupted it — exactly the "ignoring non-JSON output" / "stripped non-JSON prefix" the user saw).
- HTTP Streamable transport remains the default — no behavior change without the flag.
- README transports note added.

### Glama config (use this)
- Base image: default · Build steps: `["cd mcp-server && npm ci && npm run build"]`
- **CMD arguments**: `["node","mcp-server/dist/index.js","--stdio"]`
- Placeholder parameters: `{}` (starts with zero sources, no creds)
- Env schema: the prefilled one is fine (nothing required)

## Test plan
- [x] `tsc --noEmit` clean; `npm run build` OK
- [x] `node dist/index.js --stdio` ← initialize + notifications/initialized → **pure JSON-RPC on stdout** (valid, id=1, has result); banner/logs on stderr only