### PR TITLE
docs: de-Confluent wording + punchier demo.gif (AI agent use case)

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ The agent ([docs/agent.md](docs/agent.md)) detects anomalies within 30 seconds a
 
 ## CLI (`omcp`)
 
-A Confluent-style control CLI ships in the same npm package (`omcp` bin):
+A control CLI ships in the same npm package (`omcp` bin) — manage connectors, the demo stack, and Helm installs:
 
 ```bash
 omcp doctor                       # check docker / compose / helm / node

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -8,7 +8,7 @@ Last updated: 2026-05-14
 1. **Connectors are optional.** The MCP server starts and serves `tools/list` with zero connectors; users add Prometheus, Loki, Tempo, OpenSearch, Datadog, etc. on demand.
 2. **No build needed to add a connector.** Drop a tarball / npm package into the right place, point a config line at it, restart. No code changes to the server.
 3. **Airgapped works.** No runtime network access required to load a connector. All resolution from local filesystem or the container image.
-4. **Versioned, signed, discoverable.** A future *connector hub* (think Confluent Hub for Kafka Connect) hosts connector packages with signed manifests; the CLI can install from the hub or a private mirror.
+4. **Versioned, signed, discoverable.** A *connector hub* — a curated registry of connector packages with signed manifests — hosts the catalog; the CLI can install from the hub or a private mirror.
 5. **Backwards compatible during rollout.** The existing `PrometheusConnector` and `LokiConnector` keep working through a builtin-shim before they get extracted into separate packages.
 
 ## Non-goals (for v1)
@@ -185,7 +185,7 @@ Both install paths run the **exact same fail-closed verification** as the loader
 
 A tampered/unsigned bundle is rejected (`400`, `PluginVerificationError`) and never written. On Kubernetes, `PLUGINS_DIR` is an `emptyDir` reseeded from the bundle image on every start, so set `plugins.persistence.enabled=true` (PVC) and `plugins.uiInstall.enabled=true` in the Helm chart for runtime-installed connectors to survive pod restarts.
 
-Future: a "third-party / certified / official" rating tier like Confluent Hub.
+Future: a "third-party / certified / official" rating tier for catalog entries.
 
 ## Implementation milestones
 


### PR DESCRIPTION
## Summary
Addresses three points of feedback:

1. **"Confluent" removed** — the README said *"A Confluent-style control CLI"* and `plugin-architecture.md` referenced *"Confluent Hub"* twice. Trademark + nobody-knows-what-it-means concern. Reworded to plain descriptive language ("A control CLI ships…", "a curated registry of connector packages…", "a rating tier for catalog entries").
2. **demo.gif no longer looks static at the start** — it now opens directly on an **animated AI-agent chat** (text types out within ~0.5s, so the GIF is in motion from the first frames), then a brisk UI tour with short page holds.
3. **AI agent + strong use case shown** — the opening scene emulates the obs-mcp agent resolving a **P1 incident**: an on-call SRE asks why checkout is failing; the agent calls `detect_anomalies → get_service_health → query_logs → query_metrics` (real tool names, animated tool chips), then returns a root-cause card (payment-service OOM-loop after `payment@1.8.0`, blast radius into order-service/api-gateway, evidence from metrics+logs) and a concrete rollback recommendation.

Also removed a stray broken symlink `docs/docs2 -> /docs2` (untracked artifact).

Assets/docs only — no code change.

## Test plan
- [x] `grep -ri confluent` over README/docs → no matches remain
- [x] demo.gif regenerated headless (Playwright) against the live demo stack; 900px/10fps/palette (~4.5 MB); first motion < 1s
- [x] README hero already points at `docs/demo.gif` (from #157) — binary swap updates it in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)