### PR TITLE
feat(analysis): embeddable analysis library

### DIFF
--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -25,6 +25,13 @@
     "observability-mcp": "./dist/index.js",
     "omcp": "./dist/cli/index.js"
   },
+  "exports": {
+    ".": "./dist/index.js",
+    "./analysis": {
+      "types": "./dist/analysis/index.d.ts",
+      "default": "./dist/analysis/index.js"
+    }
+  },
   "files": [
     "dist",
     "config"

--- a/mcp-server/src/analysis/health.ts
+++ b/mcp-server/src/analysis/health.ts
@@ -1,6 +1,6 @@
 import type { HealthStatus, HealthThresholds } from "../types.js";
 
-interface HealthInputs {
+export interface HealthInputs {
   cpu: number;
   memory: number;
   errorRate: number;
@@ -8,7 +8,7 @@ interface HealthInputs {
   logErrorRate: number;
 }
 
-interface HealthResult {
+export interface HealthResult {
   score: number;
   status: HealthStatus;
   details: Record<string, { score: number; value: number; threshold: string }>;

--- a/mcp-server/src/analysis/index.ts
+++ b/mcp-server/src/analysis/index.ts
@@ -1,0 +1,67 @@
+/**
+ * Embeddable analysis library — the deterministic analysis engine
+ * (anomaly detection, seasonality, causal root-cause, health scoring) usable
+ * in-process, without running the MCP server or any transport.
+ *
+ *   import { analyzeMetric, rankRootCause, calculateHealthScore }
+ *     from "@thotischner/observability-mcp/analysis";
+ *
+ * Same code path as the MCP tools — verdicts are identical whether reached via
+ * the gateway or this library.
+ */
+
+export {
+  // robust + seasonal + orchestrated anomaly detection
+  detectAnomaly,
+  detectRobustAnomaly,
+  detectSeasonalAnomaly,
+  detectRecentAnomaly,
+  detectAnomalyPoints,
+  calculateZScore,
+  classifyMetric,
+  median,
+  mad,
+  type MetricKind,
+  type SeasonalPoint,
+  type SeasonalAnomalyOptions,
+  type SeasonalAnomalyResult,
+  type RobustAnomalyOptions,
+  type RobustAnomalyResult,
+  type AnomalyPoint,
+  type ZScoreResult,
+} from "./anomaly.js";
+
+export {
+  correlateSignals,
+  rankRootCause,
+  type ServiceEdge,
+  type RankInputAnomaly,
+  type ChangeMarker,
+  type RootCauseCandidate,
+  type RootCauseResult,
+} from "./correlator.js";
+
+export {
+  calculateHealthScore,
+  type HealthInputs,
+  type HealthResult,
+} from "./health.js";
+
+import { detectAnomaly, classifyMetric, type SeasonalPoint } from "./anomaly.js";
+
+/**
+ * One-call façade: classify the metric by name and run the orchestrated
+ * detector (seasonal when enough history, else robust). Thin convenience over
+ * {@link detectAnomaly}; identical result to calling it directly with the
+ * classified `metricKind`.
+ */
+export function analyzeMetric(
+  metric: string,
+  points: SeasonalPoint[],
+  opts: { threshold?: number } = {}
+) {
+  return detectAnomaly(points, {
+    metricKind: classifyMetric(metric),
+    threshold: opts.threshold,
+  });
+}

--- a/mcp-server/src/analysis/library.test.ts
+++ b/mcp-server/src/analysis/library.test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as lib from "./index.js";
+import { detectAnomaly } from "./anomaly.js";
+
+// Contract test for the embeddable analysis library surface. Guards that the
+// public API stays importable in-process (no MCP/transport) and that the
+// analyzeMetric façade is exactly the engine path, not a divergent reimpl.
+describe("embeddable analysis library", () => {
+  it("exposes the documented public API", () => {
+    for (const name of [
+      "detectAnomaly",
+      "detectRobustAnomaly",
+      "detectSeasonalAnomaly",
+      "rankRootCause",
+      "correlateSignals",
+      "calculateHealthScore",
+      "classifyMetric",
+      "analyzeMetric",
+    ]) {
+      assert.equal(typeof (lib as Record<string, unknown>)[name], "function", `missing export: ${name}`);
+    }
+  });
+
+  it("analyzeMetric is identical to detectAnomaly with classified kind", () => {
+    const points = Array.from({ length: 40 }, (_, i) => ({
+      timestamp: 1_700_000_000_000 + i * 60_000,
+      value: i < 30 ? 50 + (i % 3) : 800,
+    }));
+    const viaFacade = lib.analyzeMetric("latency_p99", points);
+    const viaEngine = detectAnomaly(points, { metricKind: "latency" });
+    assert.deepEqual(viaFacade, viaEngine);
+  });
+
+  it("health scoring is callable standalone", () => {
+    const r = lib.calculateHealthScore(
+      { cpu: 20, memory: 30, errorRate: 0, latencyP99: 0.2, logErrorRate: 0 },
+      {
+        weights: { errorRate: 1, latency: 1, cpu: 1, logErrors: 1 },
+        cpu: { good: 50, warn: 80, crit: 95 },
+        errorRate: { good: 1, warn: 5, crit: 10 },
+        latencyP99: { good: 0.5, warn: 1, crit: 2 },
+        logErrors: { good: 1, warn: 5, crit: 10 },
+        statusBoundaries: { healthy: 80, degraded: 50 },
+      }
+    );
+    assert.ok(r.score >= 0 && r.score <= 100);
+    assert.ok(["healthy", "degraded", "critical"].includes(r.status as string));
+  });
+});


### PR DESCRIPTION
## What

The deterministic analysis engine is now usable **in-process as a library**, not only via the MCP transport:

- `src/analysis/index.ts` barrel re-exporting the public anomaly / seasonality / causal-root-cause / health API
- `package.json` `exports` subpath `./analysis` (typed)
- `analyzeMetric()` one-call façade — classifies the metric and runs the orchestrated detector; identical result to calling the engine directly
- `HealthInputs`/`HealthResult` exported

## Tests

`library.test.ts` (3): API surface present, `analyzeMetric` ≡ `detectAnomaly` parity, standalone health scoring. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)