### PR TITLE
feat(enterprise): governed product catalog (FSL-1.1-Apache-2.0)

### DIFF
--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -21,6 +21,7 @@ operator.
 | Module | What it does |
 |--------|--------------|
 | [`rbac/`](./rbac) | Role-based access control: a pure policy evaluator + an enforcement guard that maps a request's principal/roles to an allow/deny decision over tools, sources, and services. Default-deny. |
+| [`catalog/`](./catalog) | Governed product catalog: publish named **products** (curated bundles of sources/services/tools) and **grants** of products to principals; pure evaluator + enforcement guard. Default-deny. Composes with `rbac/` (both must allow). |
 
 ## Integration contract
 

--- a/enterprise/catalog/catalog.mjs
+++ b/enterprise/catalog/catalog.mjs
@@ -1,0 +1,117 @@
+// Governed product catalog (FSL-1.1-Apache-2.0).
+//
+// A Catalog publishes named **products** — curated bundles of
+// observability scope (which sources / services / tools belong together
+// as one consumable unit) — and **grants** that say which principals may
+// consume which products. It is the "what is this principal even allowed
+// to see as a unit" layer; RBAC (enterprise/rbac) is the orthogonal
+// "what verbs may they perform" layer. Defence in depth: a request must
+// pass BOTH.
+//
+// Pure and dependency-free: a catalog + a request in, a decision out.
+// DEFAULT-DENY — a principal with no product grant sees nothing.
+//
+// Model
+// -----
+//   Catalog = { products, grants, defaultProducts? }
+//     products : { <name>: Product }
+//     grants   : { <principalId>: string[] }   // product names
+//     defaultProducts?: string[]               // for ungranted principals
+//   Product = { description?, sources, services?, tools? }
+//     sources           : string[] (required) — "*" = any
+//     services?/tools?   : string[] — omitted = unrestricted on that axis
+//
+// A request { source?, service?, tool? } is "in" a product iff every
+// SPECIFIED axis is permitted by that product. An omitted product axis
+// (services/tools) means that axis is unrestricted; an omitted/empty
+// `sources` permits nothing (default-deny on the defining axis).
+
+function axisAllows(list, value, { emptyMeans }) {
+  if (!Array.isArray(list) || list.length === 0) return emptyMeans === "all";
+  if (list.includes("*")) return true;
+  return value != null && list.includes(value);
+}
+
+function requestInProduct(product, req) {
+  if (!product || typeof product !== "object") return false;
+  // sources: defining axis — empty/omitted denies.
+  if (req.source != null && !axisAllows(product.sources, req.source, { emptyMeans: "none" })) {
+    return false;
+  }
+  // services / tools: omitted axis = unrestricted.
+  if (req.service != null && !axisAllows(product.services, req.service, { emptyMeans: "all" })) {
+    return false;
+  }
+  if (req.tool != null && !axisAllows(product.tools, req.tool, { emptyMeans: "all" })) {
+    return false;
+  }
+  return true;
+}
+
+/** Product names granted to a principal (falls back to defaultProducts). */
+export function grantedProductNames(catalog, principalId) {
+  const g = (catalog && catalog.grants && catalog.grants[principalId]) || null;
+  if (g && g.length > 0) return g;
+  return (catalog && catalog.defaultProducts) || [];
+}
+
+/** Resolved Product objects granted to a principal (skips unknown names). */
+export function resolveProducts(catalog, principalId) {
+  const names = grantedProductNames(catalog, principalId);
+  const out = [];
+  for (const n of names) {
+    const p = catalog && catalog.products && catalog.products[n];
+    if (p) out.push({ name: n, ...p });
+  }
+  return out;
+}
+
+/**
+ * Flattened effective scope across all granted products (union).
+ * "*" on an axis collapses to the wildcard. An omitted services/tools
+ * axis on ANY granted product makes that axis unrestricted (most
+ * permissive granted product wins, consistent with requestInProduct).
+ */
+export function productScope(catalog, principalId) {
+  const products = resolveProducts(catalog, principalId);
+  const scope = { sources: new Set(), services: new Set(), tools: new Set() };
+  let servicesUnrestricted = false;
+  let toolsUnrestricted = false;
+  for (const p of products) {
+    for (const s of p.sources || []) scope.sources.add(s);
+    if (!Array.isArray(p.services) || p.services.length === 0) servicesUnrestricted = true;
+    else for (const s of p.services) scope.services.add(s);
+    if (!Array.isArray(p.tools) || p.tools.length === 0) toolsUnrestricted = true;
+    else for (const t of p.tools) scope.tools.add(t);
+  }
+  return { ...scope, servicesUnrestricted, toolsUnrestricted };
+}
+
+/**
+ * Is the request inside ANY product granted to the principal?
+ * @returns {{allow: boolean, reason: string, product?: string}}
+ */
+export function evaluateCatalog(catalog, request) {
+  if (!catalog || typeof catalog !== "object") {
+    return { allow: false, reason: "no catalog configured (default-deny)" };
+  }
+  const req = request || {};
+  const products = resolveProducts(catalog, req.principalId);
+  if (products.length === 0) {
+    return {
+      allow: false,
+      reason: `principal '${req.principalId ?? "?"}' has no product grants (default-deny)`,
+    };
+  }
+  const tried = [];
+  for (const p of products) {
+    if (requestInProduct(p, req)) {
+      return { allow: true, reason: `within product '${p.name}'`, product: p.name };
+    }
+    tried.push(p.name);
+  }
+  return {
+    allow: false,
+    reason: `request outside every granted product [${tried.join(", ")}]`,
+  };
+}

