### PR TITLE
feat(connectors): Grafana Tempo connector — trace-derived service latency

### DIFF
--- a/connectors/tempo/contract/contract.mjs
+++ b/connectors/tempo/contract/contract.mjs
@@ -1,0 +1,54 @@
+// The Grafana Tempo HTTP API contract the connector must honour —
+// single, reviewable source of truth for the contract test. Same
+// rationale as the Grafana/Datadog contracts: in-process,
+// deterministic, no Tempo container, no Prism.
+//
+// Endpoints used (Tempo HTTP API):
+//   GET /ready                                            — readiness
+//   GET /api/v2/search/tag/resource.service.name/values   — service list
+//   GET /api/search?q=<TraceQL>&start&end&limit            — trace search
+
+export const CONTRACT = {
+  "GET /ready": {
+    requiredHeaders: [],
+    response: "ready",
+  },
+  "GET /api/v2/search/tag/resource.service.name/values": {
+    requiredHeaders: [],
+    response: {
+      tagValues: [
+        { type: "string", value: "checkout" },
+        { type: "string", value: "payments" },
+      ],
+    },
+  },
+  "GET /api/search": {
+    requiredHeaders: [],
+    requiredQuery: { q: "nonempty", start: "int", end: "int", limit: "int" },
+    response: {
+      traces: [
+        { traceID: "a1", rootServiceName: "checkout", startTimeUnixNano: "1715760000000000000", durationMs: 120 },
+        { traceID: "b2", rootServiceName: "checkout", startTimeUnixNano: "1715760060000000000", durationMs: 480 },
+      ],
+    },
+  },
+};
+
+export function checkRequest(method, url, headers) {
+  const u = new URL(url);
+  const key = `${method.toUpperCase()} ${u.pathname}`;
+  const rule = CONTRACT[key];
+  if (!rule) return `unexpected request: ${key} (not in the Tempo contract)`;
+  for (const h of rule.requiredHeaders || []) {
+    const v = headers ? headers[h] : undefined;
+    if (v == null || v === "") return `${key}: missing required header ${h}`;
+    if (h === "Authorization" && !/^Bearer .+/.test(v)) return `${key}: Authorization must be 'Bearer <token>'`;
+  }
+  for (const [q, kind] of Object.entries(rule.requiredQuery || {})) {
+    const v = u.searchParams.get(q);
+    if (v == null) return `${key}: missing required query param '${q}'`;
+    if (kind === "int" && !/^-?\d+$/.test(v)) return `${key}: query '${q}'='${v}' is not an integer`;
+    if (kind === "nonempty" && v.length === 0) return `${key}: query '${q}' is empty`;
+  }
+  return null;
+}

