### PR TITLE
feat(enterprise): role-based access control (FSL-1.1-Apache-2.0)

### DIFF
--- a/enterprise/LICENSE
+++ b/enterprise/LICENSE
@@ -1,0 +1,107 @@
+Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2026 ThoTischner
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, INCLUDING
+WITHOUT LIMITATION WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following will
+apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and limitations
+under the License.

--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -1,0 +1,36 @@
+# enterprise/
+
+Source-available modules licensed under the **Functional Source License,
+Version 1.1, Apache 2.0 Future License** (`FSL-1.1-Apache-2.0`) — see
+[`LICENSE`](./LICENSE). Each file converts to Apache-2.0 two years after it is
+made available.
+
+This directory is **not** part of the open-source distribution:
+
+- It lives outside `mcp-server/`, whose npm package only publishes
+  `["dist","config"]`, so it is never in the published tarball.
+- The container build context is `./mcp-server`, so it is never in the
+  Docker image.
+
+The Apache-2.0 core in `mcp-server/` runs fully standalone without anything
+here. These modules are optional and load only when explicitly wired in by an
+operator.
+
+## Modules
+
+| Module | What it does |
+|--------|--------------|
+| [`rbac/`](./rbac) | Role-based access control: a pure policy evaluator + an enforcement guard that maps a request's principal/roles to an allow/deny decision over tools, sources, and services. Default-deny. |
+
+## Integration contract
+
+`rbac/` is dependency-free ESM and duck-typed against the core
+`RequestContext` shape (`{ principalId, auth, allowedSources?, ... }`) so the
+Apache core never imports FSL code. An operator wires it at the context seam:
+resolve the principal's roles, then call `enforce(...)` before a tool runs.
+
+## Tests
+
+```
+node --test enterprise/rbac/*.test.mjs
+```

--- a/enterprise/rbac/enforce.mjs
+++ b/enterprise/rbac/enforce.mjs
@@ -1,0 +1,75 @@
+// RBAC enforcement guard (FSL-1.1-Apache-2.0).
+//
+// Bridges the Apache-2.0 core's request seam to the pure policy
+// evaluator WITHOUT the core ever importing FSL code: `enforce` is
+// duck-typed against the core RequestContext shape
+// ({ principalId, auth, allowedSources?, ... }). An operator wires it in
+// at the context seam — resolve the principal from `ctx`, then call
+// `enforce(policy, ctx, { tool, source?, service?, mutating? })` before a
+// tool runs; a denial throws and the tool never executes.
+//
+// RBAC composes WITH, never widens, the core's single-tenant
+// `allowedSources` primitive: if the context pins a source allow-list,
+// a targeted source outside it is denied before the policy is consulted
+// (defence in depth — the narrower bound always wins).
+
+import { evaluate } from "./policy.mjs";
+
+export class RbacDeniedError extends Error {
+  constructor(decision, request) {
+    super(`RBAC denied: ${decision.reason}`);
+    this.name = "RbacDeniedError";
+    this.code = "RBAC_DENIED";
+    this.decision = decision;
+    this.request = request;
+  }
+}
+
+/**
+ * Enforce a policy for a request in the scope of a core RequestContext.
+ * @param policy  the RBAC policy
+ * @param ctx     duck-typed RequestContext ({ principalId, allowedSources? })
+ * @param request { tool, source?, service?, mutating? }
+ * @returns the allow decision (on deny it throws RbacDeniedError)
+ */
+export function enforce(policy, ctx, request) {
+  const c = ctx || {};
+  const req = {
+    principalId: c.principalId,
+    tool: request && request.tool,
+    source: request && request.source,
+    service: request && request.service,
+    mutating: !!(request && request.mutating),
+  };
+
+  // Core single-tenant bound is an upper limit RBAC cannot exceed.
+  if (
+    req.source != null &&
+    Array.isArray(c.allowedSources) &&
+    c.allowedSources.length > 0 &&
+    !c.allowedSources.includes(req.source)
+  ) {
+    const decision = {
+      allow: false,
+      reason: `source '${req.source}' outside the context allow-list`,
+    };
+    throw new RbacDeniedError(decision, req);
+  }
+
+  const decision = evaluate(policy, req);
+  if (!decision.allow) throw new RbacDeniedError(decision, req);
+  return decision;
+}
+
+/**
+ * Non-throwing variant — returns the decision for callers that want to
+ * branch rather than catch.
+ */
+export function check(policy, ctx, request) {
+  try {
+    return enforce(policy, ctx, request);
+  } catch (e) {
+    if (e instanceof RbacDeniedError) return e.decision;
+    throw e;
+  }
+}

