### PR TITLE
feat(ui): tab the Connectors page like Settings

### DIFF
--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -553,22 +553,35 @@
 
     <!-- ===== Connectors ===== -->
     <div class="page" id="page-connectors">
-      <div class="card">
-        <div class="card-header"><h2>Installed connectors</h2><button class="btn btn-ghost btn-sm" onclick="loadConnectors()">Refresh</button></div>
-        <div id="conn-installed"><div class="empty">Loading...</div></div>
-      </div>
-      <div class="card">
-        <div class="card-header"><h2>Upload a connector bundle</h2></div>
-        <p class="empty" style="margin:0 0 12px">Install a signed connector <code>.tgz</code> directly — handy for air-gapped environments. The bundle is always verified against the configured trust root before it is loaded.</p>
-        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
-          <input type="file" id="conn-upload-file" accept=".tgz,.tar.gz,application/octet-stream">
-          <button class="btn btn-primary btn-sm" onclick="uploadConnector(this)">Upload &amp; install</button>
+      <div class="card" style="padding:0;">
+        <div class="tabs">
+          <button class="tab-btn active" onclick="showTab('installed')">Installed</button>
+          <button class="tab-btn" onclick="showTab('hub')">Connector Hub</button>
+          <button class="tab-btn" onclick="showTab('upload')">Upload bundle</button>
         </div>
-      </div>
-      <div class="card">
-        <div class="card-header"><h2>Available from the Connector Hub</h2>
-          <a class="btn btn-ghost btn-sm" href="https://thotischner.github.io/observability-mcp/hub/" target="_blank" rel="noopener">Open Hub ↗</a></div>
-        <div id="conn-hub"><div class="empty">Loading...</div></div>
+
+        <!-- Installed Tab -->
+        <div class="tab-content active" id="tab-installed" style="padding:20px;">
+          <div class="card-header" style="margin-bottom:12px"><h2>Installed connectors</h2><button class="btn btn-ghost btn-sm" onclick="loadConnectors()">Refresh</button></div>
+          <div id="conn-installed"><div class="empty">Loading...</div></div>
+        </div>
+
+        <!-- Connector Hub Tab -->
+        <div class="tab-content" id="tab-hub" style="padding:20px;">
+          <div class="card-header" style="margin-bottom:12px"><h2>Available from the Connector Hub</h2>
+            <a class="btn btn-ghost btn-sm" href="https://thotischner.github.io/observability-mcp/hub/" target="_blank" rel="noopener">Open Hub ↗</a></div>
+          <div id="conn-hub"><div class="empty">Loading...</div></div>
+        </div>
+
+        <!-- Upload bundle Tab -->
+        <div class="tab-content" id="tab-upload" style="padding:20px;">
+          <div class="card-header" style="margin-bottom:12px"><h2>Upload a connector bundle</h2></div>
+          <p class="empty" style="margin:0 0 12px">Install a signed connector <code>.tgz</code> directly — handy for air-gapped environments. The bundle is always verified against the configured trust root before it is loaded.</p>
+          <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+            <input type="file" id="conn-upload-file" accept=".tgz,.tar.gz,application/octet-stream">
+            <button class="btn btn-primary btn-sm" onclick="uploadConnector(this)">Upload &amp; install</button>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -841,10 +854,14 @@ async function uploadConnector(btn){
   finally { if(btn){btn.disabled=false;btn.textContent='Upload & install';} }
 }
 function showTab(name) {
-  document.querySelectorAll('.tab-content').forEach(t=>t.classList.remove('active'));
-  document.querySelectorAll('.tab-btn').forEach(b=>b.classList.remove('active'));
-  document.getElementById('tab-'+name).classList.add('active');
-  event.target.classList.add('active');
+  // Scope to the tab group's card so independent tab sets (Settings,
+  // Connectors) don't reset each other.
+  const scope = (event && event.target.closest('.card')) || document;
+  scope.querySelectorAll('.tab-content').forEach(t=>t.classList.remove('active'));
+  scope.querySelectorAll('.tab-btn').forEach(b=>b.classList.remove('active'));
+  const el = document.getElementById('tab-'+name);
+  if (el) el.classList.add('active');
+  if (event && event.target) event.target.classList.add('active');
   if(name==='metrics') populateMetricsSourceSelect();
 }
 function closeModal(id) { document.getElementById(id).classList.remove('open'); }


### PR DESCRIPTION
## Summary
Per request: the Connectors page should use tabs like Settings instead of stacked cards.

- Restructured `page-connectors` into the existing `.tabs` / `.tab-btn` / `.tab-content` pattern (same as Settings): **Installed | Connector Hub | Upload bundle**.
- `showTab()` is now scoped to the tab group's `.card` so Settings and Connectors tab sets are independent (previously the global selectors would clear the other page's active tab).
- No data-flow change: `loadConnectors()` still populates `#conn-installed` / `#conn-hub` by id; both live inside the new tab panes.

## Test plan
- [x] Rebuilt image (Docker); served HTML has the three `showTab(...)` buttons + `tab-installed/-hub/-upload` panes
- [x] `/healthz` 200, page loads
- [x] Settings tabs unaffected (scoped showTab; Settings still General/Health/Custom Metrics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)