### PR TITLE
feat(ui): Connector Hub integration — installed list + hub browse (slice 1)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,7 +49,7 @@ jobs:
         run: npm ci
       - name: Run tests
         working-directory: ./mcp-server
-        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/connectors/verify.test.ts src/cli/*.test.ts
+        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/connectors/verify.test.ts src/connectors/hub.test.ts src/cli/*.test.ts
       - name: Connector hub catalog (validate + in-sync)
         run: |
           node hub/build-catalog.mjs --check

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc && cp -r src/ui dist/ui",
+    "build": "tsc && rm -rf dist/ui && cp -r src/ui dist/ui",
     "start": "node dist/index.js"
   },
   "dependencies": {

--- a/mcp-server/src/connectors/hub.test.ts
+++ b/mcp-server/src/connectors/hub.test.ts
@@ -1,0 +1,76 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  resolveHubCatalogUrl,
+  describeInstalled,
+  mergeCatalog,
+  fetchHubCatalog,
+  DEFAULT_HUB_CATALOG_URL,
+} from "./hub.js";
+import type { LoadedConnector } from "./loader.js";
+
+test("resolveHubCatalogUrl: default + env override", () => {
+  assert.equal(resolveHubCatalogUrl({}), DEFAULT_HUB_CATALOG_URL);
+  assert.equal(
+    resolveHubCatalogUrl({ HUB_CATALOG_URL: "http://mirror/idx.json" }),
+    "http://mirror/idx.json"
+  );
+});
+
+test("describeInstalled maps loader entries, sorts, defaults", () => {
+  const loaded = [
+    { name: "loki", source: "builtin", factory: () => ({}) },
+    {
+      name: "datadog",
+      source: "filesystem",
+      factory: () => ({}),
+      manifest: {
+        displayName: "Datadog",
+        description: "DD",
+        version: "1.0.0",
+        signalTypes: ["metrics", "logs"],
+        capabilities: { queryMetrics: true },
+      },
+    },
+  ] as unknown as LoadedConnector[];
+  const d = describeInstalled(loaded);
+  assert.deepEqual(d.map((x) => x.name), ["datadog", "loki"]); // sorted
+  assert.equal(d[0].displayName, "Datadog");
+  assert.deepEqual(d[0].signalTypes, ["metrics", "logs"]);
+  assert.equal(d[1].displayName, "loki"); // falls back to name
+  assert.equal(d[1].version, null);
+  assert.deepEqual(d[1].capabilities, {});
+});
+
+test("mergeCatalog marks installed + version, sorts, tolerates null", () => {
+  const installed = describeInstalled([
+    { name: "datadog", source: "filesystem", factory: () => ({}), manifest: { version: "1.0.0" } },
+  ] as unknown as LoadedConnector[]);
+  const merged = mergeCatalog(
+    { connectors: [
+      { name: "grafana", displayName: "Grafana", description: "", tier: "official", signalTypes: ["metrics"], versions: [{ version: "1.0.0" }] },
+      { name: "datadog", displayName: "Datadog", description: "", tier: "official", signalTypes: ["metrics"], versions: [{ version: "1.0.0" }] },
+    ] },
+    installed
+  );
+  assert.deepEqual(merged.map((m) => m.name), ["datadog", "grafana"]);
+  assert.equal(merged[0].installed, true);
+  assert.equal(merged[0].installedVersion, "1.0.0");
+  assert.equal(merged[1].installed, false);
+  assert.deepEqual(mergeCatalog(null, installed), []);
+});
+
+test("fetchHubCatalog: ok, http error, malformed", async () => {
+  const ok = async () => ({ ok: true, status: 200, json: async () => ({ connectors: [{ name: "x" }], catalogVersion: 1 }) }) as Response;
+  const r = await fetchHubCatalog("u", ok as unknown as typeof fetch);
+  assert.equal(r.connectors.length, 1);
+  await assert.rejects(
+    () => fetchHubCatalog("u", (async () => ({ ok: false, status: 503, json: async () => ({}) })) as unknown as typeof fetch),
+    /HTTP 503/
+  );
+  await assert.rejects(
+    () => fetchHubCatalog("u", (async () => ({ ok: true, status: 200, json: async () => ({}) })) as unknown as typeof fetch),
+    /malformed/
+  );
+});

--- a/mcp-server/src/connectors/hub.ts
+++ b/mcp-server/src/connectors/hub.ts
@@ -1,0 +1,90 @@
+// Connector-hub integration helpers (pure, IO-injectable so they unit
+// test without network). Powers the Web UI "Connectors" page:
+//   - what's installed/loaded right now
+//   - what the hub catalog offers, with an "installed" marker
+
+import type { LoadedConnector } from "./loader.js";
+
+export const DEFAULT_HUB_CATALOG_URL =
+  "https://thotischner.github.io/observability-mcp/hub/index.json";
+
+/** Catalog source: env override wins (airgapped mirror / private hub). */
+export function resolveHubCatalogUrl(env: NodeJS.ProcessEnv = process.env): string {
+  return env.HUB_CATALOG_URL || DEFAULT_HUB_CATALOG_URL;
+}
+
+export interface InstalledConnector {
+  name: string;
+  source: "builtin" | "filesystem" | "config";
+  displayName: string;
+  description: string;
+  version: string | null;
+  signalTypes: string[];
+  capabilities: Record<string, boolean>;
+}
+
+/** Shape the loader's entries into the UI's installed list. */
+export function describeInstalled(loaded: LoadedConnector[]): InstalledConnector[] {
+  return loaded
+    .map((p) => ({
+      name: p.name,
+      source: p.source,
+      displayName: p.manifest?.displayName ?? p.name,
+      description: p.manifest?.description ?? "",
+      version: p.manifest?.version ?? null,
+      signalTypes: p.manifest?.signalTypes ?? [],
+      capabilities: (p.manifest?.capabilities as Record<string, boolean>) ?? {},
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export interface CatalogConnector {
+  name: string;
+  displayName: string;
+  description: string;
+  tier: string;
+  builtin?: boolean;
+  signalTypes: string[];
+  latest?: string;
+  versions: Array<{ version: string; tarballUrl?: string; integrity?: string; serverCompat?: string; changelog?: string; releasedAt?: string }>;
+}
+
+export interface HubCatalogEntry extends CatalogConnector {
+  installed: boolean;
+  installedVersion: string | null;
+}
+
+/**
+ * Merge the hub catalog with what's installed so the UI can show
+ * status + offer not-yet-installed connectors.
+ */
+export function mergeCatalog(
+  catalog: { connectors?: CatalogConnector[] } | null,
+  installed: InstalledConnector[]
+): HubCatalogEntry[] {
+  const byName = new Map(installed.map((i) => [i.name, i]));
+  return (catalog?.connectors ?? [])
+    .map((c) => {
+      const have = byName.get(c.name);
+      return {
+        ...c,
+        installed: !!have,
+        installedVersion: have?.version ?? null,
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Fetch + parse the catalog. fetchImpl injected for tests. */
+export async function fetchHubCatalog(
+  url: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<{ connectors: CatalogConnector[]; catalogVersion?: number }> {
+  const res = await fetchImpl(url);
+  if (!res.ok) throw new Error(`hub catalog HTTP ${res.status} from ${url}`);
+  const body = (await res.json()) as { connectors?: CatalogConnector[]; catalogVersion?: number };
+  if (!body || !Array.isArray(body.connectors)) {
+    throw new Error("hub catalog malformed (no connectors[])");
+  }
+  return { connectors: body.connectors, catalogVersion: body.catalogVersion };
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -8,6 +8,12 @@ import { z } from "zod";
 import { loadConfig, saveConfig, DEFAULT_HEALTH_THRESHOLDS, DEFAULT_SETTINGS } from "./config/loader.js";
 import { ConnectorRegistry, getSupportedTypes } from "./connectors/registry.js";
 import { getPluginLoader } from "./connectors/loader.js";
+import {
+  resolveHubCatalogUrl,
+  describeInstalled,
+  mergeCatalog,
+  fetchHubCatalog,
+} from "./connectors/hub.js";
 import { selfRegistry, withToolMetrics, apiRequests, mcpActiveSessions } from "./metrics/self.js";
 import { buildOpenApiSpec } from "./openapi.js";
 import { listSourcesHandler } from "./tools/list-sources.js";
@@ -281,6 +287,28 @@ async function main() {
         signalTypes: p.manifest?.signalTypes ?? null,
       })),
     });
+  });
+
+  // Connectors currently loaded into this server (builtin + filesystem
+  // plugins), with manifest metadata — drives the UI "Connectors" page.
+  app.get("/api/connectors", (_req, res) => {
+    res.json({ connectors: describeInstalled(getPluginLoader().list()) });
+  });
+
+  // Server-side proxy of the connector hub catalog (so the browser
+  // needn't reach the hub directly — works behind a proxy / against a
+  // mirror via HUB_CATALOG_URL). Installed status merged in.
+  app.get("/api/hub/catalog", async (_req, res) => {
+    const url = resolveHubCatalogUrl();
+    try {
+      const catalog = await fetchHubCatalog(url);
+      res.json({
+        url,
+        connectors: mergeCatalog(catalog, describeInstalled(getPluginLoader().list())),
+      });
+    } catch (e) {
+      res.status(502).json({ url, error: e instanceof Error ? e.message : String(e), connectors: [] });
+    }
   });
 
   // Add a new source

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -122,6 +122,7 @@
     .badge::before { content: ''; width: 6px; height: 6px; border-radius: 50%; background: currentColor; box-shadow: 0 0 6px currentColor; }
     .badge-ok  { background: var(--success-soft); color: var(--success); border: 1px solid rgba(74,222,128,0.25); }
     .badge-err { background: var(--danger-soft);  color: var(--danger);  border: 1px solid rgba(239,91,110,0.30); }
+    .hidden { display: none !important; }
 
     .nav { display: flex; gap: 2px; margin-left: var(--sp-6); }
     .nav-btn {
@@ -490,6 +491,7 @@
       <button class="nav-btn active" data-page="dashboard" onclick="showPage('dashboard')">Dashboard</button>
       <button class="nav-btn" data-page="sources" onclick="showPage('sources')">Sources</button>
       <button class="nav-btn" data-page="services" onclick="showPage('services')">Services</button>
+      <button class="nav-btn" data-page="connectors" onclick="showPage('connectors')">Connectors</button>
       <button class="nav-btn" data-page="health" onclick="showPage('health')">Health</button>
       <button class="nav-btn" data-page="settings" onclick="showPage('settings')">Settings</button>
     </div>
@@ -547,6 +549,19 @@
     <!-- ===== Services ===== -->
     <div class="page" id="page-services">
       <div class="card"><div class="card-header"><h2>Discovered Services</h2></div><div id="services-list"><div class="empty">Loading...</div></div></div>
+    </div>
+
+    <!-- ===== Connectors ===== -->
+    <div class="page" id="page-connectors">
+      <div class="card">
+        <div class="card-header"><h2>Installed connectors</h2><button class="btn btn-ghost btn-sm" onclick="loadConnectors()">Refresh</button></div>
+        <div id="conn-installed"><div class="empty">Loading...</div></div>
+      </div>
+      <div class="card">
+        <div class="card-header"><h2>Available from the Connector Hub</h2>
+          <a class="btn btn-ghost btn-sm" href="https://thotischner.github.io/observability-mcp/hub/" target="_blank" rel="noopener">Open Hub ↗</a></div>
+        <div id="conn-hub"><div class="empty">Loading...</div></div>
+      </div>
     </div>
 
     <!-- ===== Health ===== -->
@@ -744,6 +759,53 @@ function showPage(name) {
   document.querySelector(`.nav-btn[data-page="${name}"]`).classList.add('active');
   if(name==='settings') loadSettingsData();
   if(name==='health') loadHealthData();
+  if(name==='connectors') loadConnectors();
+}
+
+function escHtml(s){return String(s==null?'':s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));}
+
+async function loadConnectors(){
+  const inst=document.getElementById('conn-installed');
+  const hub=document.getElementById('conn-hub');
+  try {
+    const d=await(await fetch('/api/connectors')).json();
+    const cs=(d.connectors||[]);
+    inst.innerHTML = cs.length ? cs.map(c=>{
+      const caps=Object.entries(c.capabilities||{}).filter(([,v])=>v).map(([k])=>k).join(', ')||'—';
+      return `<div class="card" style="margin:0 0 10px">
+        <div class="card-header"><h2 style="font-size:15px">${escHtml(c.displayName)}
+          <span class="badge">${escHtml(c.source)}</span>
+          ${c.version?`<span class="badge">v${escHtml(c.version)}</span>`:''}</h2></div>
+        <div style="color:var(--text-muted);font-size:13px">${escHtml(c.description)||'<em>no description</em>'}</div>
+        <div style="font-size:12px;color:var(--text-muted);margin-top:6px">type <code>${escHtml(c.name)}</code> · signals ${(c.signalTypes||[]).map(escHtml).join(', ')||'—'} · ${escHtml(caps)}</div>
+      </div>`;
+    }).join('') : '<div class="empty">No connectors loaded.</div>';
+  } catch(e){ inst.innerHTML='<div class="empty">Failed to load connectors.</div>'; }
+
+  try {
+    const d=await(await fetch('/api/hub/catalog')).json();
+    if(d.error){ hub.innerHTML=`<div class="empty">Hub catalog unreachable (${escHtml(d.url)}).<br>Set <code>HUB_CATALOG_URL</code> for a mirror. ${escHtml(d.error)}</div>`; return; }
+    const cs=(d.connectors||[]);
+    hub.innerHTML = cs.length ? cs.map(c=>{
+      const v=(c.versions&&c.versions[0])||{};
+      const ver=c.latest||v.version||'';
+      const status = c.installed
+        ? `<span class="badge badge-ok">installed${c.installedVersion?` v${escHtml(c.installedVersion)}`:''}</span>`
+        : (c.builtin?'<span class="badge">builtin</span>':'<span class="badge">available</span>');
+      const cmd = c.builtin
+        ? `# ${escHtml(c.displayName)} ships in the server image — no install needed.`
+        : `curl -fsSL -o plugin-signing.pub.pem https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/plugin-signing.pub.pem\nomcp plugin install ${escHtml(c.name)}@${escHtml(ver)} --trust-root plugin-signing.pub.pem`;
+      const id='ci-'+c.name;
+      return `<div class="card" style="margin:0 0 10px">
+        <div class="card-header"><h2 style="font-size:15px">${escHtml(c.displayName)}
+          <span class="badge">${escHtml(c.tier)}</span> ${status}</h2>
+          ${c.installed||c.builtin?'':`<button class="btn btn-ghost btn-sm" onclick="document.getElementById('${id}').classList.toggle('hidden')">Install…</button>`}</div>
+        <div style="color:var(--text-muted);font-size:13px">${escHtml(c.description)}</div>
+        <div style="font-size:12px;color:var(--text-muted);margin-top:6px">type <code>${escHtml(c.name)}</code> · signals ${(c.signalTypes||[]).map(escHtml).join(', ')||'—'} · latest <code>${escHtml(ver)||'—'}</code></div>
+        <pre id="${id}" class="hidden" style="margin-top:8px;background:var(--surface-2);padding:10px;border-radius:6px;font-size:12px;overflow:auto">${escHtml(cmd)}</pre>
+      </div>`;
+    }).join('') : '<div class="empty">Catalog empty.</div>';
+  } catch(e){ hub.innerHTML='<div class="empty">Failed to reach the hub catalog.</div>'; }
 }
 function showTab(name) {
   document.querySelectorAll('.tab-content').forEach(t=>t.classList.remove('active'));


### PR DESCRIPTION
## Summary
Slice 1 of the in-UI Connector Hub integration (read-only — safe, no write path yet).

- **`GET /api/connectors`** — connectors loaded into the running server (builtin + filesystem) + manifest metadata.
- **`GET /api/hub/catalog`** — server-side proxy of the hub catalog (browser needn't reach the hub; works behind a proxy / mirror via `HUB_CATALOG_URL`); installed status merged in.
- **New "Connectors" UI page** — installed connectors + hub catalog with installed/available/builtin badges and per-connector install instructions (1-click install = slice 2).
- Pure `connectors/hub.ts` helpers + 4 unit tests (in CI glob).
- **fix(build)**: `rm -rf dist/ui` before copy — incremental builds were nesting a stale UI under `dist/ui/ui` and serving it (found while verifying this).

### Roadmap (next slices, one per loop tick)
2. `POST /api/connectors/install` from catalog — fail-closed verify vs trust root + write to `PLUGINS_DIR` + reload + guardrails (feature-flag/auth; runtime code-load is powerful).
3. `POST /api/connectors/upload` — bundle `.tgz` upload, same verify chain.
4. Helm: PVC for `/app/plugins` reconciled with the bundle init-container so UI installs survive pod restarts.
5. Docs/polish.

## Test plan
- [x] `tsc` clean; 4/4 hub unit tests
- [x] Clean-build smoke: `/api/connectors` (loki, prometheus), `/api/hub/catalog` 200 w/ installed-merge, UI nav + loader present