--- a/enterprise/rbac/enforce.test.mjs
+++ b/enterprise/rbac/enforce.test.mjs
@@ -1,0 +1,64 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { enforce, check, RbacDeniedError } from "./enforce.mjs";
+
+const POLICY = {
+  roles: {
+    sre: { tools: ["query_metrics", "get_service_health"], sources: ["*"], services: ["*"] },
+  },
+  bindings: { "key:bob": ["sre"] },
+};
+
+const ctx = (over = {}) => ({ principalId: "key:bob", auth: "apikey", correlationId: "c1", ...over });
+
+test("enforce returns the allow decision on grant", () => {
+  const d = enforce(POLICY, ctx(), { tool: "query_metrics", source: "prom-eu" });
+  assert.equal(d.allow, true);
+  assert.equal(d.matchedRole, "sre");
+});
+
+test("enforce throws RbacDeniedError on deny, tool never runs", () => {
+  let ran = false;
+  try {
+    enforce(POLICY, ctx(), { tool: "delete_source" });
+    ran = true;
+  } catch (e) {
+    assert.ok(e instanceof RbacDeniedError);
+    assert.equal(e.code, "RBAC_DENIED");
+    assert.match(e.message, /not granted/);
+    assert.equal(e.request.tool, "delete_source");
+  }
+  assert.equal(ran, false);
+});
+
+test("context allowedSources is a hard upper bound RBAC cannot exceed", () => {
+  // Policy would allow any source, but the context pins the allow-list.
+  const e = check(POLICY, ctx({ allowedSources: ["prom-eu"] }), {
+    tool: "query_metrics",
+    source: "prom-us",
+  });
+  assert.equal(e.allow, false);
+  assert.match(e.reason, /outside the context allow-list/);
+  // Within the pinned list it passes through to the policy and is allowed.
+  assert.equal(
+    check(POLICY, ctx({ allowedSources: ["prom-eu"] }), { tool: "query_metrics", source: "prom-eu" }).allow,
+    true
+  );
+});
+
+test("anonymous/unbound principal is denied (default-deny seam)", () => {
+  const d = check(POLICY, { principalId: "anonymous", auth: "anonymous" }, { tool: "query_metrics" });
+  assert.equal(d.allow, false);
+  assert.match(d.reason, /no roles \(default-deny\)/);
+});
+
+test("check() never throws RbacDeniedError, returns the decision", () => {
+  const d = check(POLICY, ctx(), { tool: "nope" });
+  assert.equal(d.allow, false);
+  assert.equal(typeof d.reason, "string");
+});
+
+test("missing ctx is treated as anonymous → denied", () => {
+  const d = check(POLICY, undefined, { tool: "query_metrics" });
+  assert.equal(d.allow, false);
+});

--- a/enterprise/rbac/index.mjs
+++ b/enterprise/rbac/index.mjs
@@ -1,0 +1,3 @@
+// Public surface of the FSL RBAC module (FSL-1.1-Apache-2.0).
+export { evaluate, rolesFor } from "./policy.mjs";
+export { enforce, check, RbacDeniedError } from "./enforce.mjs";

--- a/enterprise/rbac/package.json
+++ b/enterprise/rbac/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@observability-mcp/enterprise-rbac",
+  "version": "1.0.0",
+  "description": "Role-based access control for observability-mcp (enterprise tier).",
+  "private": true,
+  "type": "module",
+  "main": "./index.mjs",
+  "license": "FSL-1.1-Apache-2.0",
+  "scripts": {
+    "test": "node --test *.test.mjs"
+  }
+}

