### PR TITLE
ci(security): least-privilege top-level workflow permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     runs-on: ubuntu-latest

--- a/.github/workflows/connector-install-it.yml
+++ b/.github/workflows/connector-install-it.yml
@@ -20,6 +20,9 @@ on:
       - 'mcp-server/src/cli/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   install-it:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,6 +7,9 @@ on:
   merge_group:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 6 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   npm-audit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Scorecard `TokenPermissionsID` (HIGH ×8). This PR fixes the 4 pure CI/scan workflows that had **no top-level `permissions:`** (so `GITHUB_TOKEN` defaulted to broad write): `codeql.yml`, `connector-install-it.yml`, `integration.yml`, `security.yml`.

- Added top-level `permissions: contents: read`.
- Existing **job-level** elevations are untouched and still apply (CodeQL `analyze` and Trivy job keep `security-events: write`).
- These workflows never push/release → zero functional risk.

The remaining 4 (`connector-publish`, `helm-release`, `hub-pages`, `connector-bundle-image`) carry top-level `write` because they release/publish; demoting them to read + per-job write scoping is deliberately a **separate** PR so the release path isn't altered while v1.4.1 (#148) is in flight.

## Test plan
- [x] All 4 files parse as valid YAML
- [x] Job-level `security-events: write` preserved in `codeql.yml` / `security.yml` (SARIF upload still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)