### PR TITLE
fix(security): express-rate-limit on expensive routes (closes 2 HIGH)

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -11,12 +11,14 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
         "express": "^5.2.1",
+        "express-rate-limit": "^7.5.0",
         "js-yaml": "^4.1.0",
         "prom-client": "^15.1.0",
         "zod": "^4.4.3"
       },
       "bin": {
-        "observability-mcp": "dist/index.js"
+        "observability-mcp": "dist/index.js",
+        "omcp": "dist/cli/index.js"
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
@@ -519,6 +521,24 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -1033,13 +1053,10 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
       "license": "MIT",
-      "dependencies": {
-        "ip-address": "10.1.0"
-      },
       "engines": {
         "node": ">= 16"
       },

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
     "express": "^5.2.1",
+    "express-rate-limit": "^7.5.0",
     "js-yaml": "^4.1.0",
     "prom-client": "^15.1.0",
     "zod": "^4.4.3"

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import express from "express";
+import rateLimit from "express-rate-limit";
 import { randomUUID } from "node:crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
@@ -85,37 +86,18 @@ function validateSourceUrl(url: string): string | null {
 // a hostile or accidental huge artifact OOM-ing the server).
 const MAX_CONNECTOR_TGZ_BYTES = 64 * 1024 * 1024;
 
-// Dependency-free fixed-window per-client rate limiter for the runtime
-// connector install/upload routes (expensive: fetch + extract + verify +
-// fs write + loader rescan). Bounds abuse even with ENABLE_UI_INSTALL on.
-const installRateState = new Map<string, { count: number; resetAt: number }>();
-function installRateLimit(
-  req: express.Request,
-  res: express.Response,
-  next: express.NextFunction,
-): void {
-  const WINDOW_MS = 60_000;
-  const MAX = 5;
-  const now = Date.now();
-  if (installRateState.size > 5000) {
-    for (const [k, v] of installRateState) if (v.resetAt < now) installRateState.delete(k);
-  }
-  const key = req.ip || "unknown";
-  let s = installRateState.get(key);
-  if (!s || s.resetAt < now) {
-    s = { count: 0, resetAt: now + WINDOW_MS };
-    installRateState.set(key, s);
-  }
-  s.count++;
-  if (s.count > MAX) {
-    res.setHeader("Retry-After", String(Math.ceil((s.resetAt - now) / 1000)));
-    res.status(429).json({
-      error: "rate limit exceeded — too many connector install attempts, slow down",
-    });
-    return;
-  }
-  next();
-}
+// Per-client rate limiter for the expensive runtime routes (connector
+// install/upload: fetch + extract + verify + fs write + loader rescan;
+// add/test source: outbound backend connect). Uses express-rate-limit
+// so the control is explicit and well-tested. Bounds abuse even with
+// ENABLE_UI_INSTALL on.
+const installRateLimit = rateLimit({
+  windowMs: 60_000,
+  limit: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "rate limit exceeded — too many attempts, slow down" },
+});
 
 async function main() {
   // Stdio transport mode (MCP catalogs / desktop clients / Glama's
@@ -580,7 +562,7 @@ async function main() {
   );
 
   // Add a new source
-  app.post("/api/sources", async (req, res) => {
+  app.post("/api/sources", installRateLimit, async (req, res) => {
     const { name, type, url, enabled, auth, tls } = req.body;
     if (!name || !type || !url) {
       res.status(400).json({ error: "name, type, and url are required" });
@@ -640,7 +622,7 @@ async function main() {
   });
 
   // Test a source connection (without saving)
-  app.post("/api/sources/test", async (req, res) => {
+  app.post("/api/sources/test", installRateLimit, async (req, res) => {
     const { name, type, url, enabled, auth, tls } = req.body;
     if (!type || !url) {
       res.status(400).json({ error: "type and url are required" });


### PR DESCRIPTION
## Summary
Answer to "is anything else fixable?": **yes — the 2 remaining HIGH `js/missing-rate-limiting` were properly fixable, not just dismissable.**

The previous custom limiter (#147) *functionally* rate-limited install/upload, but CodeQL's `js/missing-rate-limiting` only recognises known limiter libraries, so #249 & #252 (HIGH) stayed open. Replaced with **`express-rate-limit`** (zero-dep, Express 5 compatible, emits standard `RateLimit-*` headers, CodeQL-modelled) — this closes both HIGH alerts at the source instead of suppressing them.

Also applied the limiter to `POST /api/sources` and `POST /api/sources/test` (they perform outbound backend connects — defense-in-depth and pre-empts the same finding relocating there). Budget unchanged (5 / 60 s). The `MAX_CONNECTOR_TGZ_BYTES` size cap is retained.

### Honest status of the other open findings (not silently suppressed)
- `js/http-to-file-access` ×2 / `js/file-access-to-http` ×1 (MEDIUM): inherent to the connector download/upload-to-disk feature; mitigated by `ENABLE_UI_INSTALL` gate + fail-closed signature/integrity verify + size cap + this rate limit. Not code-fixable without removing the feature — accepted, documented risk.
- `js/unused-local-variable` (note) / `js/useless-assignment-to-local` (warning): code-quality, **not** security-severity — out of scope here, can be a separate chore.
- Scorecard `BranchProtectionID` (HIGH ×1): pure repo setting (ruleset), no code. `SASTID`: informational (CodeQL is active).

## Test plan
- [x] `tsc --noEmit` clean (Docker); lockfile regenerated in Docker
- [x] Live: 5×200 then **429** on `/api/sources/test`; `RateLimit-Policy/Limit/Remaining` headers present
- [x] Unit suite green (Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)