### PR TITLE
feat(ui): connector bundle upload (slice 3) + glama.json

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "ThoTischner"
+  ]
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -374,6 +374,53 @@ async function main() {
     }
   });
 
+  // Upload a connector bundle (.tgz) and install it into the running
+  // server. Same fail-closed guardrails as /install: the upload is
+  // ALWAYS verified against PLUGIN_TRUST_ROOT (signature + integrity),
+  // so an unsigned/tampered bundle is rejected. Body is the raw tarball
+  // bytes (application/octet-stream). Persists to PLUGINS_DIR.
+  app.post(
+    "/api/connectors/upload",
+    express.raw({ type: "application/octet-stream", limit: "50mb" }),
+    async (req, res) => {
+      if (process.env.ENABLE_UI_INSTALL !== "true") {
+        return res.status(403).json({
+          error: "UI install is disabled. Set ENABLE_UI_INSTALL=true and PLUGIN_TRUST_ROOT to enable it.",
+        });
+      }
+      const trustRootPath = process.env.PLUGIN_TRUST_ROOT;
+      if (!trustRootPath) {
+        return res.status(412).json({
+          error: "PLUGIN_TRUST_ROOT not configured — refusing to install unverified code.",
+        });
+      }
+      const body = req.body;
+      if (!Buffer.isBuffer(body) || body.length === 0) {
+        return res.status(400).json({ error: "empty body — POST the connector .tgz as application/octet-stream" });
+      }
+      const pluginsDir = process.env.PLUGINS_DIR ?? "/app/plugins";
+      let work: string | null = null;
+      try {
+        work = mkdtempSync(join(tmpdir(), "obsmcp-up-"));
+        const tgz = join(work, "c.tgz");
+        writeFileSync(tgz, body);
+        const result = installTarball({ tgzPath: tgz, pluginsDir, trustRootPath });
+        await getPluginLoader().load(); // re-scan so /api/connectors reflects it
+        res.json({
+          ok: true,
+          ...result,
+          note: "uploaded, verified & persisted to PLUGINS_DIR. Add a source of this type to use it; a server restart is recommended for full availability in existing MCP sessions.",
+        });
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        const code = e instanceof PluginVerificationError ? 400 : 500;
+        res.status(code).json({ error: `upload install failed (fail-closed): ${msg}` });
+      } finally {
+        if (work) rmSync(work, { recursive: true, force: true });
+      }
+    },
+  );
+
   // Add a new source
   app.post("/api/sources", async (req, res) => {
     const { name, type, url, enabled, auth, tls } = req.body;

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -558,6 +558,14 @@
         <div id="conn-installed"><div class="empty">Loading...</div></div>
       </div>
       <div class="card">
+        <div class="card-header"><h2>Upload a connector bundle</h2></div>
+        <p class="empty" style="margin:0 0 12px">Install a signed connector <code>.tgz</code> directly — handy for air-gapped environments. The bundle is always verified against the configured trust root before it is loaded.</p>
+        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+          <input type="file" id="conn-upload-file" accept=".tgz,.tar.gz,application/octet-stream">
+          <button class="btn btn-primary btn-sm" onclick="uploadConnector(this)">Upload &amp; install</button>
+        </div>
+      </div>
+      <div class="card">
         <div class="card-header"><h2>Available from the Connector Hub</h2>
           <a class="btn btn-ghost btn-sm" href="https://thotischner.github.io/observability-mcp/hub/" target="_blank" rel="noopener">Open Hub ↗</a></div>
         <div id="conn-hub"><div class="empty">Loading...</div></div>
@@ -817,6 +825,20 @@ async function installConnector(name, btn){
     else if(r.status===403){ toast('UI install disabled — use the CLI tab, or set ENABLE_UI_INSTALL=true + PLUGIN_TRUST_ROOT.'); if(btn){btn.disabled=false;btn.textContent='Install';} }
     else { toast('Install failed: '+(d.error||r.status)); if(btn){btn.disabled=false;btn.textContent='Install';} }
   } catch(e){ toast('Install error: '+e.message); if(btn){btn.disabled=false;btn.textContent='Install';} }
+}
+async function uploadConnector(btn){
+  const inp=document.getElementById('conn-upload-file');
+  const f=inp&&inp.files&&inp.files[0];
+  if(!f){ toast('Choose a connector .tgz first'); return; }
+  if(btn){ btn.disabled=true; btn.textContent='Uploading…'; }
+  try {
+    const r=await fetch('/api/connectors/upload',{method:'POST',headers:{'Content-Type':'application/octet-stream'},body:f});
+    const d=await r.json().catch(()=>({}));
+    if(r.ok){ toast(`Installed ${d.name||'connector'}${d.version?(' v'+d.version):''}`); inp.value=''; loadConnectors(); }
+    else if(r.status===403){ toast('UI install disabled — set ENABLE_UI_INSTALL=true + PLUGIN_TRUST_ROOT.'); }
+    else { toast('Upload failed: '+(d.error||r.status)); }
+  } catch(e){ toast('Upload error: '+e.message); }
+  finally { if(btn){btn.disabled=false;btn.textContent='Upload & install';} }
 }
 function showTab(name) {
   document.querySelectorAll('.tab-content').forEach(t=>t.classList.remove('active'));


### PR DESCRIPTION
## Summary
- **Slice 3 of UI Hub integration**: `POST /api/connectors/upload` — upload a signed connector `.tgz` and install it into the running server. Reuses the proven fail-closed `installTarball()` core (signature + integrity vs `PLUGIN_TRUST_ROOT`), same `ENABLE_UI_INSTALL` + `PLUGIN_TRUST_ROOT` guardrails as `/install`, persists to `PLUGINS_DIR`. New "Upload a connector bundle" card + `uploadConnector()` on the Connectors page — maximally convenient for air-gapped operators.
- `glama.json` at repo root to claim the Glama MCP server listing (maintainer: ThoTischner).

## Test plan
- [x] `tsc --noEmit` clean (Docker, node:20-alpine)
- [x] `install.test.ts` + `hub.test.ts` 7/7 green — `installTarball` no-`expectedName` path (the upload path) is covered
- [x] Docker E2E vs the **live signed datadog release**: empty body → 400; signed `.tgz` upload → 200, installed & listed in `/api/connectors` (datadog,loki,prometheus); tampered bundle → rejected (fail-closed, not installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)