### PR TITLE
ci(security): pin Dockerfile base images by digest

### DIFF
--- a/connectors/Dockerfile.bundle
+++ b/connectors/Dockerfile.bundle
@@ -5,7 +5,7 @@
 #
 # Build context is the staged tree produced by connectors/build-bundle.sh
 # (plugins/<name>/{index.js,package.json,manifest.json,manifest.json.sig}).
-FROM busybox:1.36
+FROM busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
 LABEL org.opencontainers.image.source="https://github.com/ThoTischner/observability-mcp" \
       org.opencontainers.image.description="observability-mcp connectors (signed) for the Helm chart plugins.image / airgapped mounts"
 COPY plugins /plugins

--- a/examples/agent/Dockerfile
+++ b/examples/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:26-alpine
+FROM node:26-alpine@sha256:e71ac5e964b9201072425d59d2e876359efa25dc96bb1768cb73295728d6e4ea
 WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm install

--- a/examples/example-services/Dockerfile
+++ b/examples/example-services/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
 WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm install

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,7 +1,7 @@
 # --- Build stage -----------------------------------------------------------
 # Installs deps + compiles TS. Everything here is throwaway; only the
 # artefacts under /app are copied into the runtime stage.
-FROM node:26-alpine AS builder
+FROM node:26-alpine@sha256:e71ac5e964b9201072425d59d2e876359efa25dc96bb1768cb73295728d6e4ea AS builder
 
 WORKDIR /app
 COPY package.json package-lock.json* ./
@@ -20,7 +20,7 @@ RUN npm prune --omit=dev
 # transitive deps (e.g. ip-address) that surface as CVEs even though the
 # server never invokes npm at runtime. Removing it shrinks the image and
 # silences false-positive scans like the one ArtifactHub reported.
-FROM node:26-alpine
+FROM node:26-alpine@sha256:e71ac5e964b9201072425d59d2e876359efa25dc96bb1768cb73295728d6e4ea
 
 ARG GIT_COMMIT=""
 ARG BUILD_DATE=""


### PR DESCRIPTION
## Summary
Closes the remaining Scorecard `PinnedDependenciesID` (the 7 Dockerfile findings across 5 `FROM` lines). Deferred earlier because digest-pinning freezes base-image security patches **without an updater** — now safe: the repo's `docker` Dependabot ecosystem is active and will bump these digests.

- `mcp-server/Dockerfile` (builder + runtime), `examples/agent/Dockerfile` → `node:26-alpine@sha256:e71a…`
- `examples/example-services/Dockerfile` → `node:20-alpine@sha256:fb4c…`
- `connectors/Dockerfile.bundle` → `busybox:1.36@sha256:73aa…`

Pinned to the **multi-arch manifest-list (OCI index) digest** (not a single-arch digest) so amd64+arm64 builds keep working. Tag retained alongside the digest for readability and Dependabot.

## Test plan
- [x] `docker build mcp-server` succeeds against the pinned base
- [x] `Dockerfile.bundle` pinned base resolves (build proceeds past `FROM` to the `COPY plugins` step, which requires the CI `build-bundle.sh` prep — unrelated to the pin)
- [x] Index digests resolved via `docker buildx imagetools inspect` (multi-arch preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)