### PR TITLE
feat: request-scoped context + optional API-key auth

### DIFF
--- a/mcp-server/src/auth/credentials.test.ts
+++ b/mcp-server/src/auth/credentials.test.ts
@@ -1,0 +1,79 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  loadCredentials,
+  credentialsConfigured,
+  extractToken,
+  resolveToken,
+} from "./credentials.js";
+import { queryMetricsHandler } from "../tools/query-metrics.js";
+import { principalContext, defaultContext } from "../context.js";
+
+describe("single-tenant auth primitive", () => {
+  it("unconfigured → no credentials, anonymous (backward compatible)", () => {
+    assert.equal(credentialsConfigured({}), false);
+    assert.deepEqual(loadCredentials({}), []);
+  });
+
+  it("parses name:token and bare token", () => {
+    const creds = loadCredentials({ OMCP_API_KEYS: "ci:tok_abc, tok_bare " });
+    assert.equal(creds.length, 2);
+    assert.deepEqual(
+      creds[0],
+      { name: "ci", token: "tok_abc", allowedSources: undefined }
+    );
+    assert.equal(creds[1].name, "key");
+    assert.equal(creds[1].token, "tok_bare");
+  });
+
+  it("parses per-key source allow-list", () => {
+    const creds = loadCredentials({
+      OMCP_API_KEYS: "agent:tok1,ci:tok2",
+      OMCP_KEY_SOURCES: "agent=prom-prod|loki-prod; ci=prom-staging",
+    });
+    assert.deepEqual(creds[0].allowedSources, ["prom-prod", "loki-prod"]);
+    assert.deepEqual(creds[1].allowedSources, ["prom-staging"]);
+  });
+
+  it("extractToken handles Bearer and X-API-Key", () => {
+    assert.equal(extractToken({ authorization: "Bearer abc" }), "abc");
+    assert.equal(extractToken({ authorization: "bearer  xyz " }), "xyz");
+    assert.equal(extractToken({ "x-api-key": "k1" }), "k1");
+    assert.equal(extractToken({}), null);
+  });
+
+  it("resolveToken matches only an exact token", () => {
+    const creds = loadCredentials({ OMCP_API_KEYS: "a:secret123" });
+    assert.equal(resolveToken("secret123", creds)?.name, "a");
+    assert.equal(resolveToken("secret12", creds), null);
+    assert.equal(resolveToken("wrong", creds), null);
+    assert.equal(resolveToken(null, creds), null);
+  });
+
+  it("coarse source scoping denies an out-of-scope source", async () => {
+    const ctx = principalContext("agent", ["prom-prod"]);
+    const res = await queryMetricsHandler(
+      {} as never,
+      { service: "svc", metric: "cpu", source: "prom-secret" },
+      ctx
+    );
+    const text = res.content[0].text;
+    assert.match(text, /forbidden: source.*prom-secret.*not in your allowed sources/);
+  });
+
+  it("anonymous (no allow-list) does not trigger the scoping guard", async () => {
+    // No allowedSources → guard is a no-op. It must NOT short-circuit with a
+    // forbidden message (it falls through to normal handling, which on a stub
+    // registry may throw — that's fine, it means we passed the guard).
+    try {
+      const res = await queryMetricsHandler(
+        {} as never,
+        { service: "svc", metric: "cpu", source: "anything" },
+        defaultContext()
+      );
+      assert.doesNotMatch(res.content[0].text, /allowed sources/);
+    } catch {
+      // threw past the guard → guard correctly did not fire
+    }
+  });
+});

