### PR TITLE
chore(release): v1.4.1

### DIFF
--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,11 +4,11 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 0.10.0
+version: 0.10.1
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
-appVersion: "1.4.0"
+appVersion: "1.4.1"
 
 home: https://github.com/ThoTischner/observability-mcp
 sources:
@@ -51,7 +51,7 @@ annotations:
     url: https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc
   artifacthub.io/images: |
     - name: observability-mcp
-      image: ghcr.io/thotischner/observability-mcp:1.4.0
+      image: ghcr.io/thotischner/observability-mcp:1.4.1
       platforms:
         - linux/amd64
         - linux/arm64

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thotischner/observability-mcp",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Patch release (manually opened — auto-release pushed the branch but its token lacks PR-create permission; bumps verified correct).

- `mcp-server/package.json` → **1.4.1**
- Helm chart `version` → **0.10.1**, `appVersion` → **1.4.1**, `artifacthub.io/images` → **:1.4.1**

Ships everything since v1.4.0: Loki dedup (#141), no-store /api (#145), install/upload rate-limit+size-cap (#147), Connectors UI tabs (#146), dynamic MCP URL (#143), and the `ip-address` CVE-2026-42338 fix (lockfile already fixed; new image + bumped artifacthub.io/images tag clears the ArtifactHub medium).

Merging triggers `tag-on-release.yml` → release/docker/npm/helm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)