### PR TITLE
ci(security): per-job least-privilege for release workflows

### DIFF
--- a/.github/workflows/connector-bundle-image.yml
+++ b/.github/workflows/connector-bundle-image.yml
@@ -19,11 +19,13 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   bundle:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/connector-publish.yml
+++ b/.github/workflows/connector-publish.yml
@@ -16,11 +16,13 @@ on:
     tags: ['connector-*']
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -26,12 +26,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pages: write
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/hub-pages.yml
+++ b/.github/workflows/hub-pages.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   # Serialize anything that writes gh-pages.
@@ -27,6 +27,8 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
Follow-up to #149 — the 4 release/publish workflows that were intentionally deferred while v1.4.1 was in flight (now released, safe to touch).

Each had a broad top-level write token. Demoted to top-level `contents: read`; the minimal write is now scoped to the single job that needs it:

| Workflow | Job-level grant | Why |
|---|---|---|
| `connector-publish` | `contents: write` | `gh release create/upload` |
| `helm-release` | `contents: write`, `pages: write` | chart-releaser pushes gh-pages |
| `hub-pages` | `contents: write` | pushes gh-pages branch |
| `connector-bundle-image` | `packages: write` | GHCR image push |

Closes the remaining Scorecard `TokenPermissionsID` (HIGH) alerts (the other 4 were fixed in #149).

## Test plan
- [x] All 4 files parse as valid YAML; `permissions` parsed = top `{contents: read}`, job blocks exactly the writes each job performs
- [x] Scopes verified against each workflow's actual token use (release upload / gh-pages push / GHCR push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)