--- a/mcp-server/src/auth/credentials.ts
+++ b/mcp-server/src/auth/credentials.ts
@@ -1,0 +1,86 @@
+/**
+ * Single-tenant authentication primitive (opt-in, backward compatible).
+ *
+ * If no credentials are configured the server behaves exactly as before
+ * (anonymous, all access). If `OMCP_API_KEYS` is set, the `/mcp` endpoint
+ * requires a valid `Authorization: Bearer <token>` or `X-API-Key: <token>`.
+ *
+ * Config (env, no secrets in files):
+ *   OMCP_API_KEYS="ci:tok_abc,agent:tok_def"   # name:token, comma-separated
+ *                  (a bare "tok_xyz" is allowed; name defaults to "key")
+ *   OMCP_KEY_SOURCES="agent=prom-prod|loki-prod;ci=prom-staging"
+ *                  # optional coarse per-key source allow-list
+ *
+ * Rich role-based access control (tools/services/lookback/read-only, the
+ * full governance object) is intentionally NOT here — this is only the
+ * authentication + identity + coarse source-scoping primitive.
+ */
+
+export interface Credential {
+  name: string;
+  token: string;
+  allowedSources?: string[];
+}
+
+function parseKeySources(raw: string | undefined): Map<string, string[]> {
+  const m = new Map<string, string[]>();
+  if (!raw) return m;
+  for (const entry of raw.split(";").map((s) => s.trim()).filter(Boolean)) {
+    const [name, list] = entry.split("=");
+    if (!name || !list) continue;
+    m.set(
+      name.trim(),
+      list.split("|").map((s) => s.trim()).filter(Boolean)
+    );
+  }
+  return m;
+}
+
+/** Parse credentials from env. Returns an empty list when unconfigured. */
+export function loadCredentials(env: NodeJS.ProcessEnv = process.env): Credential[] {
+  const raw = env.OMCP_API_KEYS?.trim();
+  if (!raw) return [];
+  const keySources = parseKeySources(env.OMCP_KEY_SOURCES);
+  const creds: Credential[] = [];
+  for (const part of raw.split(",").map((s) => s.trim()).filter(Boolean)) {
+    const idx = part.indexOf(":");
+    const name = idx > 0 ? part.slice(0, idx).trim() : "key";
+    const token = (idx > 0 ? part.slice(idx + 1) : part).trim();
+    if (!token) continue;
+    creds.push({ name, token, allowedSources: keySources.get(name) });
+  }
+  return creds;
+}
+
+export function credentialsConfigured(env: NodeJS.ProcessEnv = process.env): boolean {
+  return loadCredentials(env).length > 0;
+}
+
+/** Extract a bearer/api-key token from request headers. */
+export function extractToken(headers: Record<string, unknown>): string | null {
+  const auth = headers["authorization"];
+  if (typeof auth === "string" && /^Bearer\s+/i.test(auth)) {
+    return auth.replace(/^Bearer\s+/i, "").trim() || null;
+  }
+  const apiKey = headers["x-api-key"];
+  if (typeof apiKey === "string" && apiKey.trim()) return apiKey.trim();
+  return null;
+}
+
+/** Constant-time-ish token match → resolved credential, or null. */
+export function resolveToken(
+  token: string | null,
+  creds: Credential[]
+): Credential | null {
+  if (!token) return null;
+  for (const c of creds) {
+    if (c.token.length === token.length && safeEqual(c.token, token)) return c;
+  }
+  return null;
+}
+
+function safeEqual(a: string, b: string): boolean {
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}

