### PR TITLE
feat(ui): server-side connector install from the hub (slice 2)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,7 +49,7 @@ jobs:
         run: npm ci
       - name: Run tests
         working-directory: ./mcp-server
-        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/connectors/verify.test.ts src/connectors/hub.test.ts src/cli/*.test.ts
+        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/connectors/verify.test.ts src/connectors/hub.test.ts src/connectors/install.test.ts src/cli/*.test.ts
       - name: Connector hub catalog (validate + in-sync)
         run: |
           node hub/build-catalog.mjs --check

--- a/mcp-server/src/connectors/install.test.ts
+++ b/mcp-server/src/connectors/install.test.ts
@@ -1,0 +1,69 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync, sign as edSign, createHash } from "node:crypto";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { isValidConnectorName, safeTarget, installTarball } from "./install.js";
+import { PluginVerificationError } from "./verify.js";
+
+test("isValidConnectorName: kebab only, blocks traversal", () => {
+  assert.ok(isValidConnectorName("datadog"));
+  assert.ok(isValidConnectorName("my-connector9"));
+  for (const bad of ["../evil", "Foo", "a/b", "", "1abc", "a_b", null, 42]) {
+    assert.equal(isValidConnectorName(bad as unknown), false);
+  }
+});
+
+test("safeTarget keeps the path inside pluginsDir", () => {
+  const t = safeTarget("/plugins", "datadog");
+  assert.equal(t, "/plugins/datadog");
+  assert.throws(() => safeTarget("/plugins", "../etc"), /invalid connector name|outside/);
+});
+
+function mkSignedTarball(dir: string, name: string, priv: import("node:crypto").KeyObject, opts: { tamper?: boolean; noSig?: boolean } = {}) {
+  const src = join(dir, "src");
+  mkdirSync(src, { recursive: true });
+  writeFileSync(join(src, "index.js"), "export default () => ({});\n");
+  const integ =
+    "sha256-" + createHash("sha256").update(readFileSync(join(src, "index.js"))).digest("base64");
+  const manifest = { schemaVersion: 1, name, displayName: name, version: "1.0.0", description: "x", signalTypes: ["metrics"], integrity: integ };
+  const mb = Buffer.from(JSON.stringify(manifest));
+  writeFileSync(join(src, "manifest.json"), mb);
+  if (!opts.noSig) writeFileSync(join(src, "manifest.json.sig"), edSign(null, mb, priv));
+  writeFileSync(join(src, "package.json"), JSON.stringify({ name, main: "index.js", observabilityMcp: { kind: "connector", name, manifest: "./manifest.json" } }));
+  if (opts.tamper) writeFileSync(join(src, "index.js"), "export default () => ({}); /* tampered */\n");
+  const tgz = join(dir, `${name}-1.0.0.tgz`);
+  const r = spawnSync("tar", ["-czf", tgz, "-C", src, "."]);
+  assert.equal(r.status, 0, "tar failed in test setup");
+  return tgz;
+}
+
+test("installTarball: verifies + installs; rejects tamper / missing sig / wrong name", () => {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const work = mkdtempSync(join(tmpdir(), "it-"));
+  const pub = join(work, "pub.pem");
+  writeFileSync(pub, publicKey.export({ type: "spki", format: "pem" }) as string);
+  const pluginsDir = join(work, "plugins");
+
+  const good = mkSignedTarball(join(work, "good"), "datadog", privateKey);
+  const r = installTarball({ tgzPath: good, pluginsDir, trustRootPath: pub });
+  assert.equal(r.name, "datadog");
+  assert.equal(r.version, "1.0.0");
+  assert.ok(existsSync(join(pluginsDir, "datadog", "manifest.json")));
+
+  const tampered = mkSignedTarball(join(work, "bad"), "datadog", privateKey, { tamper: true });
+  assert.throws(() => installTarball({ tgzPath: tampered, pluginsDir, trustRootPath: pub }), PluginVerificationError);
+
+  const noSig = mkSignedTarball(join(work, "nosig"), "datadog", privateKey, { noSig: true });
+  assert.throws(() => installTarball({ tgzPath: noSig, pluginsDir, trustRootPath: pub }), /missing manifest signature/);
+
+  const other = mkSignedTarball(join(work, "other"), "grafana", privateKey);
+  assert.throws(
+    () => installTarball({ tgzPath: other, pluginsDir, trustRootPath: pub, expectedName: "datadog" }),
+    /expected 'datadog'/
+  );
+});