--- a/enterprise/rbac/policy.mjs
+++ b/enterprise/rbac/policy.mjs
@@ -1,0 +1,90 @@
+// Role-based access-control policy evaluator (FSL-1.1-Apache-2.0).
+//
+// Pure and dependency-free: no I/O, no clock, no global state — a policy
+// + a request in, an allow/deny decision out. That makes it exhaustively
+// unit-testable and safe to call on every tool invocation.
+//
+// Model
+// -----
+//   Policy  = { roles, bindings, defaultRoles? }
+//     roles      : { <roleName>: Role }
+//     bindings   : { <principalId>: string[] }   // roles granted to a principal
+//     defaultRoles?: string[]                    // roles for unbound principals
+//   Role    = { tools?, sources?, services?, readOnly? }
+//     tools/sources/services : string[] allow-lists; "*" = any; omitted = none
+//     readOnly?              : true → the role denies mutating actions
+//   Request = { principalId, tool, source?, service?, mutating? }
+//
+// Decision: DEFAULT-DENY. A request is allowed only if at least one role
+// bound to the principal grants the tool AND (when given) the source AND
+// (when given) the service, and — if that role is readOnly — the action
+// is not mutating. Multiple roles compose as a union (any fully-granting
+// role allows). An unknown/unbound principal gets `defaultRoles` (if any)
+// or is denied.
+
+function listAllows(list, value) {
+  // An omitted/empty allow-list grants nothing (default-deny). "*" grants
+  // everything. Otherwise the exact value must be present.
+  if (!Array.isArray(list) || list.length === 0) return false;
+  if (list.includes("*")) return true;
+  return value != null && list.includes(value);
+}
+
+/** Roles bound to a principal, falling back to policy.defaultRoles. */
+export function rolesFor(policy, principalId) {
+  const bound = (policy && policy.bindings && policy.bindings[principalId]) || null;
+  if (bound && bound.length > 0) return bound;
+  return (policy && policy.defaultRoles) || [];
+}
+
+/**
+ * Evaluate a request against a policy.
+ * @returns {{allow: boolean, reason: string, matchedRole?: string}}
+ */
+export function evaluate(policy, request) {
+  if (!policy || typeof policy !== "object") {
+    return { allow: false, reason: "no policy configured (default-deny)" };
+  }
+  const req = request || {};
+  if (!req.tool) {
+    return { allow: false, reason: "request has no tool" };
+  }
+  const roleNames = rolesFor(policy, req.principalId);
+  if (roleNames.length === 0) {
+    return {
+      allow: false,
+      reason: `principal '${req.principalId ?? "?"}' has no roles (default-deny)`,
+    };
+  }
+
+  const tried = [];
+  for (const roleName of roleNames) {
+    const role = policy.roles && policy.roles[roleName];
+    if (!role) {
+      tried.push(`${roleName}: undefined role`);
+      continue;
+    }
+    if (!listAllows(role.tools, req.tool)) {
+      tried.push(`${roleName}: tool '${req.tool}' not granted`);
+      continue;
+    }
+    if (req.source != null && !listAllows(role.sources, req.source)) {
+      tried.push(`${roleName}: source '${req.source}' not granted`);
+      continue;
+    }
+    if (req.service != null && !listAllows(role.services, req.service)) {
+      tried.push(`${roleName}: service '${req.service}' not granted`);
+      continue;
+    }
+    if (role.readOnly && req.mutating) {
+      tried.push(`${roleName}: read-only role denies a mutating action`);
+      continue;
+    }
+    return { allow: true, reason: `granted by role '${roleName}'`, matchedRole: roleName };
+  }
+
+  return {
+    allow: false,
+    reason: `denied — no bound role grants this request [${tried.join("; ")}]`,
+  };
+}