--- a/enterprise/catalog/catalog.test.mjs
+++ b/enterprise/catalog/catalog.test.mjs
@@ -1,0 +1,107 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  evaluateCatalog,
+  resolveProducts,
+  productScope,
+  grantedProductNames,
+} from "./catalog.mjs";
+
+const CATALOG = {
+  products: {
+    "eu-payments": { description: "EU payment stack", sources: ["prom-eu", "loki-eu"], services: ["payment-service"] },
+    "eu-all": { sources: ["prom-eu", "loki-eu"] }, // services/tools unrestricted
+    "global-readonly": { sources: ["*"], tools: ["query_metrics", "get_service_health"] },
+  },
+  grants: {
+    alice: ["eu-payments"],
+    bob: ["eu-all", "global-readonly"],
+  },
+  defaultProducts: [],
+};
+
+test("default-deny: no catalog / ungranted principal", () => {
+  assert.equal(evaluateCatalog(null, { principalId: "x", source: "s" }).allow, false);
+  const d = evaluateCatalog(CATALOG, { principalId: "ghost", source: "prom-eu" });
+  assert.equal(d.allow, false);
+  assert.match(d.reason, /no product grants \(default-deny\)/);
+});
+
+test("in-product when every specified axis matches", () => {
+  const d = evaluateCatalog(CATALOG, { principalId: "alice", source: "prom-eu", service: "payment-service" });
+  assert.equal(d.allow, true);
+  assert.equal(d.product, "eu-payments");
+});
+
+test("outside product when source not in the product's sources", () => {
+  const d = evaluateCatalog(CATALOG, { principalId: "alice", source: "prom-us" });
+  assert.equal(d.allow, false);
+  assert.match(d.reason, /outside every granted product \[eu-payments\]/);
+});
+
+test("service axis is enforced when the product restricts it", () => {
+  const d = evaluateCatalog(CATALOG, { principalId: "alice", source: "prom-eu", service: "order-service" });
+  assert.equal(d.allow, false);
+});
+
+test("omitted product axis = unrestricted (eu-all has no services/tools)", () => {
+  const d = evaluateCatalog(CATALOG, { principalId: "bob", source: "prom-eu", service: "anything", tool: "any" });
+  assert.equal(d.allow, true);
+  assert.equal(d.product, "eu-all");
+});
+
+test("multi-product union: first fails, second allows", () => {
+  // bob: eu-all (sources prom-eu/loki-eu) + global-readonly (sources *, tools limited)
+  const d = evaluateCatalog(CATALOG, { principalId: "bob", source: "prom-us", tool: "query_metrics" });
+  assert.equal(d.allow, true);
+  assert.equal(d.product, "global-readonly");
+});
+
+test("wildcard-source product still enforces its tool axis", () => {
+  const onlyGlobal = { products: CATALOG.products, grants: { z: ["global-readonly"] } };
+  assert.equal(evaluateCatalog(onlyGlobal, { principalId: "z", source: "anywhere", tool: "query_metrics" }).allow, true);
+  const denied = evaluateCatalog(onlyGlobal, { principalId: "z", source: "anywhere", tool: "delete_source" });
+  assert.equal(denied.allow, false);
+});
+
+test("defaultProducts applied to ungranted principals", () => {
+  const c = { products: { pub: { sources: ["prom-eu"] } }, grants: {}, defaultProducts: ["pub"] };
+  assert.equal(evaluateCatalog(c, { principalId: "anyone", source: "prom-eu" }).allow, true);
+  assert.equal(evaluateCatalog(c, { principalId: "anyone", source: "prom-us" }).allow, false);
+});
+
+test("unknown product names are skipped, not crashed", () => {
+  const c = { products: {}, grants: { x: ["nope"] } };
+  const d = evaluateCatalog(c, { principalId: "x", source: "s" });
+  assert.equal(d.allow, false);
+  assert.match(d.reason, /no product grants \(default-deny\)/);
+});
+
+test("grantedProductNames: grant wins, else default, else []", () => {
+  assert.deepEqual(grantedProductNames(CATALOG, "alice"), ["eu-payments"]);
+  assert.deepEqual(grantedProductNames({ grants: {}, defaultProducts: ["d"] }, "ghost"), ["d"]);
+  assert.deepEqual(grantedProductNames({ grants: {} }, "ghost"), []);
+});
+
+test("resolveProducts returns named product objects, skipping unknowns", () => {
+  const c = { products: { a: { sources: ["s1"] } }, grants: { p: ["a", "missing"] } };
+  const r = resolveProducts(c, "p");
+  assert.equal(r.length, 1);
+  assert.equal(r[0].name, "a");
+  assert.deepEqual(r[0].sources, ["s1"]);
+});
+
+test("productScope flattens the union + unrestricted axis flags", () => {
+  const s = productScope(CATALOG, "bob");
+  // bob = eu-all (prom-eu/loki-eu) ∪ global-readonly (sources "*")
+  assert.deepEqual([...s.sources].sort(), ["*", "loki-eu", "prom-eu"]);
+  // eu-all has no services/tools → both axes unrestricted across the union
+  assert.equal(s.servicesUnrestricted, true);
+  assert.equal(s.toolsUnrestricted, true);
+
+  const sa = productScope(CATALOG, "alice");
+  assert.deepEqual([...sa.sources].sort(), ["loki-eu", "prom-eu"]);
+  assert.equal(sa.servicesUnrestricted, false);
+  assert.deepEqual([...sa.services], ["payment-service"]);
+  assert.equal(sa.toolsUnrestricted, true); // eu-payments omits tools
+});

