### PR TITLE
chore(license): relicense MIT → Apache-2.0 and add a CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,32 @@
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: >
+          (github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')
+          || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: ".github/cla-signatures.json"
+          path-to-document: "https://github.com/ThoTischner/observability-mcp/blob/main/CLA.md"
+          branch: "cla-signatures"
+          allowlist: "ThoTischner,dependabot[bot],github-actions[bot]"
+          custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"
+          custom-allsigned-prcomment: "All contributors have signed the CLA. ✅"

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,53 @@
+# Contributor License Agreement
+
+Thank you for contributing to observability-mcp. To keep the project
+sustainable as open core, every contributor must agree to this Contributor
+License Agreement (CLA) before a contribution can be merged. You accept it by
+commenting the sign-off phrase on your pull request when the CLA bot asks.
+
+This CLA is adapted from the Apache Individual CLA, **with an explicit
+relicensing/sublicensing grant** so the project can offer commercial and
+source-available editions.
+
+By contributing, You agree to the following for each Contribution You submit:
+
+1. **Copyright license.** You grant the project owner (Thomas Tischner) and
+   recipients of software distributed by the project a perpetual, worldwide,
+   non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+   reproduce, prepare derivative works of, publicly display, publicly
+   perform, sublicense, and distribute Your Contributions and such derivative
+   works.
+
+2. **Patent license.** You grant the project owner and recipients a
+   perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated below) patent license to make, have made, use, offer to
+   sell, sell, import, and otherwise transfer Your Contribution, where such
+   license applies only to those patent claims licensable by You that are
+   necessarily infringed by Your Contribution alone or by combination with
+   the project. If any entity institutes patent litigation alleging that the
+   project or a Contribution constitutes patent infringement, the patent
+   licenses granted to that entity under this CLA terminate.
+
+3. **Relicensing / sublicensing (the open-core grant).** You agree that the
+   project owner may license, relicense, and sublicense Your Contributions
+   and any derivative works, in whole or in part, under **any license terms
+   the project owner chooses, including proprietary, commercial, or
+   source-available terms (for example the Functional Source License), and
+   without any obligation to release such derivative works under an
+   open-source license.** This right is in addition to, and does not limit,
+   the open-source license under which the project is currently distributed
+   (Apache-2.0).
+
+4. **Original work / authority.** Each Contribution is either Your original
+   creation or You have the right to submit it under this CLA. If Your
+   employer has rights to intellectual property You create, You represent
+   that You are authorized to submit the Contribution, or that Your employer
+   has waived such rights. You must identify any third-party-licensed
+   material included in a Contribution.
+
+5. **No warranty.** Contributions are provided "as is", without warranty of
+   any kind.
+
+This is a CLA, **not a DCO**: a `Signed-off-by` line only certifies origin
+and does **not** grant the relicensing rights in clause 3, which the
+open-core model requires. `Signed-off-by` is optional and not enforced.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,15 @@
 
 Thanks for thinking about it. Quick orientation so your first PR lands without churn.
 
+## Contributor License Agreement
+
+Before your first contribution can be merged you must agree to the
+[Contributor License Agreement](./CLA.md). A bot will ask you to comment a
+one-line sign-off on your PR; it is recorded once and remembered for future
+PRs. The CLA includes an explicit relicensing grant so the project can
+sustain itself via commercial / source-available editions — a plain
+`Signed-off-by` (DCO) does not grant that and is not a substitute.
+
 ## Before you start
 
 - Browse the open issues and PRs. If you're tackling something non-trivial, open an issue first so we can align on the approach.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,202 @@
-MIT License
 
-Copyright (c) 2025 Thomas Tischner
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   1. Definitions.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,18 @@
+observability-mcp
+Copyright 2025-2026 Thomas Tischner
+
+This product includes software developed by Thomas Tischner.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Releases up to and including the last MIT-licensed version remain available
+under the MIT License. Subsequent releases are licensed under Apache-2.0 as
+stated above. The Git history is intentionally NOT rewritten.
+
+The top-level "enterprise/" directory, when present, is NOT licensed under
+Apache-2.0; it is governed separately by the Functional Source License
+(FSL-1.1-Apache-2.0). See enterprise/LICENSE for its terms.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ normalizes the data, adds robust anomaly analysis, and provides a web UI for con
 *One MCP endpoint, every backend — so an agent triaging an incident asks one normalized
 question instead of juggling N vendor servers and their query languages.*
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![npm](https://img.shields.io/npm/v/@thotischner/observability-mcp?logo=npm)](https://www.npmjs.com/package/@thotischner/observability-mcp)
 [![npm downloads](https://img.shields.io/npm/dm/@thotischner/observability-mcp?logo=npm&label=downloads)](https://www.npmjs.com/package/@thotischner/observability-mcp)
 [![GHCR](https://img.shields.io/badge/ghcr.io-observability--mcp-2496ED?logo=docker&logoColor=white)](https://github.com/ThoTischner/observability-mcp/pkgs/container/observability-mcp)
@@ -388,7 +388,11 @@ Ideas: new connectors (InfluxDB, Elasticsearch, Datadog), additional analysis al
 
 ## License
 
-MIT
+[Apache License 2.0](LICENSE) — see also [NOTICE](NOTICE).
+
+Releases up to and including the last MIT-licensed version remain available
+under MIT; subsequent releases are Apache-2.0. Contributions require a
+[Contributor License Agreement](CLA.md).
 
 ---
 

--- a/glama.json
+++ b/glama.json
@@ -2,5 +2,6 @@
   "$schema": "https://glama.ai/mcp/schemas/server.json",
   "maintainers": [
     "ThoTischner"
-  ]
+  ],
+  "license": "Apache-2.0"
 }

--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,7 +4,7 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 0.10.1
+version: 0.11.0
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
@@ -33,7 +33,7 @@ maintainers:
 annotations:
   # ArtifactHub: https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/category: monitoring-logging
-  artifacthub.io/license: MIT
+  artifacthub.io/license: Apache-2.0
   artifacthub.io/links: |
     - name: Source
       url: https://github.com/ThoTischner/observability-mcp

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "mcpName": "io.github.ThoTischner/observability-mcp",
   "repository": {
     "type": "git",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -53,7 +53,7 @@ metadata:
     with cross-signal anomaly detection. One MCP endpoint, any backend.
   homepage: https://github.com/ThoTischner/observability-mcp
   documentation: https://github.com/ThoTischner/observability-mcp#readme
-  license: MIT
+  license: Apache-2.0
   categories:
     - observability
     - monitoring


### PR DESCRIPTION
Relicense the core from **MIT → Apache-2.0** and add a **Contributor License Agreement**.

## What

- `LICENSE` → Apache License 2.0 (verbatim) + new `NOTICE`
- License field updated: `package.json` (1.5.0), Helm `Chart.yaml` (0.11.0), `smithery.yaml`, `glama.json`, README badge + section
- `CLA.md` (Apache ICLA-derived, with an explicit relicensing/sublicensing grant) + `.github/workflows/cla.yml` (CLA Assistant) + `CONTRIBUTING.md` section

## Notes

- Sole copyright holder; this is done before any external contribution.
- Releases up to the last MIT version remain available under MIT; subsequent releases are Apache-2.0. **Git history is intentionally not rewritten.**
- After merge: enable the `CLA` status check as a required check on `main` in branch protection (repo settings — maintainer action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)