--- a/mcp-server/src/context.ts
+++ b/mcp-server/src/context.ts
@@ -1,0 +1,47 @@
+import { randomUUID } from "node:crypto";
+
+/**
+ * Request-scoped context threaded from the transport boundary (HTTP `/mcp`,
+ * stdio, and the internal REST/dashboard call sites) into every tool handler.
+ *
+ * Today it carries only an anonymous principal and a correlation id — it is a
+ * deliberate pass-through that does not change behaviour. It is the single
+ * seam that later access-control / scoping / audit work attaches to, so those
+ * features become additive rather than a cross-cutting rewrite.
+ */
+export interface RequestContext {
+  /** Stable id for the calling principal. "anonymous" when no auth configured. */
+  principalId: string;
+  /** How the principal was authenticated. */
+  auth: "anonymous" | "apikey";
+  /**
+   * Coarse per-credential source allow-list (single-tenant primitive). When
+   * set, the principal may only target these source names. Rich role-based
+   * scoping (tools/services/lookback/read-only) is a separate concern.
+   */
+  allowedSources?: string[];
+  /** Correlates all tool calls within one transport request/session. */
+  correlationId: string;
+}
+
+/** Default all-access anonymous context — preserves current behaviour. */
+export function defaultContext(): RequestContext {
+  return {
+    principalId: "anonymous",
+    auth: "anonymous",
+    correlationId: randomUUID(),
+  };
+}
+
+/** Context for an authenticated API-key principal. */
+export function principalContext(
+  principalId: string,
+  allowedSources?: string[]
+): RequestContext {
+  return {
+    principalId,
+    auth: "apikey",
+    allowedSources: allowedSources && allowedSources.length > 0 ? allowedSources : undefined,
+    correlationId: randomUUID(),
+  };
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -8,6 +8,13 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { loadConfig, saveConfig, DEFAULT_HEALTH_THRESHOLDS, DEFAULT_SETTINGS } from "./config/loader.js";
 import { ConnectorRegistry, getSupportedTypes } from "./connectors/registry.js";
+import { defaultContext, principalContext, type RequestContext } from "./context.js";
+import {
+  loadCredentials,
+  credentialsConfigured,
+  extractToken,
+  resolveToken,
+} from "./auth/credentials.js";
 import { getPluginLoader } from "./connectors/loader.js";
 import {
   resolveHubCatalogUrl,
@@ -122,7 +129,7 @@ async function main() {
   // so we cannot share a single McpServer across HTTP sessions. Each new
   // session needs its own server. The factory captures the live registry
   // by reference so tool handlers always see the current configuration.
-  function createMcpServer(): McpServer {
+  function createMcpServer(ctx: RequestContext): McpServer {
     const mcpServer = new McpServer({
       name: "observability-mcp",
       version: SERVER_VERSION,
@@ -139,7 +146,7 @@ async function main() {
       "Related: use `list_services` to see what is monitored within these sources.",
     ].join(" "),
     {},
-    async () => withToolMetrics("list_sources", () => listSourcesHandler(registry))
+    async () => withToolMetrics("list_sources", () => listSourcesHandler(registry, ctx))
   );
 
   mcpServer.tool(
@@ -158,7 +165,7 @@ async function main() {
           "Optional case-insensitive substring to narrow the result to matching service names (e.g. 'payment'). Omit to list every discovered service.",
         ),
     },
-    async (args) => withToolMetrics("list_services", () => listServicesHandler(registry, args))
+    async (args) => withToolMetrics("list_services", () => listServicesHandler(registry, args, ctx))
   );
 
   const metricsList = getAvailableMetricNames(registry);
@@ -204,7 +211,7 @@ async function main() {
           "Optional. Metric label to break the result down by, e.g. 'instance', 'pod', 'node'. When set, the response contains one series per distinct label value under `groups`. Default: a single aggregated series.",
         ),
     },
-    async (args) => withToolMetrics("query_metrics", () => queryMetricsHandler(registry, args))
+    async (args) => withToolMetrics("query_metrics", () => queryMetricsHandler(registry, args, ctx))
   );
 
   mcpServer.tool(
@@ -248,7 +255,7 @@ async function main() {
           "Optional. Maximum number of log entries to return (most recent first). Default: 100.",
         ),
     },
-    async (args) => withToolMetrics("query_logs", () => queryLogsHandler(registry, args))
+    async (args) => withToolMetrics("query_logs", () => queryLogsHandler(registry, args, ctx))
   );
 
   mcpServer.tool(
@@ -266,7 +273,7 @@ async function main() {
           "Required. Exact, case-sensitive service name exactly as returned by `list_services` (e.g. 'payment-service').",
         ),
     },
-    async (args) => withToolMetrics("get_service_health", () => getServiceHealthHandler(registry, args))
+    async (args) => withToolMetrics("get_service_health", () => getServiceHealthHandler(registry, args, ctx))
   );
 
   mcpServer.tool(
@@ -297,7 +304,7 @@ async function main() {
           "Optional. Detection threshold: 'low' flags only strong deviations (>3σ), 'medium' is balanced (>2σ), 'high' is most sensitive and noisier (>1.5σ). Default: 'medium'.",
         ),
     },
-    async (args) => withToolMetrics("detect_anomalies", () => detectAnomaliesHandler(registry, args))
+    async (args) => withToolMetrics("detect_anomalies", () => detectAnomaliesHandler(registry, args, ctx))
   );
 
     return mcpServer;