--- a/enterprise/catalog/enforce.mjs
+++ b/enterprise/catalog/enforce.mjs
@@ -1,0 +1,67 @@
+// Catalog enforcement guard (FSL-1.1-Apache-2.0).
+//
+// Mirrors enterprise/rbac/enforce.mjs: duck-typed against the core
+// RequestContext shape so the Apache core never imports FSL code, and
+// composes with — never widens — the single-tenant `allowedSources`
+// bound (the narrowest bound always wins).
+//
+// Intended composition (defence in depth): an operator calls the RBAC
+// guard AND this catalog guard before a tool runs. RBAC answers "may
+// this principal perform this verb?"; the catalog answers "is this
+// resource within a product they were granted?". Both must allow.
+
+import { evaluateCatalog } from "./catalog.mjs";
+
+export class CatalogDeniedError extends Error {
+  constructor(decision, request) {
+    super(`Catalog denied: ${decision.reason}`);
+    this.name = "CatalogDeniedError";
+    this.code = "CATALOG_DENIED";
+    this.decision = decision;
+    this.request = request;
+  }
+}
+
+/**
+ * Enforce a catalog for a request in the scope of a core RequestContext.
+ * @param catalog the product catalog
+ * @param ctx     duck-typed RequestContext ({ principalId, allowedSources? })
+ * @param request { source?, service?, tool? }
+ * @returns the allow decision (on deny it throws CatalogDeniedError)
+ */
+export function enforceCatalog(catalog, ctx, request) {
+  const c = ctx || {};
+  const req = {
+    principalId: c.principalId,
+    source: request && request.source,
+    service: request && request.service,
+    tool: request && request.tool,
+  };
+
+  if (
+    req.source != null &&
+    Array.isArray(c.allowedSources) &&
+    c.allowedSources.length > 0 &&
+    !c.allowedSources.includes(req.source)
+  ) {
+    const decision = {
+      allow: false,
+      reason: `source '${req.source}' outside the context allow-list`,
+    };
+    throw new CatalogDeniedError(decision, req);
+  }
+
+  const decision = evaluateCatalog(catalog, req);
+  if (!decision.allow) throw new CatalogDeniedError(decision, req);
+  return decision;
+}
+
+/** Non-throwing variant — returns the decision. */
+export function checkCatalog(catalog, ctx, request) {
+  try {
+    return enforceCatalog(catalog, ctx, request);
+  } catch (e) {
+    if (e instanceof CatalogDeniedError) return e.decision;
+    throw e;
+  }
+}

