### PR TITLE
docs: runtime connector install/upload + persistence (slice 5)

### DIFF
--- a/docs/airgapped-deployment.md
+++ b/docs/airgapped-deployment.md
@@ -108,18 +108,19 @@ COPY ./internal-connector /app/plugins/internal-connector
 
 The PluginLoader scans `/app/plugins/` at startup and validates each manifest. Failed validation rejects the plugin (with a logged reason) but doesn't block server startup — the operator can `PLUGINS_DISABLED=internal-connector` to opt out at runtime without rebuilding.
 
+### Installing a connector at runtime (no rebuild)
+
+Baking into a derived image is the most locked-down path, but the running server can also install a connector bundle without a redeploy — useful when you cannot rebuild quickly:
+
+- **Web UI**: Connectors → *Upload a connector bundle* → pick the signed `.tgz`. No shell access to the pod needed.
+- **API**: `POST /api/connectors/upload` with the raw `.tgz` (`application/octet-stream`), or `POST /api/connectors/install` to pull a named connector from a mirrored catalog.
+- **CLI**: `omcp plugin install <name> --from <local-dir-or-mirror-url> --trust-root <pub.pem>`.
+
+All three are **off by default** and fail-closed: set `ENABLE_UI_INSTALL=true` *and* a `PLUGIN_TRUST_ROOT`, and every bundle is signature+integrity verified before it is written to `PLUGINS_DIR` (a tampered/unsigned bundle is rejected, never loaded). On Kubernetes, back `PLUGINS_DIR` with a PVC (`plugins.persistence.enabled=true`, `plugins.uiInstall.enabled=true`) so runtime installs survive pod restarts — otherwise the bundle init container reseeds the volume on every start.
+
 ### Verifying plugin provenance
 
-If your security policy requires signed plugins, run the verification step in a pre-build hook before `COPY`:
-
-```bash
-cosign verify-blob \
-  --signature internal-connector.sig \
-  --certificate internal-connector.cert \
-  internal-connector.tar.gz
-```
-
-A future release will fold this into the PluginLoader as an opt-in `PLUGIN_REQUIRE_SIGNATURE=true` mode.
+Provenance verification is **offline and built in** — no `cosign`, no Fulcio/Rekor, no network (an airgapped site cannot reach a transparency log). The server checks a local trust root with Node's built-in crypto: a plugin loads only when its `manifest.json` `integrity` (sha256 of the entry file) matches *and* the detached `manifest.json.sig` verifies against `PLUGIN_TRUST_ROOT`. Enable with `VERIFY_PLUGINS=true` (filesystem plugins) — see [`docs/plugin-architecture.md`](plugin-architecture.md#verification-airgapped-trust-root) for producing the artifacts. Runtime install/upload is *always* verified regardless of `VERIFY_PLUGINS`.
 
 ## Configuration without the Web UI
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -4,6 +4,8 @@ Each backend is a connector that owns its native query language. The MCP tool la
 
 Currently shipped: **Prometheus** (PromQL) and **Loki** (LogQL). Adding a new one means implementing one interface.
 