--- a/connectors/tempo/contract/contract.test.mjs
+++ b/connectors/tempo/contract/contract.test.mjs
@@ -1,0 +1,58 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import create from "../index.js";
+import { CONTRACT, checkRequest } from "./contract.mjs";
+
+function contractFetch(violations) {
+  return async (url, opts = {}) => {
+    const u = url.toString();
+    const method = (opts.method || "GET").toUpperCase();
+    const v = checkRequest(method, u, opts.headers || {});
+    if (v) violations.push(v);
+    const rule = CONTRACT[`${method} ${new URL(u).pathname}`];
+    return { ok: true, status: 200, json: async () => (rule ? rule.response : {}) };
+  };
+}
+
+test("checkRequest has teeth", () => {
+  assert.equal(checkRequest("GET", "http://t/ready", {}), null);
+  assert.match(
+    checkRequest("GET", "http://t/api/search?start=1&end=2&limit=3", {}),
+    /missing required query param 'q'/
+  );
+  assert.match(
+    checkRequest("GET", "http://t/api/search?q=%7B%7D&start=x&end=2&limit=3", {}),
+    /query 'start'='x' is not an integer/
+  );
+  assert.match(checkRequest("GET", "http://t/api/v9/nope", {}), /unexpected request/);
+  assert.equal(
+    checkRequest("GET", "http://t/api/search?q=%7B%7D&start=1&end=2&limit=3", {}),
+    null
+  );
+});
+
+test("connector honours the Tempo request contract end-to-end", async () => {
+  const violations = [];
+  globalThis.fetch = contractFetch(violations);
+  const c = create();
+  await c.connect({ url: "http://tempo.local/", auth: { token: "svc-token" } });
+
+  const h = await c.healthCheck();
+  assert.equal(h.status, "up");
+
+  const s = await c.listServices();
+  assert.deepEqual(s.map((x) => x.name), ["checkout", "payments"]);
+  assert.equal(s[0].signalType, "metrics");
+
+  const m = await c.queryMetrics({ service: "checkout", metric: "latency", duration: "1h" });
+  assert.equal(m.unit, "seconds");
+  assert.equal(m.values.length, 2);
+  // 120ms / 480ms → 0.12s / 0.48s, ordered by trace start time.
+  assert.deepEqual(m.values.map((v) => v.value), [0.12, 0.48]);
+  assert.equal(m.summary.current, 0.48);
+  assert.equal(m.summary.min, 0.12);
+  assert.match(m.resolvedSeries, /resource\.service\.name = "checkout"/);
+
+  assert.deepEqual(violations, [], `contract violations:\n${violations.join("\n")}`);
+});

