### PR TITLE
docs(readme): how to install the omcp CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,19 @@ The agent ([docs/agent.md](docs/agent.md)) detects anomalies within 30 seconds a
 
 ## CLI (`omcp`)
 
-A control CLI ships in the same npm package (`omcp` bin) — manage connectors, the demo stack, and Helm installs:
+A control CLI ships in the same npm package (`omcp` bin) — manage connectors, the demo stack, and Helm installs.
+
+Install it (or run ad-hoc without installing):
+
+```bash
+npm i -g @thotischner/observability-mcp   # puts `omcp` on your PATH
+omcp --help
+
+# or, no install:
+npx -p @thotischner/observability-mcp omcp doctor
+```
+
+Then:
 
 ```bash
 omcp doctor                       # check docker / compose / helm / node


### PR DESCRIPTION
The CLI section documented usage but not installation. Adds `npm i -g @thotischner/observability-mcp` (puts `omcp` on PATH) plus an `npx -p …` no-install option before the command examples. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)