+Optional connectors (Datadog, Grafana, Elasticsearch, …) are distributed via the [Connector Hub](https://thotischner.github.io/observability-mcp/hub/) and can be added to a running server without a rebuild — via the Web UI's **Connectors** page (browse the hub, install, or upload a signed `.tgz`), the `omcp plugin install` CLI, or the Helm bundle image. The runtime install paths are fail-closed and off by default; see [`docs/plugin-architecture.md`](plugin-architecture.md#the-connector-hub) for the API, guardrails (`ENABLE_UI_INSTALL` + trust root), and Kubernetes persistence.
+
 ## Adding a new connector
 
 1. Create `mcp-server/src/connectors/<name>.ts`.

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -120,7 +120,7 @@ Three supported workflows:
   ```
   This translates into an init container that extracts the listed paths from the plugin image into an `emptyDir` mounted at `/app/plugins`. No registry access from the main container.
 
-- **Sideloaded tarballs.** For VM / bare-metal deployments, operators `wget <url>` the connector tarball, `tar -xzf` into `/app/plugins/`, restart. The tarball is a published `*.tgz` from the hub (or a mirror) — the same format `npm pack` produces.
+- **Sideloaded tarballs.** For VM / bare-metal deployments, operators `wget <url>` the connector tarball, `tar -xzf` into `/app/plugins/`, restart. The tarball is a published `*.tgz` from the hub (or a mirror) — the same format `npm pack` produces. Or, with `ENABLE_UI_INSTALL=true` + a trust root, drag the same `.tgz` into the Web UI's **Connectors → Upload a connector bundle** (no shell access needed).
 
 ### Verification (airgapped trust root)
 
@@ -150,26 +150,42 @@ node -e 'const{createHash}=require("crypto"),fs=require("fs");
 openssl pkeyutl -sign -inkey signing.key -rawin -in manifest.json | base64 > manifest.json.sig
 ```
 
-The operator distributes only the **public** key as `PLUGIN_TRUST_ROOT`. The Helm chart sets `VERIFY_PLUGINS=true` and mounts the trust root for any non-builtin plugin (chart wiring is the next milestone). The future connector hub publishes the same `integrity` + detached signature per release, so the hub CLI reuses this exact check.
+The operator distributes only the **public** key as `PLUGIN_TRUST_ROOT`. The Helm chart wires `plugins.verify` (sets `VERIFY_PLUGINS=true` and mounts the trust root for any non-builtin plugin) and `plugins.uiInstall` (sets `ENABLE_UI_INSTALL`); the trust root is rendered/mounted whenever verification *or* runtime install is enabled. The connector hub publishes the same `integrity` + detached signature per release, so the hub CLI and the Web UI install path reuse this exact check.
 
 ## The connector hub
 
-The catalog contract now exists in-repo at [`hub/`](../hub/README.md): a
+The catalog contract lives in-repo at [`hub/`](../hub/README.md): a
 schema-validated `catalog/<name>.json` per connector aggregated into a
-static `catalog/index.json` (CI keeps it in sync). The web UI / install
-CLI below are still future work, but they consume this format as-is.
+static `catalog/index.json` (CI keeps it in sync). It is **live** today:
 
-- A static catalog (think `helm/charts` repo): each connector's manifest, signed tarball URL, screenshots, and changelog live as `hub/catalog/<name>.json`; `hub/build-catalog.mjs` validates and aggregates them.
-- A web UI at `hub.observability-mcp.dev` (or similar) that browses the catalog. Search by signal type, capability, vendor.
-- A CLI command `observability-mcp install <name>` that:
-  1. Fetches the manifest from the catalog
-  2. Verifies the signature
-  3. Downloads the tarball into `${PLUGINS_DIR}/<name>-<version>/`
-  4. Hot-load via SIGHUP if the server supports it, otherwise prompts to restart.
-- A "third-party / certified / official" rating tiers, like Confluent Hub.
-- Telemetry-free by default. The hub serves static files; no install pingback.
+- **Static catalog** (think `helm/charts` repo): each connector's manifest, signed tarball URL, versions, and changelog live as `hub/catalog/<name>.json`; `hub/build-catalog.mjs` validates and aggregates them. Telemetry-free — the hub serves static files, no install pingback. The hub *publishes* tarballs but does not host the server; operators can mirror the whole catalog into their own static-file CDN with a single rsync.
+- **Hosted site** at <https://thotischner.github.io/observability-mcp/hub/> — an ArtifactHub-style browser: clickable connectors, per-connector detail pages with a version table and copy-paste install boxes for every scenario (omcp CLI / air-gapped / Helm / manual).
+- **omcp CLI**: `omcp plugin list|info|install|verify` resolves the catalog (`--from <dir|url>` for air-gapped), verifies the signature, and extracts into `${PLUGINS_DIR}/<name>/`. See the CLI section in the main README.
+- **Web UI Connectors page** + JSON API on the running server (next section).
 
-The hub *publishes* tarballs but does not host the server. Operators can mirror the catalog into their own static-file CDN with a single rsync.
+### Runtime install from the running server (Web UI / API)
+
+The server exposes the hub directly so operators can manage connectors without a redeploy:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /api/connectors` | Installed connectors (builtin + filesystem) with manifest info. |
+| `GET /api/hub/catalog` | The hub catalog, server-proxied, merged with what's installed (`HUB_CATALOG_URL` overrides the source). |
+| `POST /api/connectors/install` | Install a connector by name from the catalog (downloads only catalog `tarballUrl`s — no arbitrary URL, avoids SSRF). |
+| `POST /api/connectors/upload` | Install an uploaded connector `.tgz` (raw `application/octet-stream`) — for air-gapped operators with no catalog reach. |
+
+Both install paths run the **exact same fail-closed verification** as the loader and the CLI (signature + integrity against `PLUGIN_TRUST_ROOT`), then persist into `PLUGINS_DIR` and re-scan the loader.
+
+**Guardrails** — runtime code-load is powerful, so it is doubly gated and off by default:
+
+| Setting | Env | Default | Meaning |
+|---------|-----|---------|---------|
+| Enable UI install/upload | `ENABLE_UI_INSTALL` | off | Both endpoints return `403` unless this is `true`. |
+| Trust root | `PLUGIN_TRUST_ROOT` | — | Required (`412` otherwise) — the server refuses to install unverified code, even when `VERIFY_PLUGINS` is off. |
+
+A tampered/unsigned bundle is rejected (`400`, `PluginVerificationError`) and never written. On Kubernetes, `PLUGINS_DIR` is an `emptyDir` reseeded from the bundle image on every start, so set `plugins.persistence.enabled=true` (PVC) and `plugins.uiInstall.enabled=true` in the Helm chart for runtime-installed connectors to survive pod restarts.
+
+Future: a "third-party / certified / official" rating tier like Confluent Hub.
 
 ## Implementation milestones
 
@@ -184,9 +200,12 @@ These will be separate PRs so each can pass smoke independently:
 | 5  | Loki connector → own package. |
 | 6  | ✅ Offline verification (`VERIFY_PLUGINS` + local trust root) — fail-closed manifest signature + entry integrity. (Local trust root, not sigstore: airgapped sites can't reach a transparency log.) |
 | 7  | ✅ Helm `plugins.image` + init-container extraction, plus an official signed multi-connector bundle image (`observability-mcp-plugins`) so no image build is needed. |
-| 8  | ✅ Catalog contract in `hub/` (schema + validated `index.json` + generator + CI). Hosted static site / install CLI remain future work on top of this format. |
+| 8  | ✅ Catalog contract in `hub/` (schema + validated `index.json` + generator + CI). |
+| 9  | ✅ Hosted hub site (GitHub Pages, ArtifactHub-style detail pages) + `omcp` CLI (`plugin list/info/install/verify`, `--from` for air-gapped). |
+| 10 | ✅ Web UI Connectors page + JSON API: list installed, browse hub, server-side install from catalog, upload a bundle `.tgz` — all behind `ENABLE_UI_INSTALL` + trust root, fail-closed. |
+| 11 | ✅ Helm `plugins.persistence` (PVC for `/app/plugins`) + `plugins.uiInstall` so runtime-installed connectors survive pod restarts. |
 
-The first three PRs unlock airgapped deployments. Everything after is incremental polish.
+The first three PRs unlock airgapped deployments. Everything after is incremental polish — milestones 1–11 are complete.
 
 ## Open questions
 


### PR DESCRIPTION
## Summary
Slice 5 (final) of the UI Hub integration — bring the docs in line with the shipped feature set and fix stale/inaccurate sections.

- `docs/plugin-architecture.md`: the connector hub is documented as **live** (hosted site, omcp CLI, Web UI); new **"Runtime install from the running server (Web UI / API)"** section with endpoint + guardrail (`ENABLE_UI_INSTALL` / `PLUGIN_TRUST_ROOT`) tables and the k8s persistence note; milestones table extended with 9–11 (✅).
- `docs/airgapped-deployment.md`: added the no-rebuild runtime install path (UI upload / API / CLI); **corrected** the provenance section — it referenced `cosign`/Fulcio, but verification is deliberately offline Node crypto (airgapped sites can't reach a transparency log), and the "future release" note is now done.
- `docs/connectors.md`: short pointer to the hub + runtime install.

Docs only — no code or test changes.

## Test plan
- [x] Prose/accuracy review against the actual endpoints, env vars and Helm values shipped in PRs #135–#138
- [x] Internal anchor links resolve (`#verification-airgapped-trust-root`, `#the-connector-hub`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)