--- a/mcp-server/src/connectors/install.ts
+++ b/mcp-server/src/connectors/install.ts
@@ -1,0 +1,123 @@
+// Shared connector-install core: extract a tarball, verify it
+// fail-closed against a trust root (the SAME crypto as the server
+// loader / omcp CLI — verify.ts), then atomically place it under
+// PLUGINS_DIR. Used by the Web UI install API (and reusable by the
+// CLI). Pure guards are split out for unit testing.
+
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  cpSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  loadTrustRoot,
+  verifyIntegrity,
+  verifyManifestSignature,
+  PluginVerificationError,
+} from "./verify.js";
+
+const NAME_RE = /^[a-z][a-z0-9-]*$/;
+
+/** A connector name is safe iff kebab-case ASCII (also blocks traversal). */
+export function isValidConnectorName(name: unknown): name is string {
+  return typeof name === "string" && NAME_RE.test(name);
+}
+
+/**
+ * Resolve the install target and guarantee it stays directly inside
+ * pluginsDir (defence-in-depth against `..`/absolute names even though
+ * isValidConnectorName already rejects them).
+ */
+export function safeTarget(pluginsDir: string, name: string): string {
+  if (!isValidConnectorName(name)) throw new Error(`invalid connector name: ${String(name)}`);
+  const base = resolve(pluginsDir);
+  const target = resolve(base, name);
+  if (target !== join(base, name) || !target.startsWith(base + "/")) {
+    throw new Error("refusing path outside PLUGINS_DIR");
+  }
+  return target;
+}
+
+function tarExtract(tgz: string, dest: string): void {
+  const r = spawnSync("tar", ["-xzf", tgz, "-C", dest], { stdio: "pipe" });
+  if (r.status !== 0) throw new Error(`tar extraction failed: ${r.stderr?.toString() || r.status}`);
+}
+
+function findPluginRoot(base: string): string | null {
+  for (const dir of [base, ...readdirSync(base).map((e) => join(base, e))]) {
+    try {
+      if (!statSync(dir).isDirectory()) continue;
+      const pkgPath = join(dir, "package.json");
+      if (!existsSync(pkgPath)) continue;
+      if (JSON.parse(readFileSync(pkgPath, "utf8")).observabilityMcp?.kind === "connector") return dir;
+    } catch {
+      /* skip */
+    }
+  }
+  return null;
+}
+
+export interface InstallResult {
+  name: string;
+  version: string | null;
+}
+
+/**
+ * Install a connector tarball into pluginsDir, fail-closed. Always
+ * verifies the manifest signature + entry integrity against trustRoot
+ * — there is intentionally NO insecure bypass on this path (it's
+ * reachable over HTTP). Throws PluginVerificationError on any failure.
+ */
+export function installTarball(opts: {
+  tgzPath: string;
+  pluginsDir: string;
+  trustRootPath: string;
+  expectedName?: string;
+}): InstallResult {
+  const trustRoot = loadTrustRoot(opts.trustRootPath); // throws if unreadable/bad
+  const work = mkdtempSync(join(tmpdir(), "obsmcp-install-"));
+  try {
+    const stage = join(work, "stage");
+    mkdirSync(stage);
+    tarExtract(opts.tgzPath, stage);
+    const root = findPluginRoot(stage);
+    if (!root) throw new PluginVerificationError("tarball has no connector package.json marker");
+
+    const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+    const marker = pkg.observabilityMcp;
+    const name = marker?.name;
+    if (!isValidConnectorName(name)) throw new PluginVerificationError(`invalid connector name in package: ${String(name)}`);
+    if (opts.expectedName && opts.expectedName !== name) {
+      throw new PluginVerificationError(`tarball is '${name}', expected '${opts.expectedName}'`);
+    }
+    const manifestRel = marker.manifest || "./manifest.json";
+    const manifestPath = resolve(root, manifestRel);
+    if (!existsSync(manifestPath)) throw new PluginVerificationError(`manifest not found: ${manifestRel}`);
+    const sigPath = manifestPath + ".sig";
+    if (!existsSync(sigPath)) throw new PluginVerificationError(`missing manifest signature: ${manifestRel}.sig`);
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    const entryPath = resolve(root, pkg.main || "index.js");
+
+    // Fail-closed: signature over the manifest + manifest pins the
+    // entry hash. Throws PluginVerificationError on mismatch.
+    verifyManifestSignature(readFileSync(manifestPath), readFileSync(sigPath), trustRoot);
+    verifyIntegrity(entryPath, manifest.integrity);
+
+    const target = safeTarget(opts.pluginsDir, name);
+    mkdirSync(opts.pluginsDir, { recursive: true });
+    if (existsSync(target)) rmSync(target, { recursive: true, force: true });
+    cpSync(root, target, { recursive: true });
+    return { name, version: manifest.version ?? null };
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -14,6 +14,8 @@ import {
   mergeCatalog,
   fetchHubCatalog,
 } from "./connectors/hub.js";
+import { isValidConnectorName, installTarball } from "./connectors/install.js";
+import { PluginVerificationError } from "./connectors/verify.js";
 import { selfRegistry, withToolMetrics, apiRequests, mcpActiveSessions } from "./metrics/self.js";
 import { buildOpenApiSpec } from "./openapi.js";
 import { listSourcesHandler } from "./tools/list-sources.js";
@@ -25,7 +27,8 @@ import { detectAnomaliesHandler } from "./tools/detect-anomalies.js";
 import type { Config } from "./types.js";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -308,6 +311,66 @@ async function main() {
       });
     } catch (e) {
       res.status(502).json({ url, error: e instanceof Error ? e.message : String(e), connectors: [] });
+    }
+  });
+
+  // Install a connector from the hub into the running server.
+  //
+  // Runtime code-load is powerful, so this is doubly gated:
+  //   1. ENABLE_UI_INSTALL=true must be set (default OFF).
+  //   2. PLUGIN_TRUST_ROOT must be configured — install is ALWAYS
+  //      fail-closed verified (no insecure bypass over HTTP).
+  // Only catalog tarballUrls are fetched (no arbitrary URL in the body)
+  // to avoid SSRF. The connector persists to PLUGINS_DIR (back it with
+  // a PVC on k8s so it survives restarts).
+  app.post("/api/connectors/install", async (req, res) => {
+    if (process.env.ENABLE_UI_INSTALL !== "true") {
+      return res.status(403).json({
+        error: "UI install is disabled. Set ENABLE_UI_INSTALL=true and PLUGIN_TRUST_ROOT to enable it.",
+      });
+    }
+    const trustRootPath = process.env.PLUGIN_TRUST_ROOT;
+    if (!trustRootPath) {
+      return res.status(412).json({
+        error: "PLUGIN_TRUST_ROOT not configured — refusing to install unverified code.",
+      });
+    }
+    const name = (req.body || {}).name;
+    const version = (req.body || {}).version as string | undefined;
+    if (!isValidConnectorName(name)) {
+      return res.status(400).json({ error: "invalid connector name" });
+    }
+    const pluginsDir = process.env.PLUGINS_DIR ?? "/app/plugins";
+    let work: string | null = null;
+    try {
+      const catalog = await fetchHubCatalog(resolveHubCatalogUrl());
+      const entry = catalog.connectors.find((c) => c.name === name);
+      if (!entry) return res.status(404).json({ error: `'${name}' is not in the catalog` });
+      if (entry.builtin) return res.status(409).json({ error: `'${name}' is builtin — no install needed` });
+      const v = version
+        ? entry.versions.find((x) => x.version === version)
+        : entry.versions.find((x) => x.version === (entry.latest ?? entry.versions[0]?.version)) ?? entry.versions[0];
+      if (!v || !v.tarballUrl) {
+        return res.status(422).json({ error: `no tarball for ${name}@${version ?? "latest"}` });
+      }
+      const resp = await fetch(v.tarballUrl);
+      if (!resp.ok) return res.status(502).json({ error: `tarball download HTTP ${resp.status}` });
+      work = mkdtempSync(join(tmpdir(), "obsmcp-dl-"));
+      const tgz = join(work, "c.tgz");
+      writeFileSync(tgz, Buffer.from(await resp.arrayBuffer()));
+      const result = installTarball({ tgzPath: tgz, pluginsDir, trustRootPath, expectedName: name });
+      await getPluginLoader().load(); // re-scan so /api/connectors reflects it
+      res.json({
+        ok: true,
+        ...result,
+        note: "installed & persisted to PLUGINS_DIR. Add a source of this type to use it; a server restart is recommended for full availability in existing MCP sessions.",
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      const code = e instanceof PluginVerificationError ? 400 : 500;
+      res.status(code).json({ error: `install failed (fail-closed): ${msg}` });
+    } finally {
+      if (work) rmSync(work, { recursive: true, force: true });
     }
   });
 

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -799,13 +799,24 @@ async function loadConnectors(){
       return `<div class="card" style="margin:0 0 10px">
         <div class="card-header"><h2 style="font-size:15px">${escHtml(c.displayName)}
           <span class="badge">${escHtml(c.tier)}</span> ${status}</h2>
-          ${c.installed||c.builtin?'':`<button class="btn btn-ghost btn-sm" onclick="document.getElementById('${id}').classList.toggle('hidden')">Install…</button>`}</div>
+          ${c.installed||c.builtin?'':`<span style="display:flex;gap:6px"><button class="btn btn-primary btn-sm" onclick="installConnector('${escHtml(c.name)}',this)">Install</button><button class="btn btn-ghost btn-sm" onclick="document.getElementById('${id}').classList.toggle('hidden')">CLI…</button></span>`}</div>
         <div style="color:var(--text-muted);font-size:13px">${escHtml(c.description)}</div>
         <div style="font-size:12px;color:var(--text-muted);margin-top:6px">type <code>${escHtml(c.name)}</code> · signals ${(c.signalTypes||[]).map(escHtml).join(', ')||'—'} · latest <code>${escHtml(ver)||'—'}</code></div>
         <pre id="${id}" class="hidden" style="margin-top:8px;background:var(--surface-2);padding:10px;border-radius:6px;font-size:12px;overflow:auto">${escHtml(cmd)}</pre>
       </div>`;
     }).join('') : '<div class="empty">Catalog empty.</div>';
   } catch(e){ hub.innerHTML='<div class="empty">Failed to reach the hub catalog.</div>'; }
