### PR TITLE
ci(cla): grant contents:write so the signature store can be created

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   actions: write
-  contents: read
+  contents: write
   pull-requests: write
   statuses: write
 


### PR DESCRIPTION
The CLA Assistant action could not create the `cla-signatures` storage branch (`Resource not accessible by integration`) because the workflow only had `contents: read`. Grant `contents: write` — sufficient for same-repo PRs, no PAT needed.

After this lands and the check goes green on a PR, the `cla` status check can be added to the `main` ruleset's required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)