--- a/connectors/tempo/index.js
+++ b/connectors/tempo/index.js
@@ -1,0 +1,176 @@
+// Grafana Tempo connector for observability-mcp. Tempo is the
+// OTLP-native distributed-tracing backend: applications push spans over
+// OTLP, Tempo stores them, and exposes a *query* HTTP API (TraceQL
+// search + tag discovery). This connector turns that trace store into a
+// signal the analysis engine already understands.
+//
+// Scope (deliberately narrow — honest over broad):
+//   - signalType "metrics": it surfaces a TRACE-DERIVED service latency
+//     series (one sample per matched trace, value = trace duration in
+//     seconds). That feeds the same robust-anomaly / health path as any
+//     Prometheus latency metric — no new tool surface, no dead code.
+//   - listServices: real, from Tempo's `resource.service.name` tag
+//     values.
+// It does NOT claim raw-span retrieval, logs, or server-side rollups —
+// those are out of scope for the query-connector contract and would be
+// overclaiming.
+//
+// Standalone dependency-free ESM (Node 20 fetch), duck-typed against the
+// ObservabilityConnector contract (no SDK import → self-contained,
+// airgapped-mirrorable tarball).
+//
+// Auth: Tempo is commonly unauthenticated behind a gateway; an optional
+// Bearer token (source auth token, or TEMPO_TOKEN) is sent when present.
+
+function parseTimeRange(duration) {
+  const m = String(duration || "").match(/^(\d+)([mhd])$/);
+  if (!m) throw new Error(`invalid duration: ${duration} (use 5m, 1h, 24h)`);
+  const n = parseInt(m[1], 10);
+  const secs = m[2] === "m" ? n * 60 : m[2] === "h" ? n * 3600 : n * 86400;
+  const end = Math.floor(Date.now() / 1000);
+  return { start: end - secs, end };
+}
+
+function computeTrend(values) {
+  if (values.length < 4) return "stable";
+  const mid = Math.floor(values.length / 2);
+  const a = values.slice(0, mid).reduce((x, y) => x + y, 0) / mid;
+  const b = values.slice(mid).reduce((x, y) => x + y, 0) / (values.length - mid);
+  const pct = ((b - a) / (a || 1)) * 100;
+  return pct > 10 ? "rising" : pct < -10 ? "falling" : "stable";
+}
+
+function summarize(values) {
+  if (values.length === 0) return { current: 0, average: 0, min: 0, max: 0, trend: "stable" };
+  return {
+    current: values[values.length - 1],
+    average: values.reduce((a, b) => a + b, 0) / values.length,
+    min: Math.min(...values),
+    max: Math.max(...values),
+    trend: computeTrend(values),
+  };
+}
+
+// A Tempo search result trace carries durationMs; we expose it as a
+// "latency" metric in SECONDS to match the rest of the connector fleet
+// (Grafana/Datadog latency unit) so classifyMetric() treats it
+// one-sided (a latency drop is good news, never an anomaly).
+const DEFAULT_METRICS = [
+  {
+    name: "latency",
+    query: '{ resource.service.name = "$service" }',
+    unit: "seconds",
+    description: "Per-trace service latency derived from Tempo trace durations",
+  },
+];
+// Accepted aliases → all resolve to the trace-duration series.
+const LATENCY_ALIASES = new Set(["latency", "latency_p99", "duration", "response_time"]);
+
+export class TempoConnector {
+  constructor() {
+    this.name = "tempo";
+    this.type = "tempo";
+    this.signalType = "metrics";
+    this._metrics = DEFAULT_METRICS;
+    this._base = "";
+    this._token = "";
+  }
+
+  async connect(config) {
+    this._base = config && config.url ? String(config.url).replace(/\/$/, "") : "";
+    if (!this._base) throw new Error("Tempo url is required");
+    const auth = (config && config.auth) || {};
+    this._token = auth.token || process.env.TEMPO_TOKEN || "";
+    if (Array.isArray(config && config.metrics) && config.metrics.length > 0) {
+      this._metrics = config.metrics;
+    }
+  }
+
+  async disconnect() {
+    /* stateless */
+  }
+
+  _headers() {
+    return this._token ? { Authorization: `Bearer ${this._token}` } : {};
+  }
+
+  async healthCheck() {
+    const started = Date.now();
+    try {
+      const res = await fetch(`${this._base}/ready`, { headers: this._headers() });
+      const latencyMs = Date.now() - started;
+      return res.ok
+        ? { status: "up", latencyMs }
+        : { status: "down", latencyMs, message: `Tempo /ready HTTP ${res.status}` };
+    } catch (e) {
+      return { status: "down", latencyMs: Date.now() - started, message: String(e) };
+    }
+  }
+
+  getDefaultMetrics() {
+    return DEFAULT_METRICS;
+  }
+
+  getMetrics() {
+    return this._metrics;
+  }
+
+  async listServices() {
+    try {
+      const res = await fetch(
+        `${this._base}/api/v2/search/tag/resource.service.name/values`,
+        { headers: this._headers() }
+      );
+      if (!res.ok) return [];
+      const body = await res.json();
+      const vals = (body && body.tagValues) || [];
+      return vals
+        .map((v) => (typeof v === "string" ? v : v && v.value))
+        .filter(Boolean)
+        .map((name) => ({ name, source: this.name, signalType: "metrics" }));
+    } catch {
+      return [];
+    }
+  }
+
+  async queryMetrics(params) {
+    const known =
+      this._metrics.find((m) => m.name === params.metric) ||
+      DEFAULT_METRICS.find((m) => m.name === params.metric);
+    const def = known || (LATENCY_ALIASES.has(String(params.metric).toLowerCase()) ? DEFAULT_METRICS[0] : null);
+    if (!def) throw new Error(`unknown metric '${params.metric}' for tempo (only trace-derived latency is supported)`);
+    const { start, end } = parseTimeRange(params.duration);
+    const q = def.query.replace(/\$service\b/g, params.service);
+    const u = new URL(`${this._base}/api/search`);
+    u.searchParams.set("q", q);
+    u.searchParams.set("start", String(start));
+    u.searchParams.set("end", String(end));
+    u.searchParams.set("limit", String(Math.min(params.limit || 200, 1000)));
+    const res = await fetch(u, { headers: this._headers() });
+    if (!res.ok) throw new Error(`Tempo search HTTP ${res.status}`);
+    const body = await res.json();
+    const traces = (body && body.traces) || [];
+    const dps = traces
+      .map((t) => ({
+        // Tempo returns startTimeUnixNano as a string; durationMs as a number.
+        ts: Number(t.startTimeUnixNano) / 1e6,
+        value: Number(t.durationMs) / 1000, // ms → seconds
+      }))
+      .filter((d) => !Number.isNaN(d.value) && !Number.isNaN(d.ts))
+      .sort((a, b) => a.ts - b.ts)
+      .map((d) => ({ timestamp: new Date(d.ts).toISOString(), value: d.value }));
+    return {
+      source: this.name,
+      service: params.service,
+      metric: params.metric,
+      unit: def.unit,
+      values: dps,
+      summary: summarize(dps.map((d) => d.value)),
+      resolvedSeries: q,
+    };
+  }
+}
+
+export default function create() {
+  return new TempoConnector();
+}