--- a/enterprise/catalog/enforce.test.mjs
+++ b/enterprise/catalog/enforce.test.mjs
@@ -1,0 +1,58 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { enforceCatalog, checkCatalog, CatalogDeniedError } from "./enforce.mjs";
+
+const CATALOG = {
+  products: {
+    "eu-payments": { sources: ["prom-eu"], services: ["payment-service"] },
+  },
+  grants: { "key:alice": ["eu-payments"] },
+};
+
+const ctx = (over = {}) => ({ principalId: "key:alice", auth: "apikey", correlationId: "c1", ...over });
+
+test("enforceCatalog returns the allow decision when in a granted product", () => {
+  const d = enforceCatalog(CATALOG, ctx(), { source: "prom-eu", service: "payment-service" });
+  assert.equal(d.allow, true);
+  assert.equal(d.product, "eu-payments");
+});
+
+test("enforceCatalog throws CatalogDeniedError outside any granted product", () => {
+  let ran = false;
+  try {
+    enforceCatalog(CATALOG, ctx(), { source: "prom-us" });
+    ran = true;
+  } catch (e) {
+    assert.ok(e instanceof CatalogDeniedError);
+    assert.equal(e.code, "CATALOG_DENIED");
+    assert.match(e.message, /outside every granted product/);
+    assert.equal(e.request.source, "prom-us");
+  }
+  assert.equal(ran, false);
+});
+
+test("context allowedSources is a hard upper bound the catalog cannot exceed", () => {
+  const d = checkCatalog(CATALOG, ctx({ allowedSources: ["prom-eu"] }), { source: "prom-xx" });
+  assert.equal(d.allow, false);
+  assert.match(d.reason, /outside the context allow-list/);
+  assert.equal(
+    checkCatalog(CATALOG, ctx({ allowedSources: ["prom-eu"] }), { source: "prom-eu", service: "payment-service" }).allow,
+    true
+  );
+});
+
+test("anonymous / ungranted principal is denied (default-deny seam)", () => {
+  const d = checkCatalog(CATALOG, { principalId: "anonymous", auth: "anonymous" }, { source: "prom-eu" });
+  assert.equal(d.allow, false);
+  assert.match(d.reason, /no product grants \(default-deny\)/);
+});
+
+test("checkCatalog never throws, returns the decision", () => {
+  const d = checkCatalog(CATALOG, ctx(), { source: "prom-us" });
+  assert.equal(d.allow, false);
+  assert.equal(typeof d.reason, "string");
+});
+
+test("missing ctx → anonymous → denied", () => {
+  assert.equal(checkCatalog(CATALOG, undefined, { source: "prom-eu" }).allow, false);
+});

--- a/enterprise/catalog/index.mjs
+++ b/enterprise/catalog/index.mjs
@@ -1,0 +1,8 @@
+// Public surface of the FSL Catalog/Products module (FSL-1.1-Apache-2.0).
+export {
+  evaluateCatalog,
+  resolveProducts,
+  productScope,
+  grantedProductNames,
+} from "./catalog.mjs";
+export { enforceCatalog, checkCatalog, CatalogDeniedError } from "./enforce.mjs";

--- a/enterprise/catalog/package.json
+++ b/enterprise/catalog/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@observability-mcp/enterprise-catalog",
+  "version": "1.0.0",
+  "description": "Governed product catalog for observability-mcp (enterprise tier).",
+  "private": true,
+  "type": "module",
+  "main": "./index.mjs",
+  "license": "FSL-1.1-Apache-2.0",
+  "scripts": {
+    "test": "node --test *.test.mjs"
+  }
+}


### PR DESCRIPTION
## What

Second FSL enterprise module: **`enterprise/catalog`** — a governed **product catalog**.

- **Products**: named, curated bundles of observability scope — which `sources` / `services` / `tools` belong together as one consumable unit.
- **Grants**: which principals may consume which products (with `defaultProducts` fallback for ungranted principals).
- **`catalog.mjs`** — pure, dependency-free, **default-deny** evaluator: `evaluateCatalog`, `resolveProducts`, `productScope` (flattened union + unrestricted-axis flags), `grantedProductNames`. Wildcards (`*`), omitted-axis = unrestricted, multi-product union.
- **`enforce.mjs`** — `enforceCatalog` / `checkCatalog` / `CatalogDeniedError`, **duck-typed against the core `RequestContext`** so the Apache core never imports FSL code; composes with — never widens — the single-tenant `allowedSources` bound.

Orthogonal to `enterprise/rbac` and designed to compose with it (defence in depth): **RBAC** answers "which verbs may this principal perform?", the **catalog** answers "is this resource within a product they were granted?" — both must allow.

## Verification (real, end-to-end)
- `node --test enterprise/catalog/*.test.mjs` — **18/18 pass**
- Full enterprise suite — **34/34** (rbac 16 + catalog 18)
- OSS exclusion **re-proven**: `npm pack --dry-run` in `mcp-server` → zero `enterprise/` files; Docker build context is `./mcp-server` (top-level `enterprise/` structurally cannot enter the image)
- No `mcp-server/` files touched → core behaviour provably unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)