### PR TITLE
ci(security): least-privilege for tag-on-release & release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
         description: 'Tag to release'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/tag-on-release.yml
+++ b/.github/workflows/tag-on-release.yml
@@ -12,11 +12,13 @@ on:
       - mcp-server/package.json
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # push the release tag
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## Summary
Can the remaining Scorecard `TokenPermissionsID` (HIGH) be removed? **Partly — the reducible part, yes; the rest is irreducible.**

It dropped 8 → 5 after #149/#150. Of the 5, only **`tag-on-release.yml`** still had a *top-level* `contents: write` (reducible). This PR:
- `tag-on-release.yml`: top-level → `contents: read`; job `tag` gets `contents: write` (it pushes the release tag).
- `release.yml`: had **no** top-level block (default-open) → add top-level `contents: read`; job `release` keeps `contents: write` (`softprops/action-gh-release` must create the Release).

Now every workflow follows the same least-privilege shape.

### Honest residual
`hub-pages`, `helm-release`, `connector-publish`, `release`, `tag-on-release` still carry **job-level** `contents: write`. That is **irreducible**: pushing a git tag, creating a GitHub Release, and pushing the `gh-pages` branch all require `contents: write`. Scorecard scores any `contents: write` as 0 (its remediation literally says "restrict to read"), so these specific alerts cannot reach green without removing the project's ability to publish releases — the same inherent-requirement trade-off class as the solo-maintainer branch-protection one. No safe code change closes them further.

## Test plan
- [x] Both files valid YAML; parsed perms = top `{contents: read}`, job `{contents: write}` (only where the job genuinely needs it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)