--- a/connectors/tempo/index.test.mjs
+++ b/connectors/tempo/index.test.mjs
@@ -1,0 +1,106 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import create, { TempoConnector } from "./index.js";
+
+function mockFetch(routes) {
+  return async (url) => {
+    const u = url.toString();
+    for (const [pat, h] of routes) if (u.includes(pat)) return h(u);
+    return { ok: false, status: 404, json: async () => ({}) };
+  };
+}
+const ok = (b) => ({ ok: true, status: 200, json: async () => b });
+
+test("create() shape", () => {
+  const c = create();
+  assert.ok(c instanceof TempoConnector);
+  assert.equal(c.name, "tempo");
+  assert.equal(c.signalType, "metrics");
+  assert.equal(c.getDefaultMetrics().length, 1);
+  assert.equal(c.getDefaultMetrics()[0].unit, "seconds");
+});
+
+test("connect requires url; token optional", async () => {
+  await assert.rejects(() => create().connect({}), /url is required/);
+  const c = create();
+  await c.connect({ url: "http://tempo/" });
+  assert.equal(c._base, "http://tempo");
+  assert.equal(c._token, "");
+});
+
+test("TEMPO_TOKEN env is used when no source token", async () => {
+  process.env.TEMPO_TOKEN = "envtok";
+  const c = create();
+  await c.connect({ url: "http://tempo" });
+  assert.equal(c._token, "envtok");
+  delete process.env.TEMPO_TOKEN;
+});
+
+test("healthCheck up/down on /ready", async () => {
+  const c = create();
+  await c.connect({ url: "http://tempo" });
+  globalThis.fetch = mockFetch([["/ready", () => ok("ready")]]);
+  assert.equal((await c.healthCheck()).status, "up");
+  globalThis.fetch = mockFetch([["/ready", () => ({ ok: false, status: 503, json: async () => ({}) })]]);
+  const d = await c.healthCheck();
+  assert.equal(d.status, "down");
+  assert.match(d.message, /503/);
+});
+
+test("listServices reads v2 tag values, tolerates string or object form, never throws", async () => {
+  const c = create();
+  await c.connect({ url: "http://tempo" });
+  globalThis.fetch = mockFetch([
+    ["/api/v2/search/tag/resource.service.name/values", () =>
+      ok({ tagValues: [{ type: "string", value: "api" }, "db", { value: "" }] })],
+  ]);
+  assert.deepEqual((await c.listServices()).map((s) => s.name), ["api", "db"]);
+  globalThis.fetch = async () => { throw new Error("down"); };
+  assert.deepEqual(await c.listServices(), []);
+});
+
+test("queryMetrics maps trace durations → seconds, sorted by start time", async () => {
+  const c = create();
+  await c.connect({ url: "http://tempo" });
+  let seen;
+  globalThis.fetch = mockFetch([
+    ["/api/search", (u) => {
+      seen = new URL(u);
+      return ok({
+        traces: [
+          { traceID: "late", startTimeUnixNano: "2000000000000000000", durationMs: 900 },
+          { traceID: "early", startTimeUnixNano: "1000000000000000000", durationMs: 100 },
+        ],
+      });
+    }],
+  ]);
+  const r = await c.queryMetrics({ service: "checkout", metric: "latency_p99", duration: "30m" });
+  assert.match(seen.searchParams.get("q"), /resource\.service\.name = "checkout"/);
+  assert.ok(/^\d+$/.test(seen.searchParams.get("start")));
+  assert.ok(/^\d+$/.test(seen.searchParams.get("limit")));
+  // sorted ascending by start time: early (0.1s) before late (0.9s)
+  assert.deepEqual(r.values.map((v) => v.value), [0.1, 0.9]);
+  assert.equal(r.unit, "seconds");
+  assert.equal(r.summary.current, 0.9);
+  assert.equal(r.summary.min, 0.1);
+});
+
+test("queryMetrics rejects unknown metrics, drops NaN samples", async () => {
+  const c = create();
+  await c.connect({ url: "http://tempo" });
+  await assert.rejects(
+    () => c.queryMetrics({ service: "s", metric: "cpu", duration: "1h" }),
+    /unknown metric 'cpu'/
+  );
+  globalThis.fetch = mockFetch([
+    ["/api/search", () => ok({ traces: [
+      { startTimeUnixNano: "1000000000000000000", durationMs: 200 },
+      { startTimeUnixNano: "bad", durationMs: 300 },
+      { startTimeUnixNano: "2000000000000000000", durationMs: "x" },
+    ] })],
+  ]);
+  const r = await c.queryMetrics({ service: "s", metric: "latency", duration: "1h" });
+  assert.equal(r.values.length, 1);
+  assert.equal(r.values[0].value, 0.2);
+});

