### PR TITLE
feat(helm): plugins PVC + UI-install toggle (slice 4)

### DIFF
--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,7 +4,7 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 0.9.0
+version: 0.10.0
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
@@ -56,6 +56,10 @@ annotations:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
+    - kind: added
+      description: plugins.persistence — back /app/plugins with a PVC so connectors installed at runtime (Web UI / bundle upload / omcp) survive pod restarts
+    - kind: added
+      description: plugins.uiInstall — enable the fail-closed Web UI / API connector install + upload endpoints (ENABLE_UI_INSTALL; requires a plugin trust root)
     - kind: changed
       description: plugins.image now defaults to the official signed bundle (ghcr.io/thotischner/observability-mcp-plugins:latest) — connectors available on a plain helm install; set plugins.image="" to opt out
     - kind: added

--- a/helm/observability-mcp/README.md
+++ b/helm/observability-mcp/README.md
@@ -41,6 +41,16 @@ helm install obs-mcp ./helm/observability-mcp \
 | `plugins.verify.enabled` | `false` | Fail-closed connector verification (`VERIFY_PLUGINS`) — builtin Prometheus/Loki are never gated |
 | `plugins.verify.trustRootPem` | `""` | PEM public key trust root (rendered into a Secret) |
 | `plugins.verify.existingSecret` | `""` | Instead reference a Secret with key `trust-root.pem` |
+| `plugins.uiInstall.enabled` | `false` | Enable the fail-closed Web UI / API connector install + upload endpoints (`ENABLE_UI_INSTALL`). Requires a trust root (`plugins.verify.trustRootPem`/`existingSecret`) |
+| `plugins.persistence.enabled` | `false` | Back `/app/plugins` with a PVC so connectors installed at runtime (Web UI / bundle upload / `omcp`) survive pod restarts. The bundle init container still refreshes its connectors on top (additive) |
+| `plugins.persistence.existingClaim` | `""` | Use an existing PVC instead of letting the chart create one |
+| `plugins.persistence.size` | `1Gi` | Size of the chart-created plugins PVC |
+| `plugins.persistence.accessMode` | `ReadWriteOnce` | Access mode of the plugins PVC |
+| `plugins.persistence.storageClass` | `""` | StorageClass for the plugins PVC (empty = cluster default) |
+
+To let operators add connectors from the running server and keep them
+across restarts, pair the two: `--set plugins.uiInstall.enabled=true
+--set plugins.persistence.enabled=true` plus a trust root.
 
 See [`values.yaml`](./values.yaml) for the full schema and
 [`docs/plugin-architecture.md`](../../docs/plugin-architecture.md) for the

--- a/helm/observability-mcp/templates/_helpers.tpl
+++ b/helm/observability-mcp/templates/_helpers.tpl
@@ -47,6 +47,24 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- default .Chart.AppVersion .Values.image.tag -}}
 {{- end -}}
 
+{{/*
+A plugin trust root is required whenever fail-closed verification is on
+(verify.enabled) OR the runtime UI/upload install endpoints are enabled
+(uiInstall.enabled — the server refuses to install unverified code).
+*/}}
+{{- define "observability-mcp.needsTrustRoot" -}}
+{{- if or .Values.plugins.verify.enabled .Values.plugins.uiInstall.enabled -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+/app/plugins must be writable when connectors are installed at runtime
+(uiInstall) or persisted across restarts (persistence) — otherwise the
+init container only needs to seed a read-only emptyDir.
+*/}}
+{{- define "observability-mcp.pluginsWritable" -}}
+{{- if or .Values.plugins.uiInstall.enabled .Values.plugins.persistence.enabled -}}true{{- end -}}
+{{- end -}}
+
 {{- define "observability-mcp.authSecretName" -}}
 {{- if .Values.auth.existingSecret -}}
 {{- .Values.auth.existingSecret -}}

--- a/helm/observability-mcp/templates/deployment.yaml
+++ b/helm/observability-mcp/templates/deployment.yaml
@@ -88,8 +88,14 @@ spec:
             {{- if .Values.plugins.verify.enabled }}
             - name: VERIFY_PLUGINS
               value: "true"
+            {{- end }}
+            {{- if include "observability-mcp.needsTrustRoot" . }}
             - name: PLUGIN_TRUST_ROOT
               value: /app/trust/trust-root.pem
+            {{- end }}
+            {{- if .Values.plugins.uiInstall.enabled }}
+            - name: ENABLE_UI_INSTALL
+              value: "true"
             {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
@@ -111,12 +117,12 @@ spec:
             - name: data
               mountPath: /app/config
             {{- end }}
-            {{- if .Values.plugins.image }}
+            {{- if or .Values.plugins.image .Values.plugins.persistence.enabled }}
             - name: plugins
               mountPath: /app/plugins
-              readOnly: true
+              readOnly: {{ if include "observability-mcp.pluginsWritable" . }}false{{ else }}true{{ end }}
             {{- end }}
-            {{- if .Values.plugins.verify.enabled }}
+            {{- if include "observability-mcp.needsTrustRoot" . }}
             - name: trust-root
               mountPath: /app/trust
               readOnly: true
@@ -132,11 +138,16 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "observability-mcp.fullname" . }}
         {{- end }}
