### PR TITLE
fix(loki): deduplicate service discovery (stop unioning labels)

### DIFF
--- a/mcp-server/src/connectors/loki.test.ts
+++ b/mcp-server/src/connectors/loki.test.ts
@@ -128,4 +128,35 @@ describe("LokiConnector", () => {
       assert.equal(proto.escapeLogQLRegex("error`test`"), "error\\`test\\`");
     });
   });
+
+  describe("listServices", () => {
+    function withLabelValues(map: Record<string, string[]>) {
+      const c = new LokiConnector() as any;
+      c.serviceLabels = ["service_name", "service", "job", "app", "container"];
+      c.getLabelValues = async (label: string) => map[label] ?? [];
+      return c;
+    }
+
+    it("first non-empty label wins — does NOT union container aliases", async () => {
+      const c = withLabelValues({
+        service: ["api-gateway", "payment-service"],
+        // co-located shipper noise that must NOT leak in:
+        container: ["myproj-api-gateway-1", "k8s_POD_api-gateway_demo_x"],
+      });
+      const names = (await c.listServices()).map((s: any) => s.name).sort();
+      assert.deepEqual(names, ["api-gateway", "payment-service"]);
+    });
+
+    it("falls back to a lower-priority label only when higher ones are empty", async () => {
+      const c = withLabelValues({ container: ["/svc-a", "/svc-b"] });
+      const svcs = await c.listServices();
+      assert.deepEqual(svcs.map((s: any) => s.name).sort(), ["svc-a", "svc-b"]);
+      assert.equal(svcs[0].labels.discoveredVia, "container");
+    });
+
+    it("returns empty when no candidate label has values", async () => {
+      const c = withLabelValues({});
+      assert.deepEqual(await c.listServices(), []);
+    });
+  });
 });

--- a/mcp-server/src/connectors/loki.ts
+++ b/mcp-server/src/connectors/loki.ts
@@ -78,13 +78,18 @@ export class LokiConnector implements ObservabilityConnector {
   async disconnect(): Promise<void> {}
 
   async listServices(): Promise<ServiceInfo[]> {
-    // Probe each candidate label and merge values. Loki streams may identify
-    // services via service_name, service, job, app, or container depending on
-    // the shipper configuration. Walking all candidates ensures historical
-    // streams remain reachable when label conventions change over time.
+    // Candidate labels are ordered by preference (service_name, service,
+    // job, app, container). The FIRST label that yields any values wins —
+    // we do not union across labels. Unioning duplicated every service:
+    // one real container is simultaneously `service="api-gateway"` and
+    // `container="myproj-api-gateway-1"`, and a co-located shipper can add
+    // unrelated `container` values (e.g. other compose/k8s containers on
+    // the same Docker host). The ordered fallback still keeps streams
+    // reachable on backends that only carry a low-priority label.
     const seen = new Map<string, ServiceInfo>();
     for (const label of this.serviceLabels) {
       const values = await this.getLabelValues(label);
+      if (values.length === 0) continue;
       for (const raw of values) {
         // Docker's loki.source.docker writes container names with a leading '/'
         // (Docker API Names[0] convention). Strip it for display so the name
@@ -99,6 +104,7 @@ export class LokiConnector implements ObservabilityConnector {
           });
         }
       }
+      break; // first non-empty label is authoritative
     }
     return Array.from(seen.values());
   }


### PR DESCRIPTION
## Summary
Surfaced while running the demo locally: `/api/services` listed every demo service 2–3× (`api-gateway` **and** `observability-mcp-api-gateway-1` **and** stale `k8s_POD_*` entries).

Root cause: `LokiConnector.listServices()` probed all candidate labels (`service_name, service, job, app, container`) and **unioned** every value. A single container is simultaneously `service="api-gateway"`, `container="<compose-project>-api-gateway-1"`, and Loki's auto-derived `service_name` — and a host-level shipper adds `container` values for unrelated containers (other compose projects, k8s pods on the same Docker host).

Fix: the **first label in priority order that yields any values wins** — no cross-label union. The ordered fallback still keeps streams reachable on backends that only carry a low-priority label; `LOKI_SERVICE_LABELS` still overrides the priority list per deployment (e.g. pin to a curated `service` label).

## Test plan
- [x] `tsc --noEmit` clean (Docker)
- [x] 3 new `listServices` unit tests (first-non-empty wins / fallback / empty) — 22/22 loki tests green
- [x] Verified live against the running demo stack: `/api/services` went 9 → 3 (only the real services remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)