--- a/connectors/tempo/manifest.json
+++ b/connectors/tempo/manifest.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": 1,
+  "name": "tempo",
+  "displayName": "Grafana Tempo",
+  "version": "1.0.0",
+  "description": "Grafana Tempo connector — OTLP-native tracing backend. Surfaces trace-derived service latency (per-trace duration) via the Tempo TraceQL search API and discovers services from the resource.service.name tag. Optional Bearer auth.",
+  "signalTypes": ["metrics"],
+  "homepage": "https://github.com/ThoTischner/observability-mcp",
+  "license": "MIT",
+  "capabilities": {
+    "queryMetrics": true,
+    "listServices": true
+  },
+  "compat": {
+    "serverVersion": ">=1.4.0"
+  },
+  "integrity": "sha256-Wpg5LcyUCuGxzM8OPGdVn/4/LmpP4iWrvbsCEp8kMdQ="
+}

--- a/connectors/tempo/package.json
+++ b/connectors/tempo/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@observability-mcp/connector-tempo",
+  "version": "1.0.0",
+  "description": "Grafana Tempo connector for observability-mcp — trace-derived service latency via the Tempo TraceQL search API.",
+  "type": "module",
+  "main": "./index.js",
+  "license": "MIT",
+  "files": ["index.js", "manifest.json"],
+  "observabilityMcp": {
+    "kind": "connector",
+    "name": "tempo",
+    "manifest": "./manifest.json"
+  }
+}

--- a/hub/catalog/index.json
+++ b/hub/catalog/index.json
@@ -104,6 +104,27 @@
           "changelog": "Bundled with the server image — no install step. Listed for discoverability and to anchor the catalog format."
         }
       ]