--- a/enterprise/rbac/policy.test.mjs
+++ b/enterprise/rbac/policy.test.mjs
@@ -1,0 +1,96 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { evaluate, rolesFor } from "./policy.mjs";
+
+const POLICY = {
+  roles: {
+    admin: { tools: ["*"], sources: ["*"], services: ["*"] },
+    sre: { tools: ["query_metrics", "get_service_health"], sources: ["prom-eu"], services: ["*"] },
+    auditor: { tools: ["*"], sources: ["*"], services: ["*"], readOnly: true },
+    payments_only: { tools: ["query_metrics"], sources: ["*"], services: ["payment-service"] },
+  },
+  bindings: {
+    alice: ["admin"],
+    bob: ["sre"],
+    carol: ["auditor"],
+    dave: ["sre", "payments_only"],
+  },
+  defaultRoles: [],
+};
+
+test("default-deny: no policy / no tool / unbound principal", () => {
+  assert.equal(evaluate(null, { principalId: "x", tool: "t" }).allow, false);
+  assert.equal(evaluate(POLICY, { principalId: "alice" }).allow, false);
+  const u = evaluate(POLICY, { principalId: "nobody", tool: "query_metrics" });
+  assert.equal(u.allow, false);
+  assert.match(u.reason, /no roles \(default-deny\)/);
+});
+
+test("admin wildcard grants anything", () => {
+  const d = evaluate(POLICY, { principalId: "alice", tool: "detect_anomalies", source: "any", service: "any" });
+  assert.equal(d.allow, true);
+  assert.equal(d.matchedRole, "admin");
+});
+
+test("role tool allow-list is enforced", () => {
+  assert.equal(evaluate(POLICY, { principalId: "bob", tool: "query_metrics", source: "prom-eu" }).allow, true);
+  const denied = evaluate(POLICY, { principalId: "bob", tool: "detect_anomalies", source: "prom-eu" });
+  assert.equal(denied.allow, false);
+  assert.match(denied.reason, /tool 'detect_anomalies' not granted/);
+});
+
+test("role source allow-list is enforced", () => {
+  const d = evaluate(POLICY, { principalId: "bob", tool: "query_metrics", source: "prom-us" });
+  assert.equal(d.allow, false);
+  assert.match(d.reason, /source 'prom-us' not granted/);
+});
+
+test("read-only role denies mutating actions but allows reads", () => {
+  assert.equal(evaluate(POLICY, { principalId: "carol", tool: "query_metrics", mutating: false }).allow, true);
+  const m = evaluate(POLICY, { principalId: "carol", tool: "update_config", mutating: true });
+  assert.equal(m.allow, false);
+  assert.match(m.reason, /read-only role denies a mutating action/);
+});
+
+test("multiple roles compose as a union", () => {
+  // dave: sre (query_metrics on prom-eu) + payments_only (query_metrics, payment-service)
+  assert.equal(
+    evaluate(POLICY, { principalId: "dave", tool: "query_metrics", service: "payment-service" }).allow,
+    true
+  );
+  // sre grants get_service_health only on prom-eu; payments_only doesn't grant it → with a
+  // foreign source both roles fail.
+  const d = evaluate(POLICY, { principalId: "dave", tool: "get_service_health", source: "prom-us" });
+  assert.equal(d.allow, false);
+});
+
+test("service allow-list is enforced", () => {
+  const d = evaluate(POLICY, { principalId: "dave", tool: "query_metrics", service: "order-service" });
+  // sre allows services:* but source defaults absent; payments_only restricts service.
+  assert.equal(d.allow, true); // sre grants (services "*", no source in request)
+  const onlyPayments = evaluate(
+    { roles: POLICY.roles, bindings: { x: ["payments_only"] } },
+    { principalId: "x", tool: "query_metrics", service: "order-service" }
+  );
+  assert.equal(onlyPayments.allow, false);
+  assert.match(onlyPayments.reason, /service 'order-service' not granted/);
+});
+
+test("defaultRoles applied to unbound principals", () => {
+  const p = { roles: { ro: { tools: ["query_metrics"], sources: ["*"], services: ["*"] } }, bindings: {}, defaultRoles: ["ro"] };
+  assert.equal(evaluate(p, { principalId: "anyone", tool: "query_metrics" }).allow, true);
+  assert.equal(evaluate(p, { principalId: "anyone", tool: "delete_source" }).allow, false);
+});
+
+test("rolesFor: binding wins over default, missing → default", () => {
+  assert.deepEqual(rolesFor(POLICY, "bob"), ["sre"]);
+  assert.deepEqual(rolesFor({ bindings: {}, defaultRoles: ["ro"] }, "ghost"), ["ro"]);
+  assert.deepEqual(rolesFor({ bindings: {} }, "ghost"), []);
+});
+
+test("undefined referenced role is skipped, not crashed", () => {
+  const p = { roles: {}, bindings: { x: ["ghostrole"] } };
+  const d = evaluate(p, { principalId: "x", tool: "query_metrics" });
+  assert.equal(d.allow, false);
+  assert.match(d.reason, /undefined role/);
+});


### PR DESCRIPTION
## What

Introduces a source-available **enterprise tier** under a new top-level `enterprise/` directory, licensed **FSL-1.1-Apache-2.0** (each file converts to Apache-2.0 two years after release). First module: **RBAC**.

### Structural OSS isolation (proven)
`enterprise/` lives outside `mcp-server/`, so it is excluded from **both** OSS artifacts by construction — no allow-list maintenance needed:
- **npm**: `mcp-server` publishes only `["dist","config"]`. Verified: `npm pack --dry-run` → **zero `enterprise/` files**.
- **Docker**: build context is `./mcp-server`; a top-level `enterprise/` can never enter the image.

The Apache-2.0 core runs fully standalone — nothing here is imported by core code.

### `enterprise/rbac`
- **`policy.mjs`** — pure, dependency-free, **default-deny** policy evaluator. Roles carry `tools` / `sources` / `services` allow-lists (`*` wildcard), optional `readOnly`; multiple roles compose as a union; unbound principals fall back to `defaultRoles` (else denied).
- **`enforce.mjs`** — enforcement guard **duck-typed against the core `RequestContext` shape** (`{ principalId, allowedSources?, ... }`) so the Apache core never imports FSL code. Composes with — never widens — the existing single-tenant `allowedSources` bound (narrower bound always wins; defence in depth). `enforce()` throws `RbacDeniedError` (tool never runs); `check()` is the non-throwing variant.

## Verification (real, end-to-end)
- `node --test enterprise/rbac/*.test.mjs` — **16/16 pass** (default-deny, tool/source/service allow-lists, read-only blocks mutations, multi-role union, defaultRoles, context-bound upper limit, anonymous denied, undefined-role safety)
- OSS exclusion proven concretely (npm pack dry-run + Docker context), shown above
- No `mcp-server/` files touched → core behaviour provably unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)