### PR TITLE
fix(demo): sovereign quickstart — strong, self-verified signal

### DIFF
--- a/scripts/demo-sovereign.sh
+++ b/scripts/demo-sovereign.sh
@@ -4,14 +4,17 @@
 # Brings up the demo stack, injects a real incident, and shows the contrast
 # an AI agent sees WITHOUT vs WITH the analysis layer:
 #   - RAW   : a Prometheus query returns a wall of numbers, no verdict.
-#   - ANALYZED: /api/health returns a scored verdict that pinpoints the
-#               failing service and why.
+#   - ANALYZED: /api/health returns a scored verdict that drops the failing
+#               service out of "healthy" and surfaces correlated signals.
 #
 # The proof is deterministic and needs no LLM. The optional `agent` service
 # in the demo profile consumes exactly this analyzed layer using a LOCAL
 # model (Ollama on host.docker.internal) — nothing leaves the host. The
 # "no data egress" guarantee is enforced separately (`make test-offline`,
 # src/net/egress-policy.test.ts).
+#
+# Self-verifying: if the analyzed layer does NOT flag the injected incident,
+# the script exits non-zero (a demo must never silently show "all healthy").
 set -euo pipefail
 
 CHAOS="http://localhost:8081"
@@ -20,6 +23,7 @@ PROM="http://localhost:9090"
 KEEP_UP="${KEEP_UP:-0}"
 
 say() { printf '\n\033[1m== %s ==\033[0m\n' "$*"; }
+have_jq() { command -v jq >/dev/null 2>&1; }
 
 cleanup() {
   curl -fsS -X POST "$CHAOS/chaos/reset" >/dev/null 2>&1 || true
@@ -40,21 +44,36 @@ done
 curl -fsS "$MCP/healthz" >/dev/null
 
 say "Baseline — analyzed health of all services (no incident yet)"
-curl -fsS "$MCP/api/health" | (jq '[.[] | {service, status, score}]' 2>/dev/null || cat)
+curl -fsS "$MCP/api/health" | (have_jq && jq '[.[] | {service, status, score}]' || cat)
 
-say "Injecting a real incident: memory leak on payment-service"
-for _ in 1 2 3 4; do curl -fsS -X POST "$CHAOS/chaos/memory-leak" >/dev/null; sleep 30; done
+# error-spike is the canonical correlated incident: it drives error rate,
+# CPU and latency together, so the analyzed layer must clearly flag it.
+say "Injecting a real incident: error-spike on payment-service"
+curl -fsS -X POST "$CHAOS/chaos/error-spike" >/dev/null
+echo "waiting ~75s for the signal to build in Prometheus/Loki..."
+for _ in 1 2 3 4 5; do curl -fsS -X POST "$CHAOS/chaos/error-spike" >/dev/null; sleep 15; done
 
 say "RAW — what an agent gets WITHOUT the analysis layer (Prometheus, no verdict)"
-curl -fsS "$PROM/api/v1/query?query=service_memory_usage_bytes%7Bjob%3D%22payment-service%22%7D" \
-  | (jq -c '.data.result[0:3]' 2>/dev/null || cat)
+curl -fsS "$PROM/api/v1/query?query=rate%28http_requests_total%7Bjob%3D%22payment-service%22%7D%5B1m%5D%29" \
+  | (have_jq && jq -c '.data.result[0:4]' || cat)
 echo "  ^ raw numbers. No 'is this bad?', no culprit, no mechanism."
 
 say "ANALYZED — what the agent gets WITH the layer (scored verdict + culprit)"
-curl -fsS "$MCP/api/health/payment-service" \
-  | (jq '{service, status, score, signals, anomalies}' 2>/dev/null || cat)
+PAY=$(curl -fsS "$MCP/api/health/payment-service")
+echo "$PAY" | (have_jq && jq '{service, status, score, signals, anomalies, correlations}' || cat)
+say "ANALYZED — services no longer healthy"
 curl -fsS "$MCP/api/health" \
-  | (jq '[.[] | select(.status != "healthy") | {service, status, score}]' 2>/dev/null || cat)
+  | (have_jq && jq '[.[] | select(.status != "healthy") | {service, status, score}]' || cat)
+
+# --- Self-verification: the analyzed layer MUST have caught it ----------
+status=$(echo "$PAY" | (have_jq && jq -r '.status' || sed -n 's/.*"status":"\([a-z]*\)".*/\1/p' | head -1))
+score=$(echo "$PAY" | (have_jq && jq -r '.score' || sed -n 's/.*"score":\([0-9]*\).*/\1/p' | head -1))
+echo "payment-service verdict: status=${status:-?} score=${score:-?}"
+if [ "${status:-healthy}" = "healthy" ]; then
+  echo "FAIL: analyzed layer did not flag the injected incident (still healthy)" >&2
+  exit 1
+fi
+echo "PASS: the analyzed layer flagged payment-service as ${status} — raw Prometheus did not."
 
 say "Sovereign summary"
 cat <<'EOF'


### PR DESCRIPTION
## Why

Found by running the merged demo end-to-end (not just `bash -n`): the memory-leak scenario left payment-service `healthy` (score 90), so `demo-sovereign` did **not** actually demonstrate the analysis layer catching the incident, and the "non-healthy" summary surfaced a noise anomaly on the wrong service.

## What

- Switch the injected incident to **error-spike** (correlated error-rate + cpu + latency + error logs) — a deterministic, strong signal.
- Add a **hard self-assertion**: the script exits non-zero if the analyzed verdict for payment-service is still `healthy`. A demo must never silently show "all healthy".

## Verified end-to-end (real run, not syntax-only)

- payment-service → `degraded`, score 70; `error_rate` anomaly (2.0σ, +125%); correlation: "2 metric anomalies alongside 15 error logs … Top: POST /payments (11x)".
- "no longer healthy" filter shows **only** payment-service (no false positives).
- Assertion: `PASS … flagged payment-service as degraded — raw Prometheus did not.` (exit 0).

Follow-up (separate PR): `/api/health` flags a *negative* latency deviation as `high` severity — a one-sided-metric bug in that detector path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)