+    },
+    {
+      "name": "tempo",
+      "displayName": "Grafana Tempo",
+      "description": "Grafana Tempo connector — OTLP-native tracing backend. Surfaces trace-derived service latency via the Tempo TraceQL search API, feeding the same anomaly/health path as a Prometheus latency metric.",
+      "tier": "official",
+      "builtin": false,
+      "signalTypes": [
+        "metrics"
+      ],
+      "latest": "1.0.0",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "releasedAt": "2026-05-18",
+          "serverCompat": ">=1.4.0",
+          "tarballUrl": "https://github.com/ThoTischner/observability-mcp/releases/download/connector-tempo-1.0.0/tempo-1.0.0.tgz",
+          "integrity": "sha256-Wpg5LcyUCuGxzM8OPGdVn/4/LmpP4iWrvbsCEp8kMdQ=",
+          "changelog": "Initial release: trace-derived service latency via Tempo TraceQL search, service discovery from resource.service.name tag, optional Bearer auth."
+        }
+      ]
     }
   ]
 }

--- a/hub/catalog/tempo.json
+++ b/hub/catalog/tempo.json
@@ -1,0 +1,20 @@
+{
+  "catalogVersion": 1,
+  "name": "tempo",
+  "displayName": "Grafana Tempo",
+  "description": "Grafana Tempo connector — OTLP-native tracing backend. Surfaces trace-derived service latency via the Tempo TraceQL search API, feeding the same anomaly/health path as a Prometheus latency metric.",
+  "vendor": "observability-mcp",
+  "homepage": "https://github.com/ThoTischner/observability-mcp",
+  "tier": "official",
+  "signalTypes": ["metrics"],
+  "versions": [
+    {
+      "version": "1.0.0",
+      "releasedAt": "2026-05-18",
+      "serverCompat": ">=1.4.0",
+      "tarballUrl": "https://github.com/ThoTischner/observability-mcp/releases/download/connector-tempo-1.0.0/tempo-1.0.0.tgz",
+      "integrity": "sha256-Wpg5LcyUCuGxzM8OPGdVn/4/LmpP4iWrvbsCEp8kMdQ=",
+      "changelog": "Initial release: trace-derived service latency via Tempo TraceQL search, service discovery from resource.service.name tag, optional Bearer auth."
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds a **Grafana Tempo** connector under `connectors/tempo/`. Tempo is the OTLP-native distributed-tracing backend; this connector turns its query API into a signal the analysis engine already understands.

### Scope (deliberately narrow — honest over broad)
- **`signalType: "metrics"`** — exposes a *trace-derived* per-trace service latency series (value = trace duration in seconds) via the Tempo TraceQL search API (`GET /api/search`). Latency unit is `seconds` so `classifyMetric()` treats it one-sided (a latency drop is never an anomaly) — it feeds the exact same robust-anomaly / health path as a Prometheus latency metric, **no new tool surface, no dead code**.
- **`listServices`** — real, from Tempo's `resource.service.name` tag values (`GET /api/v2/search/tag/.../values`).
- Health via `GET /ready`; optional Bearer auth (source token or `TEMPO_TOKEN`).
- It does **not** claim raw-span retrieval, logs, or server-side rollups — out of scope for the query-connector contract; documented in the connector header.

Dependency-free ESM (Node 20 `fetch`), duck-typed against `ObservabilityConnector` — self-contained, airgapped-mirrorable tarball, same pattern as the Grafana/Datadog connectors.

## Verification (real, end-to-end)
- `node --test connectors/tempo/**` — **9/9 pass** (unit + in-process request-contract test, no Tempo instance needed)
- Full connector gate: `node --test connectors/*/*.test.mjs connectors/*/contract/*.test.mjs` — **38/38 pass**
- CI integrity-in-sync script — manifest + catalog integrity in sync for all connectors
- `connectors/pack.test.mjs` + `hub/build-catalog.test.mjs` — pass; `hub/build-catalog.mjs --check` clean
- `node connectors/pack.mjs connectors/tempo` packs cleanly; **`connectors/loader-smoke.mjs` loads tempo & confirms it's callable in the real server**
- mcp-server Docker suite unchanged: 205/209 (same 4 pre-existing unrelated failures), `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)