@@ -664,7 +671,7 @@ async function main() {
   // List discovered services
   app.get("/api/services", async (_req, res) => {
     try {
-      const result = await listServicesHandler(registry, {});
+      const result = await listServicesHandler(registry, {}, defaultContext());
       res.json(parseToolResult(result));
     } catch { res.status(500).json({ error: "Failed to list services" }); }
   });
@@ -672,7 +679,7 @@ async function main() {
   // Health endpoint for UI dashboard
   app.get("/api/health/:service", async (req, res) => {
     try {
-      const result = await getServiceHealthHandler(registry, { service: req.params.service });
+      const result = await getServiceHealthHandler(registry, { service: req.params.service }, defaultContext());
       res.json(parseToolResult(result));
     } catch {
       res.status(500).json({ error: "Failed to get service health" });
@@ -682,13 +689,13 @@ async function main() {
   // Health for all services
   app.get("/api/health", async (_req, res) => {
     try {
-      const servicesResult = await listServicesHandler(registry, {});
+      const servicesResult = await listServicesHandler(registry, {}, defaultContext());
       const parsed = parseToolResult(servicesResult) as { services?: Array<{ name: string }> };
       const services = parsed?.services || [];
       const health: Record<string, unknown> = {};
       for (const svc of services) {
         try {
-          const result = await getServiceHealthHandler(registry, { service: svc.name });
+          const result = await getServiceHealthHandler(registry, { service: svc.name }, defaultContext());
           health[svc.name] = parseToolResult(result);
         } catch { health[svc.name] = { error: "failed to fetch health" }; }
       }
@@ -779,7 +786,7 @@ async function main() {
 
   // Stdio transport: one server over stdin/stdout, no HTTP listener.
   if (STDIO) {
-    const server = createMcpServer();
+    const server = createMcpServer(defaultContext());
     await server.connect(new StdioServerTransport());
     console.error(
       `observability-mcp running on stdio transport · connectors: ${registry
@@ -808,7 +815,31 @@ async function main() {
     mcpActiveSessions.set(transports.size);
   }, 5 * 60 * 1000);
 
+  // Single-tenant auth gate. No credentials configured → anonymous (current
+  // behaviour, fully backward compatible). Configured → require a valid
+  // Bearer/X-API-Key on every /mcp request; resolve the principal + its
+  // coarse source allow-list into the RequestContext.
+  function gateCtx(
+    req: import("express").Request,
+    res: import("express").Response
+  ): RequestContext | null {
+    if (!credentialsConfigured()) return defaultContext();
+    const cred = resolveToken(
+      extractToken(req.headers as Record<string, unknown>),
+      loadCredentials()
+    );
+    if (!cred) {
+      res
+        .status(401)
+        .json({ error: "unauthorized: valid Bearer token or X-API-Key required" });
+      return null;
+    }
+    return principalContext(cred.name, cred.allowedSources);
+  }
+
   app.post("/mcp", async (req, res) => {
+    const ctx = gateCtx(req, res);
+    if (!ctx) return;
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
     let transport: StreamableHTTPServerTransport;
 
@@ -827,7 +858,7 @@ async function main() {
         mcpActiveSessions.set(transports.size);
       };
 
-      const sessionMcpServer = createMcpServer();
+      const sessionMcpServer = createMcpServer(ctx);
       await sessionMcpServer.connect(transport);
     }
 
@@ -843,6 +874,7 @@ async function main() {
   });
 
   app.get("/mcp", async (req, res) => {
+    if (!gateCtx(req, res)) return;
     const sessionId = req.headers["mcp-session-id"] as string;
     const transport = transports.get(sessionId);
     if (!transport) {
@@ -853,6 +885,7 @@ async function main() {
   });
 
   app.delete("/mcp", async (req, res) => {
+    if (!gateCtx(req, res)) return;
     const sessionId = req.headers["mcp-session-id"] as string;
     const transport = transports.get(sessionId);
     if (transport) {

--- a/mcp-server/src/tools/context-seam.test.ts
+++ b/mcp-server/src/tools/context-seam.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Keystone guard: every tool handler must accept the RequestContext seam.
+// This prevents a new handler (or a refactor) from silently bypassing the
+// request-scoped context that access-control / scoping / audit attach to.
+const here = dirname(fileURLToPath(import.meta.url));
+
+describe("RequestContext seam", () => {
+  const handlerFiles = readdirSync(here).filter(
+    (f) => f.endsWith(".ts") && !f.endsWith(".test.ts")
+  );
+
+  for (const file of handlerFiles) {
+    const src = readFileSync(join(here, file), "utf8");
+    const hasHandler = /export\s+(async\s+)?function\s+\w*Handler\s*\(/.test(src);
+    if (!hasHandler) continue;
+
+    it(`${file}: handler accepts a RequestContext`, () => {
+      assert.match(
+        src,
+        /_ctx:\s*RequestContext/,
+        `${file} exports a *Handler but does not thread RequestContext — ` +
+          `add the ctx seam (see context.ts)`
+      );
+      assert.match(
+        src,
+        /from "\.\.\/context\.js"/,
+        `${file} must import from ../context.js`
+      );
+    });
+  }
+});

--- a/mcp-server/src/tools/detect-anomalies.ts
+++ b/mcp-server/src/tools/detect-anomalies.ts
@@ -1,4 +1,5 @@
 import type { ConnectorRegistry } from "../connectors/registry.js";
+import { defaultContext, type RequestContext } from "../context.js";
 import type { AnomalyReport } from "../types.js";
 import { detectAnomaly, classifyMetric } from "../analysis/anomaly.js";
 import { rankRootCause } from "../analysis/correlator.js";
@@ -44,7 +45,8 @@ const CRITICAL_LOG_PATTERN =
 
 export async function detectAnomaliesHandler(
   registry: ConnectorRegistry,
-  args: { service?: string; duration?: string; sensitivity?: string }
+  args: { service?: string; duration?: string; sensitivity?: string },
+  _ctx: RequestContext = defaultContext()
 ) {
   const duration = args.duration || "10m";
   const threshold = SENSITIVITY_THRESHOLDS[args.sensitivity || "medium"] || 2.0;

--- a/mcp-server/src/tools/get-service-health.ts
+++ b/mcp-server/src/tools/get-service-health.ts
@@ -1,4 +1,5 @@
 import type { ConnectorRegistry } from "../connectors/registry.js";
+import { defaultContext, type RequestContext } from "../context.js";
 import type { ServiceHealth, AnomalyReport, HealthThresholds } from "../types.js";
 import { calculateHealthScore } from "../analysis/health.js";
 import { detectRecentAnomaly } from "../analysis/anomaly.js";
@@ -28,7 +29,8 @@ export const getServiceHealthDefinition = {
 
 export async function getServiceHealthHandler(
   registry: ConnectorRegistry,
-  args: { service: string }
+  args: { service: string },
+  _ctx: RequestContext = defaultContext()
 ) {
   const metricsConnectors = registry.getBySignal("metrics");
   const logConnectors = registry.getBySignal("logs");

--- a/mcp-server/src/tools/list-services.ts
+++ b/mcp-server/src/tools/list-services.ts
@@ -1,5 +1,6 @@
 import type { ConnectorRegistry } from "../connectors/registry.js";
 import type { ServiceInfo } from "../types.js";
+import { defaultContext, type RequestContext } from "../context.js";
 
 export const listServicesDefinition = {
   name: "list_services" as const,
@@ -18,7 +19,8 @@ export const listServicesDefinition = {
 
 export async function listServicesHandler(
   registry: ConnectorRegistry,
-  args: { filter?: string }
+  args: { filter?: string },
+  _ctx: RequestContext = defaultContext()
 ) {
   const connectors = registry.getAll();
   const allServices: ServiceInfo[] = [];

--- a/mcp-server/src/tools/list-sources.ts
+++ b/mcp-server/src/tools/list-sources.ts
@@ -1,4 +1,5 @@
 import type { ConnectorRegistry } from "../connectors/registry.js";
+import { defaultContext, type RequestContext } from "../context.js";
 
 export const listSourcesDefinition = {
   name: "list_sources" as const,
@@ -10,7 +11,10 @@ export const listSourcesDefinition = {
   },
 };
 
-export async function listSourcesHandler(registry: ConnectorRegistry) {
+export async function listSourcesHandler(
+  registry: ConnectorRegistry,
+  _ctx: RequestContext = defaultContext()
+) {
   const healthResults = await registry.healthCheckAll();
   const connectors = registry.getAll();
 

--- a/mcp-server/src/tools/query-logs.ts
+++ b/mcp-server/src/tools/query-logs.ts
@@ -1,4 +1,5 @@
 import type { ConnectorRegistry } from "../connectors/registry.js";
+import { defaultContext, type RequestContext } from "../context.js";
 import type { LogResult } from "../types.js";
 import { validateDuration, validateServiceName, errorResponse } from "./validation.js";
 
@@ -36,7 +37,8 @@ export const queryLogsDefinition = {
 
 export async function queryLogsHandler(
   registry: ConnectorRegistry,
-  args: { service: string; query?: string; duration?: string; level?: string; limit?: number }
+  args: { service: string; query?: string; duration?: string; level?: string; limit?: number },
+  _ctx: RequestContext = defaultContext()
 ) {
   const svcErr = validateServiceName(args.service);
   if (svcErr) return errorResponse(svcErr);

--- a/mcp-server/src/tools/query-metrics.ts
+++ b/mcp-server/src/tools/query-metrics.ts
@@ -1,4 +1,5 @@
 import type { ConnectorRegistry } from "../connectors/registry.js";
+import { defaultContext, type RequestContext } from "../context.js";
 import type { MetricResult } from "../types.js";
 import { validateDuration, validateMetricName, validateServiceName, errorResponse } from "./validation.js";
 
@@ -38,8 +39,20 @@ export const queryMetricsDefinition = {
 
 export async function queryMetricsHandler(
   registry: ConnectorRegistry,
-  args: { service: string; metric: string; duration?: string; source?: string; groupBy?: string }
+  args: { service: string; metric: string; duration?: string; source?: string; groupBy?: string },
+  _ctx: RequestContext = defaultContext()
 ) {
+  // Coarse single-tenant source scoping: if the principal is restricted to a
+  // source allow-list, deny an explicit out-of-scope source.
+  if (
+    _ctx.allowedSources &&
+    args.source &&
+    !_ctx.allowedSources.includes(args.source)
+  ) {
+    return errorResponse(
+      `forbidden: source "${args.source}" is not in your allowed sources`
+    );
+  }
   const svcErr = validateServiceName(args.service);
   if (svcErr) return errorResponse(svcErr);
   const duration = args.duration || "5m";


### PR DESCRIPTION
## What

- **RequestContext seam** — a request-scoped context is threaded from the transport boundary through `createMcpServer` into every tool handler. Default is anonymous all-access → **zero behaviour change**. A guard test (`context-seam.test.ts`) keeps every handler on the seam.
- **Opt-in single-tenant auth** — set `OMCP_API_KEYS` (`name:token,…`, optional `OMCP_KEY_SOURCES`) and `/mcp` (POST/GET/DELETE) requires a `Bearer`/`X-API-Key`; the principal + a coarse per-key source allow-list land in the context. **No keys → unchanged, fully backward compatible.**

## Tests

`context-seam` + `credentials` suites green; full suite unchanged except the 4 pre-existing, unrelated prometheus/registry failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)