### PR TITLE
ci(release): bump artifacthub.io/images tag on release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -87,9 +87,13 @@ jobs:
           new_chart="${MA}.${MI}.$((PA + 1))"
           sed -i -E "s/^appVersion: .*/appVersion: \"${appver}\"/" Chart.yaml
           sed -i -E "0,/^version: .*/s//version: ${new_chart}/" Chart.yaml
+          # ArtifactHub scans the image pinned in artifacthub.io/images —
+          # re-point it at the new tag too, otherwise the security report
+          # keeps scanning the old (now superseded) image forever.
+          sed -i -E "s|(image: ghcr\.io/thotischner/observability-mcp:)[^[:space:]]+|\1${appver}|" Chart.yaml
           echo "new_chart=${new_chart}" >> "$GITHUB_OUTPUT"
           echo "chart ${cur_chart} -> ${new_chart}, appVersion -> ${appver}"
-          grep -E '^(version|appVersion):' Chart.yaml
+          grep -E '^(version|appVersion):|image: ghcr\.io' Chart.yaml
 
       # NOTE: GITHUB_TOKEN can create PRs only when the repo setting
       # "Settings → Actions → General → Allow GitHub Actions to create


### PR DESCRIPTION
## Summary
Follow-up to #142. The chart-bump step updated `appVersion` + chart `version` but **not** the hardcoded image tag in the `artifacthub.io/images` annotation. ArtifactHub's Security Report scans exactly that pinned image — so it would keep scanning the old, superseded image indefinitely and the report would never clear after a release.

Concretely: the current ArtifactHub medium (`ip-address` CVE-2026-42338) is **already fixed in the lockfile** (override pins `10.2.0` ≥ fixed `10.1.1`); the published `1.4.0` image just predates it. Without this change, even after the 1.4.1 release the annotation would still point at `:1.4.0` and the medium would persist on ArtifactHub.

Now the release step also rewrites `image: ghcr.io/thotischner/observability-mcp:<tag>` to the new version, so ArtifactHub re-scans the fresh, clean image.

## Test plan
- [x] `auto-release.yml` parses as valid YAML
- [x] Full chart-bump dry-run vs the real `Chart.yaml`: `version` 0.10.0→0.10.1, `appVersion` "1.4.0"→"1.4.1", `artifacthub.io/images` image → `:1.4.1`, result still valid YAML
- [x] Confirmed the live `ghcr.io/thotischner/observability-mcp:1.4.0` Trivy MEDIUM is solely `ip-address` CVE-2026-42338, and the committed lockfile already resolves `ip-address` to `10.2.0` (fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)