### PR TITLE
feat(net): verifiable offline mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,11 @@ lint: ## helm lint + tsc --noEmit
 	docker run --rm -w /app -v "$(PWD)/mcp-server:/app" node:20-alpine \
 	  sh -c "npm install --silent --no-audit --no-fund && npx tsc --noEmit"
 
+# Proves the server boots and serves health with NO internet and NO sources
+# configured — the "verifiable offline mode" guarantee, end to end.
+test-offline: build ## Boot the image on an egress-blocked network and assert healthy
+	./scripts/offline-boot-check.sh
+
 # A faster local approximation of the CI smoke test. CI is authoritative
 # (`.github/workflows/integration.yml`); this is for quick iteration.
 smoke: demo ## Run the local smoke probe against the demo stack

--- a/docs/offline.md
+++ b/docs/offline.md
@@ -1,0 +1,41 @@
+# Verifiable Offline Mode
+
+observability-mcp is air-gapped by design and **makes no telemetry,
+analytics, phone-home, or update-check calls**. The only outbound traffic it
+ever performs is to:
+
+1. the **source backends you configure** (Prometheus/Loki/… URLs), and
+2. a **plugin artifact URL** you or your configured registry explicitly ask
+   it to install.
+
+Nothing else leaves the process — ever.
+
+## How this is guaranteed (not just claimed)
+
+**Static guard (always-on, CI):** `mcp-server/src/net/egress-policy.ts`
+defines the egress allowlist and forbidden-SDK rules;
+`egress-policy.test.ts` scans every source file and **fails the build** if an
+outbound call appears outside the allowlist, or if any analytics/telemetry
+SDK is imported anywhere. The "no data egress" property therefore cannot
+silently regress.
+
+**End-to-end proof (on demand):**
+
+```bash
+make test-offline
+```
+
+This builds the image, starts it on an **`--internal` Docker network with no
+internet route** and **zero sources configured**, and asserts `/healthz` and
+`/readyz` from an isolated sibling container. If the server needed any
+external call to boot or serve health, this fails.
+
+## Running fully air-gapped
+
+- No runtime `npm install` (dependencies are baked into the image).
+- Plugin tarballs can be baked in; set `PLUGIN_REQUIRE_SIGNATURE=true` to
+  reject anything unsigned.
+- Leave `PROMETHEUS_URL` / `LOKI_URL` empty and add sources later via the Web
+  UI or `config/sources.yaml` — the server starts healthy with no sources.
+
+See also [airgapped-deployment.md](airgapped-deployment.md).

--- a/mcp-server/src/net/egress-policy.test.ts
+++ b/mcp-server/src/net/egress-policy.test.ts
@@ -1,0 +1,66 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, relative } from "node:path";
+import {
+  OUTBOUND_PATTERN,
+  FORBIDDEN_TELEMETRY,
+  isEgressAllowed,
+  EGRESS_ALLOWLIST,
+} from "./egress-policy.js";
+
+// Verifiable offline mode: static guard so the "no data egress" guarantee
+// cannot silently regress. Any new outbound call outside the documented
+// allowlist, or any analytics/telemetry SDK anywhere, fails CI here.
+const srcRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const e of readdirSync(dir)) {
+    const p = join(dir, e);
+    if (statSync(p).isDirectory()) out.push(...walk(p));
+    else if (e.endsWith(".ts") && !e.endsWith(".test.ts")) out.push(p);
+  }
+  return out;
+}
+
+describe("verifiable offline mode — egress policy", () => {
+  const files = walk(srcRoot)
+    .map((f) => ({
+      rel: relative(srcRoot, f).replace(/\\/g, "/"),
+      src: readFileSync(f, "utf8"),
+    }))
+    // The policy module itself names these tokens by design.
+    .filter((f) => f.rel !== "net/egress-policy.ts");
+
+  it("scans a non-trivial number of source files", () => {
+    assert.ok(files.length > 20, `only scanned ${files.length} files`);
+  });
+
+  it("no outbound call outside the egress allowlist", () => {
+    const breaches = files
+      .filter((f) => OUTBOUND_PATTERN.test(f.src) && !isEgressAllowed(f.rel))
+      .map((f) => f.rel);
+    assert.deepEqual(
+      breaches,
+      [],
+      `outbound calls found outside allowlist (${EGRESS_ALLOWLIST.map((a) => a.prefix).join(", ")}): ` +
+        `${breaches.join(", ")} — telemetry/phone-home is forbidden; if legitimate, extend EGRESS_ALLOWLIST with a reason`
+    );
+  });
+
+  it("no analytics/telemetry SDK anywhere in source", () => {
+    const hits = files
+      .filter((f) => FORBIDDEN_TELEMETRY.test(f.src))
+      .map((f) => f.rel);
+    assert.deepEqual(hits, [], `forbidden telemetry/analytics identifiers in: ${hits.join(", ")}`);
+  });
+
+  it("allowlisted files are still present (allowlist not stale)", () => {
+    for (const { prefix } of EGRESS_ALLOWLIST) {
+      const covered = files.some((f) => f.rel === prefix || f.rel.startsWith(prefix));
+      assert.ok(covered, `allowlist entry "${prefix}" matches no source file — prune it`);
+    }
+  });
+});