-        {{- if .Values.plugins.image }}
+        {{- if or .Values.plugins.image .Values.plugins.persistence.enabled }}
         - name: plugins
+          {{- if .Values.plugins.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.plugins.persistence.existingClaim | default (printf "%s-plugins" (include "observability-mcp.fullname" .)) }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
         {{- end }}
-        {{- if .Values.plugins.verify.enabled }}
+        {{- if include "observability-mcp.needsTrustRoot" . }}
         - name: trust-root
           secret:
             secretName: {{ .Values.plugins.verify.existingSecret | default (printf "%s-trust-root" (include "observability-mcp.fullname" .)) }}

--- a/helm/observability-mcp/templates/pvc-plugins.yaml
+++ b/helm/observability-mcp/templates/pvc-plugins.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.plugins.persistence.enabled (not .Values.plugins.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "observability-mcp.fullname" . }}-plugins
+  labels:
+    {{- include "observability-mcp.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.plugins.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.plugins.persistence.size | quote }}
+  {{- with .Values.plugins.persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/observability-mcp/templates/secret-trust-root.yaml
+++ b/helm/observability-mcp/templates/secret-trust-root.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.plugins.verify.enabled .Values.plugins.verify.trustRootPem (not .Values.plugins.verify.existingSecret) }}
+{{- if and (include "observability-mcp.needsTrustRoot" .) .Values.plugins.verify.trustRootPem (not .Values.plugins.verify.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/observability-mcp/values.schema.json
+++ b/helm/observability-mcp/values.schema.json
@@ -79,6 +79,24 @@
             "trustRootPem": { "type": "string" },
             "existingSecret": { "type": "string" }
           }
+        },
+        "persistence": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "existingClaim": { "type": "string" },
+            "size": { "type": "string" },
+            "accessMode": { "type": "string" },
+            "storageClass": { "type": "string" }
+          }
+        },
+        "uiInstall": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
         }
       }
     },

--- a/helm/observability-mcp/values.yaml
+++ b/helm/observability-mcp/values.yaml
@@ -88,6 +88,25 @@ plugins:
     # key `trust-root.pem`.
     trustRootPem: ""
     existingSecret: ""
+  # Persist runtime-installed connectors. By default /app/plugins is an
+  # emptyDir reseeded from `image` on every start, so connectors added at
+  # runtime (Web UI / bundle upload / `omcp plugin install`) are LOST on
+  # pod restart. Enable this to back /app/plugins with a PVC so they
+  # survive restarts; the init container still refreshes the bundled
+  # connectors on top (additive copy — your installs are kept).
+  persistence:
+    enabled: false
+    existingClaim: ""
+    size: 1Gi
+    accessMode: ReadWriteOnce
+    storageClass: ""
+  # Enable the Web UI / API connector install + upload endpoints
+  # (ENABLE_UI_INSTALL). Runtime code-load is powerful, so this is OFF
+  # by default and ALWAYS fail-closed verified — it requires a plugin
+  # trust root (set verify.trustRootPem or verify.existingSecret).
+  # Pair with persistence.enabled so UI-installed connectors survive.
+  uiInstall:
+    enabled: false
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## Summary
Slice 4 of the UI Hub integration — addresses the user requirement *"die Connectoren müssen persistiert werden, also z.B. bei k8s ein PVC dahinter"*.

- `plugins.persistence.*` — back `/app/plugins` with a PVC (chart-created or `existingClaim`) so connectors installed at runtime (Web UI / bundle upload / `omcp`) **survive pod restarts**. The bundle init container still refreshes its connectors on top (additive `cp -a`, runtime installs preserved).
- `plugins.uiInstall.enabled` — toggles the fail-closed install + upload endpoints (`ENABLE_UI_INSTALL`); together with persistence makes the `/app/plugins` mount writable.
- New `needsTrustRoot` helper: trust-root Secret/mount + `PLUGIN_TRUST_ROOT` now render whenever **verify OR uiInstall** is on (the server refuses to install unverified code).
- Default behaviour unchanged (emptyDir, read-only, no UI install) → existing installs & `helm-integration` CI unaffected.
- `values.schema.json`, chart `README`, ArtifactHub changelog, Chart `0.9.0 → 0.10.0`.

## Test plan
- [x] `helm lint` — default + uiInstall+persistence+verify combined
- [x] `helm template` scenarios: default → emptyDir + readOnly mount; persistence → PVC object + `claimName=*-plugins` + writable mount; `existingClaim` → uses given claim, no chart PVC; uiInstall → `ENABLE_UI_INSTALL`+`PLUGIN_TRUST_ROOT` env, `VERIFY_PLUGINS` absent when verify off, trust-root Secret rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)