### PR TITLE
fix(ui): dynamic MCP endpoint URL (closes #123)

### DIFF
--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -821,7 +821,7 @@ async function installConnector(name, btn){
   try {
     const r=await fetch('/api/connectors/install',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name})});
     const d=await r.json().catch(()=>({}));
-    if(r.ok){ toast(`Installed ${name}${d.version?(' v'+d.version):''}`); loadConnectors(); }
+    if(r.ok){ toast(`Installed ${name}${d.version?(' v'+d.version):''}`); loadConnectors(); loadTypes(); }
     else if(r.status===403){ toast('UI install disabled — use the CLI tab, or set ENABLE_UI_INSTALL=true + PLUGIN_TRUST_ROOT.'); if(btn){btn.disabled=false;btn.textContent='Install';} }
     else { toast('Install failed: '+(d.error||r.status)); if(btn){btn.disabled=false;btn.textContent='Install';} }
   } catch(e){ toast('Install error: '+e.message); if(btn){btn.disabled=false;btn.textContent='Install';} }
@@ -834,7 +834,7 @@ async function uploadConnector(btn){
   try {
     const r=await fetch('/api/connectors/upload',{method:'POST',headers:{'Content-Type':'application/octet-stream'},body:f});
     const d=await r.json().catch(()=>({}));
-    if(r.ok){ toast(`Installed ${d.name||'connector'}${d.version?(' v'+d.version):''}`); inp.value=''; loadConnectors(); }
+    if(r.ok){ toast(`Installed ${d.name||'connector'}${d.version?(' v'+d.version):''}`); inp.value=''; loadConnectors(); loadTypes(); }
     else if(r.status===403){ toast('UI install disabled — set ENABLE_UI_INSTALL=true + PLUGIN_TRUST_ROOT.'); }
     else { toast('Upload failed: '+(d.error||r.status)); }
   } catch(e){ toast('Upload error: '+e.message); }
@@ -1219,6 +1219,9 @@ async function loadInfo(){
   }catch{/* server too old or /api/info disabled */}
 }
 
+// Show the endpoint the user is actually reaching the server through
+// (localhost, a port-forward, or an ingress) — not a hardcoded host.
+document.getElementById('mcp-url').textContent = window.location.origin + '/mcp';
 (async()=>{await loadTypes();await refresh();await loadInfo();setInterval(refresh,15000);})();
 </script>
 


### PR DESCRIPTION
## Summary
Closes #123 (reported by @jmrr). The Web UI showed a hardcoded `http://localhost:3000/mcp`; behind an ingress/reverse-proxy/port-forward this is wrong and users copy the wrong endpoint.

Now set at init from `window.location.origin + '/mcp'`, so the displayed (and Copy-button-copied) endpoint always matches how the user actually reaches the server. The static span value remains only as a no-JS fallback.

## Test plan
- [x] Rebuilt mcp-server image (Docker); served bundle contains `window.location.origin + '/mcp'`
- [x] Page loads, `/healthz` 200 — locally still resolves to `http://localhost:3000/mcp` (same origin), so no regression for the default case while ingress now shows the real host

🤖 Generated with [Claude Code](https://claude.com/claude-code)