### PR TITLE
fix(api): no-store cache header for dynamic /api responses

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -290,11 +290,18 @@ async function main() {
   app.use(express.json({ limit: "1mb" }));
 
   // Security headers
-  app.use((_req, res, next) => {
+  app.use((req, res, next) => {
     res.setHeader("X-Content-Type-Options", "nosniff");
     res.setHeader("X-Frame-Options", "DENY");
     res.setHeader("X-XSS-Protection", "1; mode=block");
     res.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+    // Dynamic API responses must never be served from the browser/proxy
+    // cache: after a mutation (e.g. installing a connector) the UI
+    // re-fetches these GETs immediately, and a heuristically-cached stale
+    // body would make the change "not show up until a page reload".
+    if (req.path.startsWith("/api/")) {
+      res.setHeader("Cache-Control", "no-store");
+    }
     next();
   });
 


### PR DESCRIPTION
## Summary
Bug reported: after installing a connector via the Web UI it doesn't appear (as a badge / in the installed list) until you reload the page.

Root cause: `GET /api/connectors` and `GET /api/hub/catalog` (and other `/api/*` GETs) had no `Cache-Control`. The browser heuristically caches them; right after the install POST the UI re-fetches them and gets the **stale, pre-install** cached body. A full page reload revalidates and the connector appears. This is the same root cause as the earlier stale `/api/source-types` type-dropdown.

Fix: the existing security-headers middleware now also sets `Cache-Control: no-store` for any `req.path` under `/api/`. The static UI keeps the `express.static` defaults (verified: `/api/connectors` → `no-store`, `/` → `public, max-age=0`).

## Test plan
- [x] `tsc --noEmit` clean (Docker)
- [x] Rebuilt image; `curl -D-` shows `Cache-Control: no-store` on `/api/connectors`, unchanged on `/`
- [x] Unit suite 101/101 green (Docker)

## Note
A second reported bug — Elasticsearch connector Install → tarball 404 — is **not** code: `connector-elasticsearch-1.0.0` was never published (only datadog/grafana have releases). Needs a `connector-publish.yml` run; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)