### PR TITLE
feat(analysis): robust anomaly detection (median/MAD + trend + dwell)

### DIFF
--- a/mcp-server/src/analysis/anomaly.test.ts
+++ b/mcp-server/src/analysis/anomaly.test.ts
@@ -1,6 +1,14 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { calculateZScore, detectAnomalyPoints, detectRecentAnomaly } from "./anomaly.js";
+import {
+  calculateZScore,
+  detectAnomalyPoints,
+  detectRecentAnomaly,
+  detectRobustAnomaly,
+  classifyMetric,
+  median,
+  mad,
+} from "./anomaly.js";
 
 describe("calculateZScore", () => {
   it("returns zeros for empty array", () => {
@@ -96,5 +104,99 @@ describe("detectRecentAnomaly", () => {
     const highResult = detectRecentAnomaly([...baseline, ...slight], 5, 3.0);
     // Slight increase might trigger low threshold but not high
     assert.ok(lowResult.isAnomaly || !highResult.isAnomaly);
+  });
+});
+
+describe("median / mad", () => {
+  it("median handles odd and even lengths", () => {
+    assert.equal(median([3, 1, 2]), 2);
+    assert.equal(median([1, 2, 3, 4]), 2.5);
+    assert.equal(median([]), 0);
+  });
+  it("mad is robust to outliers", () => {
+    const stable = [8, 10, 12, 9, 11, 10, 13, 7];
+    const withOutlier = [...stable, 100000];
+    const stdDev = (xs: number[]) => {
+      const m = xs.reduce((a, b) => a + b, 0) / xs.length;
+      return Math.sqrt(xs.reduce((s, v) => s + (v - m) ** 2, 0) / xs.length);
+    };
+    // MAD barely moves; stdDev explodes by orders of magnitude.
+    assert.ok(mad(stable) > 0);
+    assert.ok(mad(withOutlier) < mad(stable) * 2);
+    assert.ok(stdDev(withOutlier) > stdDev(stable) * 100);
+  });
+});
+
+describe("classifyMetric", () => {
+  it("classifies by name", () => {
+    assert.equal(classifyMetric("latency_p99"), "latency");
+    assert.equal(classifyMetric("error_rate"), "error_rate");
+    assert.equal(classifyMetric("cpu"), "saturation");
+    assert.equal(classifyMetric("memory_used_bytes"), "saturation");
+    assert.equal(classifyMetric("request_rate"), "throughput");
+    assert.equal(classifyMetric("widgets_total"), "generic");
+  });
+});
+
+describe("detectRobustAnomaly", () => {
+  it("warmup: no detection below minSamples", () => {
+    const r = detectRobustAnomaly([1, 2, 3, 4, 5]);
+    assert.equal(r.isAnomaly, false);
+    assert.equal(r.method, "none");
+  });
+
+  it("no anomaly for stable noisy data", () => {
+    const v = Array.from({ length: 40 }, (_, i) => 100 + (i % 3) - 1);
+    assert.equal(detectRobustAnomaly(v).isAnomaly, false);
+  });
+
+  // The exact production false-negative: a slow memory-leak ramp toward OOM.
+  // detectRecentAnomaly misses it because the rising baseline poisons its own
+  // mean/stdDev; detectRobustAnomaly must catch it.
+  it("REGRESSION: detects slow memory-leak ramp the legacy detector misses", () => {
+    // The query window opened AFTER the leak began, so there is no flat
+    // baseline — the metric climbs monotonically across the whole window.
+    // Legacy windowed z-score stays sub-threshold (the baseline already
+    // contains the ramp); this is the production "all healthy during OOM"
+    // false-negative. The robust trend detector must catch it.
+    const series = Array.from({ length: 40 }, (_, i) => 120 + i * 7);
+
+    const legacy = detectRecentAnomaly(series, 5, 2.0);
+    assert.equal(legacy.isAnomaly, false, "legacy detector misses the leak spanning the window");
+
+    const robust = detectRobustAnomaly(series, { metricKind: "saturation" });
+    assert.equal(robust.isAnomaly, true, "robust detector must catch the leak");
+    assert.equal(robust.method, "trend");
+    assert.equal(robust.direction, "above");
+  });
+
+  it("detects a hard spike via robust-z", () => {
+    const base = Array.from({ length: 25 }, (_, i) => 50 + (i % 3));
+    const spike = Array(5).fill(500);
+    const r = detectRobustAnomaly([...base, ...spike], { metricKind: "latency" });
+    assert.equal(r.isAnomaly, true);
+    assert.equal(r.method, "robust-z");
+  });
+
+  it("dwell/hysteresis: a single transient spike does not fire", () => {
+    const base = Array.from({ length: 30 }, (_, i) => 50 + (i % 3));
+    const series = [...base, 50, 51, 49, 500]; // one lone spike at the very end
+    const r = detectRobustAnomaly(series, { metricKind: "latency", dwell: 2 });
+    assert.equal(r.isAnomaly, false, "single point should not satisfy dwell");
+  });
+
+  it("one-sided: a drop in error_rate is not an anomaly", () => {
+    const base = Array.from({ length: 25 }, (_, i) => 20 + (i % 3));
+    const drop = Array(5).fill(0);
+    const r = detectRobustAnomaly([...base, ...drop], { metricKind: "error_rate" });
+    assert.equal(r.isAnomaly, false);
+  });
+
+  it("two-sided generic metric flags a drop", () => {
+    const base = Array.from({ length: 25 }, (_, i) => 100 + (i % 3));
+    const drop = Array(5).fill(5);
+    const r = detectRobustAnomaly([...base, ...drop], { metricKind: "generic" });
+    assert.equal(r.isAnomaly, true);
+    assert.equal(r.direction, "below");
   });
 });

--- a/mcp-server/src/analysis/anomaly.ts
+++ b/mcp-server/src/analysis/anomaly.ts
@@ -49,6 +49,175 @@ export function detectAnomalyPoints(
   return anomalies;
 }
 
+// ---------------------------------------------------------------------------
+// Robust detection (median/MAD) — resistant to the trend & outliers that skew
+// mean/stdDev. Adds warmup, dwell/hysteresis, a slow-ramp trend detector, and
+// per-metric-type behaviour.
+// ---------------------------------------------------------------------------
+
+export function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = sorted.length >> 1;
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/** Median Absolute Deviation, scaled to be a consistent estimator of stdDev. */
+export function mad(values: number[], center?: number): number {
+  if (values.length === 0) return 0;
+  const med = center ?? median(values);
+  const deviations = values.map((v) => Math.abs(v - med));
+  return 1.4826 * median(deviations);
+}
+
+export type MetricKind = "latency" | "error_rate" | "saturation" | "throughput" | "generic";
+
+export function classifyMetric(metric: string): MetricKind {
+  const m = metric.toLowerCase();
+  if (/(latency|duration|response_time|p\d{2,3})/.test(m)) return "latency";
+  if (/(error|fail|5xx|4xx)/.test(m)) return "error_rate";
+  if (/(cpu|mem|memory|heap|disk|saturat|util|queue|pool|fd|gc)/.test(m)) return "saturation";
+  if (/(request_rate|rps|qps|throughput|traffic)/.test(m)) return "throughput";
+  return "generic";
+}
+
+export interface RobustAnomalyOptions {
+  /** Minimum samples before any detection (cold-start guard). */
+  minSamples?: number;
+  /** Number of trailing points evaluated as "recent". */
+  recentWindow?: number;
+  /** Robust-z threshold. */
+  threshold?: number;
+  /** Consecutive breaching recent points required to fire (dwell/hysteresis). */
+  dwell?: number;
+  metricKind?: MetricKind;
+}
+
+export interface RobustAnomalyResult {
+  isAnomaly: boolean;
+  /** Robust z = (median(recent) - median(baseline)) / MAD(baseline). */
+  score: number;
+  method: "robust-z" | "trend" | "none";
+  direction: "above" | "below" | "flat";
+  recentValue: number;
+  baselineValue: number;
+  reason: string;
+}
+
+const NONE: RobustAnomalyResult = {
+  isAnomaly: false,
+  score: 0,
+  method: "none",
+  direction: "flat",
+  recentValue: 0,
+  baselineValue: 0,
+  reason: "insufficient data (warmup)",
+};
+
+/**
+ * Robust anomaly detection.
+ *
+ * Unlike {@link detectRecentAnomaly}, the baseline is the *early stable* portion
+ * of the series (it excludes the recent window AND the trailing ramp), so a slow
+ * monotonic increase — e.g. a memory leak heading toward OOM — no longer poisons
+ * its own baseline. Saturation/latency metrics additionally run a trend detector
+ * that catches gradual ramps even when no single point is a spike.
+ */
+export function detectRobustAnomaly(
+  values: number[],
+  opts: RobustAnomalyOptions = {}
+): RobustAnomalyResult {
+  const minSamples = opts.minSamples ?? 15;
+  const recentWindow = opts.recentWindow ?? 5;
+  const threshold = opts.threshold ?? 3.0;
+  const dwell = opts.dwell ?? 2;
+  const kind = opts.metricKind ?? "generic";
+
+  // Warmup guard.
+  if (values.length < Math.max(minSamples, recentWindow * 3)) return { ...NONE };
+
+  const recent = values.slice(-recentWindow);
+  // Baseline = leading stable portion only; exclude the recent window and a
+  // trailing margin so a ramp that ends in `recent` cannot inflate it.
+  const baselineEnd = Math.max(
+    Math.floor(values.length * 0.5),
+    values.length - recentWindow * 3
+  );
+  const baseline = values.slice(0, baselineEnd);
+  if (baseline.length < 3) return { ...NONE };
+
+  const baseMed = median(baseline);
+  const baseMad = mad(baseline, baseMed);
+  const recentMed = median(recent);
+
+  // One-sided metrics: a drop in error_rate / latency / saturation is good news.
+  const oneSidedUp = kind === "error_rate" || kind === "latency" || kind === "saturation";
+
+  // Robust z. Guard against MAD == 0 (perfectly flat baseline) with a tiny
+  // relative epsilon so a real shift off a flat baseline still registers.
+  const scale = baseMad > 0 ? baseMad : Math.max(Math.abs(baseMed) * 1e-3, 1e-9);
+  const z = (recentMed - baseMed) / scale;
+  const direction: RobustAnomalyResult["direction"] =
+    z > 0 ? "above" : z < 0 ? "below" : "flat";
+
+  // Dwell: require the last `dwell` points to each individually breach.
+  const tail = values.slice(-dwell);
+  const breaches = tail.filter((v) => {
+    const pz = (v - baseMed) / scale;
+    return oneSidedUp ? pz >= threshold : Math.abs(pz) >= threshold;
+  });
+  const dwellMet = breaches.length >= dwell;
+
+  const zHit = (oneSidedUp ? z >= threshold : Math.abs(z) >= threshold) && dwellMet;
+
+  // Trend detector for slow ramps (saturation/latency). Catches a sustained
+  // monotonic climb even when the windowed robust-z is still sub-threshold.
+  let trendHit = false;
+  let trendReason = "";
+  if (!zHit && (kind === "saturation" || kind === "latency") && values.length >= minSamples) {
+    let ups = 0;
+    for (let i = 1; i < values.length; i++) if (values[i] > values[i - 1]) ups++;
+    const monotonicFrac = ups / (values.length - 1);
+    const netRise = (recentMed - baseMed) / scale;
+    if (monotonicFrac >= 0.7 && netRise >= 2.0) {
+      trendHit = true;
+      trendReason = `sustained upward trend: ${Math.round(monotonicFrac * 100)}% of steps rising, +${netRise.toFixed(1)} robust-σ net`;
+    }
+  }
+
+  if (zHit) {
+    return {
+      isAnomaly: true,
+      score: z,
+      method: "robust-z",
+      direction,
+      recentValue: recentMed,
+      baselineValue: baseMed,
+      reason: `recent median ${recentMed.toFixed(2)} is ${z.toFixed(1)} robust-σ ${direction} baseline ${baseMed.toFixed(2)} (dwell ${breaches.length}/${dwell})`,
+    };
+  }
+  if (trendHit) {
+    return {
+      isAnomaly: true,
+      score: (recentMed - baseMed) / scale,
+      method: "trend",
+      direction: "above",
+      recentValue: recentMed,
+      baselineValue: baseMed,
+      reason: trendReason,
+    };
+  }
+  return {
+    isAnomaly: false,
+    score: z,
+    method: "none",
+    direction,
+    recentValue: recentMed,
+    baselineValue: baseMed,
+    reason: "within robust baseline",
+  };
+}
+
 /**
  * Check if the most recent values deviate significantly from the baseline.
  * Compares the last `recentWindow` values against the rest.

--- a/mcp-server/src/tools/detect-anomalies.ts
+++ b/mcp-server/src/tools/detect-anomalies.ts
@@ -1,6 +1,6 @@
 import type { ConnectorRegistry } from "../connectors/registry.js";
 import type { AnomalyReport } from "../types.js";
-import { detectRecentAnomaly } from "../analysis/anomaly.js";
+import { detectRobustAnomaly, classifyMetric } from "../analysis/anomaly.js";
 import { correlateSignals } from "../analysis/correlator.js";
 
 export const detectAnomaliesDefinition = {
@@ -71,18 +71,21 @@ export async function detectAnomaliesHandler(
         try {
           const result = await connector.queryMetrics({ service: serviceName, metric, duration });
           const values = result.values.map((v) => v.value);
-          const anomaly = detectRecentAnomaly(values, 5, threshold);
+          const anomaly = detectRobustAnomaly(values, {
+            threshold,
+            metricKind: classifyMetric(metric),
+          });
 
           if (anomaly.isAnomaly) {
-            const deviationPercent = anomaly.baselineAvg === 0
+            const deviationPercent = anomaly.baselineValue === 0
               ? 100
-              : Math.round(((anomaly.recentAvg - anomaly.baselineAvg) / anomaly.baselineAvg) * 100);
+              : Math.round(((anomaly.recentValue - anomaly.baselineValue) / anomaly.baselineValue) * 100);
             allAnomalies.push({
               metric,
-              severity: Math.abs(anomaly.zScore) >= 3 ? "high" : Math.abs(anomaly.zScore) >= 2 ? "medium" : "low",
-              description: `${metric} is ${anomaly.zScore.toFixed(1)}σ ${anomaly.zScore > 0 ? "above" : "below"} baseline (${anomaly.baselineAvg.toFixed(2)} → ${anomaly.recentAvg.toFixed(2)})`,
-              currentValue: anomaly.recentAvg,
-              baselineValue: anomaly.baselineAvg,
+              severity: Math.abs(anomaly.score) >= 6 ? "high" : Math.abs(anomaly.score) >= 4 ? "medium" : "low",
+              description: `${metric}: ${anomaly.reason}`,
+              currentValue: anomaly.recentValue,
+              baselineValue: anomaly.baselineValue,
               deviationPercent,
               source: connector.name,
               service: serviceName,


### PR DESCRIPTION
## Why

The anomaly engine used a windowed mean/stdDev z-score. Two structural blind spots:

1. **Trend poisons its own baseline.** When a metric climbs across the whole query window (e.g. a query opened after a memory leak began), the baseline already contains the ramp — mean is dragged up, stdDev inflated — so the recent window never reaches the z threshold. The scan reports "all healthy" during an active incident.
2. **Outlier sensitivity & flapping.** A single transient blip can fire; cold-start (few samples) produces false positives.

## What

- **median/MAD** robust baseline instead of mean/stdDev
- **baseline = early stable portion only** (excludes recent window + trailing margin)
- **trend detector** for saturation/latency: catches a sustained monotonic ramp even when no single point is a spike
- **warmup** (min samples) — cold-start guard
- **dwell/hysteresis** — N consecutive breaches required
- **per-metric-type** classification: error_rate/latency/saturation one-sided, generic/throughput two-sided
- `detect_anomalies` wired to the robust detector with per-metric classification

`detectRecentAnomaly` is kept for backward compatibility (still used by health scoring).

## Tests

+10 unit tests including a **regression**: a slow ramp spanning the whole query window — the legacy windowed detector misses it (z stays at 1.98 < 2.0), the robust trend detector catches it. Full analysis suite 34/34 green; no change to the 4 unrelated pre-existing prometheus/registry failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)