### PR TITLE
feat(detect_anomalies): scan memory + flag critical log patterns

### DIFF
--- a/mcp-server/src/tools/detect-anomalies.ts
+++ b/mcp-server/src/tools/detect-anomalies.ts
@@ -34,7 +34,13 @@ const SENSITIVITY_THRESHOLDS: Record<string, number> = {
   high: 1.5,
 };
 
-const KEY_METRICS = ["cpu", "error_rate", "latency_p99", "request_rate"];
+const KEY_METRICS = ["cpu", "memory", "error_rate", "latency_p99", "request_rate"];
+
+// Patterns that signal a serious incident even at warn level and even when
+// the overall error ratio is low (e.g. a memory leak emits a handful of
+// "OutOfMemoryWarning" lines long before it turns into 5xx errors).
+const CRITICAL_LOG_PATTERN =
+  /\b(out\s?of\s?memory|oom|outofmemory|heap (usage|exhaust)|memory leak|panic|fatal|deadlock|segfault|stack overflow|cannot allocate)\b/i;
 
 export async function detectAnomaliesHandler(
   registry: ConnectorRegistry,
@@ -102,6 +108,25 @@ export async function detectAnomaliesHandler(
       if (!connector.queryLogs) continue;
       try {
         const logs = await connector.queryLogs({ service: serviceName, duration, limit: 500 });
+
+        // Critical-pattern scan — independent of the error-ratio gate, so a
+        // warn-level OOM/leak signal is not silently dropped.
+        const criticalPattern = logs.summary.topPatterns.find((p) =>
+          CRITICAL_LOG_PATTERN.test(p)
+        );
+        if (criticalPattern) {
+          allAnomalies.push({
+            metric: "log_critical_pattern",
+            severity: "high",
+            description: `Critical log pattern detected: "${criticalPattern}"`,
+            currentValue: logs.summary.errorCount + logs.summary.warnCount,
+            baselineValue: 0,
+            deviationPercent: 100,
+            source: connector.name,
+            service: serviceName,
+          });
+        }
+
         if (logs.summary.errorCount > 5) {
           const errorRatio = logs.summary.total > 0
             ? logs.summary.errorCount / logs.summary.total

--- a/mcp-server/src/tools/handlers.test.ts
+++ b/mcp-server/src/tools/handlers.test.ts
@@ -4,6 +4,7 @@ import { ConnectorRegistry } from "../connectors/registry.js";
 import { DEFAULT_SETTINGS, DEFAULT_HEALTH_THRESHOLDS } from "../config/loader.js";
 import { listSourcesHandler } from "./list-sources.js";
 import { listServicesHandler } from "./list-services.js";
+import { detectAnomaliesHandler } from "./detect-anomalies.js";
 import type { Config, ServiceInfo, MetricResult, LogResult, ConnectorHealth, MetricDefinition, SignalType } from "../types.js";
 import type { ObservabilityConnector } from "../connectors/interface.js";
 
@@ -147,5 +148,81 @@ describe("listServicesHandler", () => {
     const result = await listServicesHandler(reg, { filter: "nonexistent" });
     const data = JSON.parse(result.content[0].text);
     assert.equal(data.total, 0);
+  });
+});
+
+describe("detectAnomaliesHandler — A5 memory/OOM coverage", () => {
+  const flatMemory = () => ({
+    source: "prom1", service: "payment-service", metric: "memory", unit: "bytes",
+    values: Array.from({ length: 40 }, (_, i) => ({
+      timestamp: new Date(Date.now() - (40 - i) * 9000).toISOString(),
+      value: 1.3e8 + (i % 3) * 1e6, // noisy, no trend → no metric anomaly
+    })),
+    summary: { current: 1.3e8, average: 1.3e8, min: 1.28e8, max: 1.33e8, trend: "stable" as const },
+  });
+
+  it("scans the memory metric (now in KEY_METRICS)", async () => {
+    const requested: string[] = [];
+    const reg = createRegistryWithMocks([
+      createMockConnector({
+        name: "prom1", type: "prometheus", signalType: "metrics",
+        listServices: async () => [{ name: "payment-service", source: "prom1", signalType: "metrics" }],
+        queryMetrics: async ({ metric }: any) => {
+          requested.push(metric);
+          return flatMemory();
+        },
+      }),
+    ]);
+    await detectAnomaliesHandler(reg, {});
+    assert.ok(requested.includes("memory"), `memory not scanned; got ${requested.join(",")}`);
+  });
+
+  it("flags a warn-level OOM log pattern below the error-rate gate", async () => {
+    const reg = createRegistryWithMocks([
+      createMockConnector({
+        name: "prom1", type: "prometheus", signalType: "metrics",
+        listServices: async () => [{ name: "payment-service", source: "prom1", signalType: "metrics" }],
+        queryMetrics: async () => flatMemory(),
+      }),
+      createMockConnector({
+        name: "loki1", type: "loki", signalType: "logs",
+        queryLogs: async () => ({
+          source: "loki1", service: "payment-service", entries: [],
+          // Only 4 warn-level lines: errorCount below the >5 gate, ratio tiny.
+          summary: {
+            total: 800, errorCount: 4, warnCount: 4,
+            topPatterns: ["OutOfMemoryWarning: heap usage exceeding threshold (4x)"],
+          },
+        }),
+      }),
+    ]);
+    const result = await detectAnomaliesHandler(reg, {});
+    const data = JSON.parse(result.content[0].text);
+    const crit = data.anomalies.find((a: any) => a.metric === "log_critical_pattern");
+    assert.ok(crit, "expected a log_critical_pattern anomaly for the OOM warning");
+    assert.equal(crit.service, "payment-service");
+    assert.equal(crit.severity, "high");
+    assert.equal(data.rootCause.ranked[0].service, "payment-service");
+    assert.notEqual(data.summary, "All services healthy — no anomalies detected.");
+  });
+
+  it("does not flag benign warn patterns", async () => {
+    const reg = createRegistryWithMocks([
+      createMockConnector({
+        name: "prom1", type: "prometheus", signalType: "metrics",
+        listServices: async () => [{ name: "order-service", source: "prom1", signalType: "metrics" }],
+        queryMetrics: async () => flatMemory(),
+      }),
+      createMockConnector({
+        name: "loki1", type: "loki", signalType: "logs",
+        queryLogs: async () => ({
+          source: "loki1", service: "order-service", entries: [],
+          summary: { total: 500, errorCount: 1, warnCount: 2, topPatterns: ["cache miss for key user:42"] },
+        }),
+      }),
+    ]);
+    const result = await detectAnomaliesHandler(reg, {});
+    const data = JSON.parse(result.content[0].text);
+    assert.equal(data.anomalies.length, 0);
   });
 });


### PR DESCRIPTION
## Why

`detect_anomalies` scanned only cpu/error_rate/latency_p99/request_rate and only raised a log anomaly when the error *ratio* crossed a gate. A memory leak toward OOM slipped through both: the `memory` signal was never queried, and its early symptom is a few **warn-level** `OutOfMemoryWarning` lines — well below the error-rate gate. (`get_service_health` already surfaced both; the scan tool didn't.)

## What

- **`memory` added to `KEY_METRICS`** — `classifyMetric` maps it to the saturation kind, so the robust/trend detector (median/MAD + ramp, one-sided) from #164 applies.
- **Critical-pattern log scan** — top log patterns are matched against critical signatures (OOM / heap exhaustion / memory leak / panic / fatal / deadlock / segfault / cannot allocate); a match raises a high-severity `log_critical_pattern` anomaly **independently** of the error-ratio gate.

## Tests

+3 handler tests: `memory` is now scanned; a 4-line warn-level OOM pattern (below the error gate) is flagged and root-caused to the service; benign warn patterns stay silent. Full suite green; the 4 unrelated pre-existing prometheus/registry failures are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)