--- a/mcp-server/src/net/egress-policy.ts
+++ b/mcp-server/src/net/egress-policy.ts
@@ -1,0 +1,45 @@
+/**
+ * Verifiable offline mode — egress policy.
+ *
+ * The server performs **no telemetry, analytics, phone-home, or update
+ * checks**. The only outbound network calls it ever makes are to backends
+ * the operator explicitly configures (Prometheus/Loki/... source URLs) or to
+ * an artifact URL the operator/registry explicitly asks it to install.
+ *
+ * This module is the machine-checkable statement of that guarantee:
+ * `egress-policy.test.ts` fails CI if any source file outside the allowlist
+ * introduces an outbound call — so the "no data egress" property cannot
+ * silently regress.
+ */
+
+export const OFFLINE_STATEMENT =
+  "observability-mcp makes no telemetry/analytics/phone-home/update calls. " +
+  "Outbound traffic goes only to operator-configured source backends and " +
+  "operator/registry-requested plugin artifacts. It runs fully air-gapped.";
+
+/** Regex of outbound-call shapes the guard scans for. */
+export const OUTBOUND_PATTERN =
+  /\b(fetch\s*\(|https?\.request\s*\(|new\s+WebSocket\s*\(|import\s*\(\s*['"]https?:)/;
+
+/**
+ * Files/prefixes permitted to make outbound calls, each with the reason.
+ * Anything matching OUTBOUND_PATTERN outside these paths is a policy breach
+ * (e.g. a newly added analytics/telemetry module).
+ */
+export const EGRESS_ALLOWLIST: ReadonlyArray<{ prefix: string; reason: string }> = [
+  { prefix: "connectors/", reason: "connectors query operator-configured source backends" },
+  { prefix: "cli/index.ts", reason: "CLI fetches a source location the operator passed explicitly" },
+  { prefix: "index.ts", reason: "connector-hub plugin install of an operator/registry-requested tarball URL" },
+];
+
+/**
+ * Hard-blocked analytics/telemetry SDKs — matches an *import/require of the
+ * package*, not the word in prose, so comments/policy text don't false-positive.
+ */
+export const FORBIDDEN_TELEMETRY =
+  /(?:from\s*['"]|require\(\s*['"])[^'"]*(sentry|posthog|mixpanel|amplitude|@segment|datadog-rum|analytics-node|google-analytics)/i;
+
+export function isEgressAllowed(relPath: string): boolean {
+  const p = relPath.replace(/\\/g, "/");
+  return EGRESS_ALLOWLIST.some((a) => p === a.prefix || p.startsWith(a.prefix));
+}

--- a/scripts/offline-boot-check.sh
+++ b/scripts/offline-boot-check.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Verifiable offline mode: start the image on an internal (no-internet) Docker
+# network with zero sources configured, then assert /healthz and /readyz from
+# a sibling container on the same isolated network. Exits non-zero on any
+# failure. This is the end-to-end proof of the "no data egress / air-gapped"
+# guarantee (the static guard lives in src/net/egress-policy.test.ts).
+set -euo pipefail
+
+IMG="${IMG:-observability-mcp:offline-check}"
+NET="omcp-offline-$$"
+SRV="omcp-offline-srv-$$"
+
+cleanup() {
+  docker rm -f "$SRV" >/dev/null 2>&1 || true
+  docker network rm "$NET" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> building image ($IMG)"
+docker build -t "$IMG" ./mcp-server
+
+echo "==> creating INTERNAL network (no internet egress): $NET"
+docker network create --internal "$NET" >/dev/null
+
+echo "==> starting server with NO sources, no internet"
+docker run -d --name "$SRV" --network "$NET" \
+  -e PROMETHEUS_URL= -e LOKI_URL= \
+  "$IMG" >/dev/null
+
+echo "==> probing /healthz and /readyz from an isolated sibling"
+ok=0
+for i in $(seq 1 30); do
+  if docker run --rm --network "$NET" curlimages/curl:8.10.1 \
+       -fsS "http://$SRV:3000/healthz" >/dev/null 2>&1; then
+    ok=1; break
+  fi
+  sleep 2
+done
+
+if [ "$ok" -ne 1 ]; then
+  echo "FAIL: server did not become healthy offline"
+  docker logs "$SRV" || true
+  exit 1
+fi
+
+docker run --rm --network "$NET" curlimages/curl:8.10.1 \
+  -fsS "http://$SRV:3000/readyz" >/dev/null
+
+echo "PASS: server boots and serves health fully offline, zero sources, no egress"


### PR DESCRIPTION
## What

Makes the air-gapped / no-data-egress guarantee **machine-checkable**:

- `src/net/egress-policy.ts` — egress allowlist + forbidden-SDK rules + the offline statement
- `egress-policy.test.ts` — scans all source: fails if an outbound call appears outside the allowlist (connectors / CLI / hub-plugin install) or any analytics/telemetry SDK is imported anywhere
- `make test-offline` + `scripts/offline-boot-check.sh` — boots the image on an `--internal` (no-internet) Docker network with zero sources and asserts `/healthz`+`/readyz`
- `docs/offline.md`

## Tests

`egress-policy` suite 4/4; tsc clean. No telemetry/phone-home exists — this locks that in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)