### PR TITLE
fix(health): one-sided detector for /api/health anomalies

### DIFF
--- a/mcp-server/src/tools/get-service-health.ts
+++ b/mcp-server/src/tools/get-service-health.ts
@@ -2,7 +2,7 @@ import type { ConnectorRegistry } from "../connectors/registry.js";
 import { defaultContext, type RequestContext } from "../context.js";
 import type { ServiceHealth, AnomalyReport, HealthThresholds } from "../types.js";
 import { calculateHealthScore } from "../analysis/health.js";
-import { detectRecentAnomaly } from "../analysis/anomaly.js";
+import { detectRobustAnomaly, classifyMetric } from "../analysis/anomaly.js";
 import { sanitizeForLog } from "../util/sanitize.js";
 
 let _thresholds: HealthThresholds | null = null;
@@ -121,17 +121,20 @@ function checkAnomaly(
   source: string,
   anomalies: AnomalyReport[]
 ) {
-  const result = detectRecentAnomaly(values);
+  // Robust, metric-type-aware detector (same path as detect_anomalies):
+  // latency/error_rate/saturation are one-sided, so a *decrease* (e.g.
+  // latency dropping) is correctly NOT flagged as an anomaly.
+  const result = detectRobustAnomaly(values, { metricKind: classifyMetric(metric) });
   if (result.isAnomaly) {
-    const deviationPercent = result.baselineAvg === 0
+    const deviationPercent = result.baselineValue === 0
       ? 100
-      : Math.round(((result.recentAvg - result.baselineAvg) / result.baselineAvg) * 100);
+      : Math.round(((result.recentValue - result.baselineValue) / result.baselineValue) * 100);
     anomalies.push({
       metric,
-      severity: Math.abs(result.zScore) >= 3 ? "high" : Math.abs(result.zScore) >= 2 ? "medium" : "low",
-      description: `${metric} is ${result.zScore.toFixed(1)}σ ${result.zScore > 0 ? "above" : "below"} baseline (${result.baselineAvg.toFixed(2)} → ${result.recentAvg.toFixed(2)})`,
-      currentValue: result.recentAvg,
-      baselineValue: result.baselineAvg,
+      severity: Math.abs(result.score) >= 6 ? "high" : Math.abs(result.score) >= 4 ? "medium" : "low",
+      description: `${metric}: ${result.reason}`,
+      currentValue: result.recentValue,
+      baselineValue: result.baselineValue,
       deviationPercent,
       source,
       service,

--- a/mcp-server/src/tools/handlers.test.ts
+++ b/mcp-server/src/tools/handlers.test.ts
@@ -5,6 +5,7 @@ import { DEFAULT_SETTINGS, DEFAULT_HEALTH_THRESHOLDS } from "../config/loader.js
 import { listSourcesHandler } from "./list-sources.js";
 import { listServicesHandler } from "./list-services.js";
 import { detectAnomaliesHandler } from "./detect-anomalies.js";
+import { getServiceHealthHandler } from "./get-service-health.js";
 import type { Config, ServiceInfo, MetricResult, LogResult, ConnectorHealth, MetricDefinition, SignalType } from "../types.js";
 import type { ObservabilityConnector } from "../connectors/interface.js";
 
@@ -224,5 +225,37 @@ describe("detectAnomaliesHandler — A5 memory/OOM coverage", () => {
     const result = await detectAnomaliesHandler(reg, {});
     const data = JSON.parse(result.content[0].text);
     assert.equal(data.anomalies.length, 0);
+  });
+});
+
+describe("getServiceHealthHandler — one-sided latency (regression)", () => {
+  const series = (vals: number[]): MetricResult => ({
+    source: "prom1", service: "payment-service", metric: "x", unit: "",
+    values: vals.map((v, i) => ({ timestamp: new Date(Date.now() - (vals.length - i) * 9000).toISOString(), value: v })),
+    summary: { current: vals[vals.length - 1], average: vals[0], min: Math.min(...vals), max: Math.max(...vals), trend: "falling" as const },
+  });
+
+  it("a DECREASING latency_p99 is NOT flagged as an anomaly", async () => {
+    const reg = new ConnectorRegistry();
+    const mock = {
+      connect: async () => {}, disconnect: async () => {},
+      healthCheck: async () => ({ status: "up" as const, latencyMs: 1 }),
+      getDefaultMetrics: () => [], getMetrics: () => [],
+      listServices: async () => [{ name: "payment-service", source: "prom1", signalType: "metrics" as const }],
+      name: "prom1", type: "prometheus", signalType: "metrics" as const,
+      queryMetrics: async ({ metric }: any) => {
+        if (metric === "latency_p99")
+          return series(Array.from({ length: 30 }, (_, i) => 1.0 - i * 0.025)); // 1.0 → 0.275, strictly down
+        if (metric === "cpu") return series(Array.from({ length: 30 }, () => 20 + (Math.random() < 0 ? 1 : 0)));
+        return series(Array.from({ length: 30 }, () => 0.01)); // error_rate flat
+      },
+    } as unknown as ObservabilityConnector;
+    (reg as any).connectors.set("prom1", mock);
+    (reg as any).sourceConfigs.set("prom1", { name: "prom1", type: "prometheus", url: "http://m", enabled: true });
+
+    const result = await getServiceHealthHandler(reg, { service: "payment-service" });
+    const data = JSON.parse(result.content[0].text);
+    const latAnom = (data.anomalies || []).find((a: any) => a.metric === "latency_p99");
+    assert.equal(latAnom, undefined, `latency dropping must not be an anomaly, got: ${JSON.stringify(latAnom)}`);
   });
 });


### PR DESCRIPTION
## Why

Surfaced by the real `demo-sovereign` run: `/api/health` reported `latency_p99 is -5.0σ below baseline … severity high` — a latency *drop* (good) flagged as a high anomaly. `get_service_health` still used the legacy two-sided `detectRecentAnomaly`.

## What

Switch `checkAnomaly` to `detectRobustAnomaly` + `classifyMetric` — the same hardened, metric-type-aware path `detect_anomalies` uses. latency/error_rate/saturation are one-sided, so an improvement is correctly not flagged. Severity/description aligned with `detect_anomalies`.

## Tests

+ handler-level regression: a strictly decreasing `latency_p99` series through the real `getServiceHealthHandler` yields **no** latency anomaly. Full suite 205 pass; the 4 failures are the pre-existing unrelated prometheus/registry ones. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)