+}
+
+async function installConnector(name, btn){
+  if(btn){ btn.disabled=true; btn.textContent='Installing…'; }
+  try {
+    const r=await fetch('/api/connectors/install',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name})});
+    const d=await r.json().catch(()=>({}));
+    if(r.ok){ toast(`Installed ${name}${d.version?(' v'+d.version):''}`); loadConnectors(); }
+    else if(r.status===403){ toast('UI install disabled — use the CLI tab, or set ENABLE_UI_INSTALL=true + PLUGIN_TRUST_ROOT.'); if(btn){btn.disabled=false;btn.textContent='Install';} }
+    else { toast('Install failed: '+(d.error||r.status)); if(btn){btn.disabled=false;btn.textContent='Install';} }
+  } catch(e){ toast('Install error: '+e.message); if(btn){btn.disabled=false;btn.textContent='Install';} }
 }
 function showTab(name) {
   document.querySelectorAll('.tab-content').forEach(t=>t.classList.remove('active'));


### PR DESCRIPTION
## Summary
Slice 2 — 1-click install of a hub connector into the running server, **fail-closed & doubly gated** (runtime code-load is powerful).

- `POST /api/connectors/install` `{name, version?}` + an **Install** button on the Connectors page.
- **Guardrails:** `ENABLE_UI_INSTALL=true` required (default **OFF**); `PLUGIN_TRUST_ROOT` required; **always** signature+integrity verified via the shared `verify.ts` — no insecure bypass on this HTTP path; only catalog `tarballUrl`s are fetched (no arbitrary URL → no SSRF); connector name kebab-validated + path-traversal guarded.
- Persists to `PLUGINS_DIR` (k8s: back with a PVC — slice 4) and re-scans the loader so `/api/connectors` reflects it. Response is honest that a restart is recommended for full availability in existing MCP sessions.
- Shared install core `connectors/install.ts` (reusable by the CLI later); 4 unit tests incl. tamper / missing-sig / wrong-name rejection (CI glob).
- UI keeps a "CLI…" tab for when install is disabled.

## Test plan
- [x] `tsc` clean; install+hub unit tests green
- [x] E2E: disabled→403; enabled+trust-root → **real signed datadog release downloads, verifies vs the committed public trust root, installs** (then in `/api/connectors`); `../evil`→400

Roadmap remaining: (3) bundle `.tgz` upload-install, (4) Helm PVC for `/app/plugins`, (5) docs/polish.