### PR TITLE
chore: clear 2 non-security CodeQL code-quality alerts

### DIFF
--- a/connectors/pack.mjs
+++ b/connectors/pack.mjs
@@ -16,7 +16,7 @@
 // catalog URLs are deterministic (release tag scheme) and committed.
 
 import { createHash, createPrivateKey, sign as edSign } from "node:crypto";
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 

--- a/examples/agent/src/index.ts
+++ b/examples/agent/src/index.ts
@@ -162,7 +162,10 @@ async function main() {
   let { tools } = await client.listTools();
   log(`MCP tools: ${tools.map((t) => t.name).join(", ")}`);
 
-  let ollamaAvailable = await ensureModel();
+  // Warm up / pull the model at boot for its side effect; the loop
+  // re-checks availability each iteration before use.
+  await ensureModel();
+  let ollamaAvailable = false;
 
   while (true) {
     try {


### PR DESCRIPTION
## Summary
The two non-security CodeQL alerts (note + warning severity), cleaned up for completeness:

- **`js/unused-local-variable`** — `connectors/pack.mjs` imported `existsSync` but never used it. Removed from the import.
- **`js/useless-assignment-to-local`** — `examples/agent/src/index.ts`: `let ollamaAvailable = await ensureModel()` at boot, but the loop reassigns it every iteration *before* its only read, so the initial binding was dead. Kept the boot `await ensureModel()` (it has a model-pull side effect), declared `ollamaAvailable` separately.

No behavior change.

## Test plan
- [x] `node --check connectors/pack.mjs` OK
- [x] `examples/agent` `tsc --noEmit` clean (Docker)
- [x] `pack.mjs` still uses `readFileSync`/`writeFileSync`/`mkdirSync` (only the genuinely-unused import dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)