### PR TITLE
feat(enterprise): tamper-evident append-only audit log (FSL-1.1-Apache-2.0)

### DIFF
--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -22,6 +22,7 @@ operator.
 |--------|--------------|
 | [`rbac/`](./rbac) | Role-based access control: a pure policy evaluator + an enforcement guard that maps a request's principal/roles to an allow/deny decision over tools, sources, and services. Default-deny. |
 | [`catalog/`](./catalog) | Governed product catalog: publish named **products** (curated bundles of sources/services/tools) and **grants** of products to principals; pure evaluator + enforcement guard. Default-deny. Composes with `rbac/` (both must allow). |
+| [`audit/`](./audit) | Append-only, tamper-evident audit log: hash-chained access-control decisions and tool invocations; `verifyChain` detects any modification, reorder, insertion or mid-log truncation. Sink-injected (file/SIEM), dependency-free (`node:crypto`). |
 
 ## Integration contract
 

--- a/enterprise/audit/audit.mjs
+++ b/enterprise/audit/audit.mjs
@@ -1,0 +1,110 @@
+// Append-only, tamper-evident audit log (FSL-1.1-Apache-2.0).
+//
+// Records access-control decisions (rbac / catalog) and tool
+// invocations into a hash-chained sequence: every entry carries the
+// hash of the previous entry, so any insertion, modification,
+// reordering or truncation of the middle of the log is detectable by
+// re-walking the chain. Uses only node:crypto — dependency-free.
+//
+// The log is sink-injected (default: in-memory) so it is pure and
+// exhaustively testable; an operator passes a sink that appends a line
+// to a file / ships it to a SIEM. The sink only ever APPENDS — there is
+// no update or delete path by construction.
+
+import { createHash } from "node:crypto";
+
+const GENESIS = "0".repeat(64);
+
+// Deterministic JSON: object keys sorted recursively, so the hash of a
+// logically-equal record is stable regardless of insertion order.
+export function canonical(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return "[" + value.map(canonical).join(",") + "]";
+  const keys = Object.keys(value).sort();
+  return "{" + keys.map((k) => JSON.stringify(k) + ":" + canonical(value[k])).join(",") + "}";
+}
+
+function hashEntry(prevHash, body) {
+  return createHash("sha256").update(prevHash + "\n" + canonical(body)).digest("hex");
+}
+
+/**
+ * Create an append-only audit log.
+ * @param opts.sink optional (entry) => void|Promise — receives each
+ *   sealed entry exactly once, in order. Defaults to in-memory only.
+ * @param opts.now  optional () => ISO string clock (injectable for tests)
+ */
+export function createAuditLog(opts = {}) {
+  const sink = typeof opts.sink === "function" ? opts.sink : null;
+  const now = typeof opts.now === "function" ? opts.now : () => new Date().toISOString();
+  const entries = [];
+  let lastHash = GENESIS;
+  let seq = 0;
+
+  async function record(event) {
+    const body = {
+      seq,
+      ts: now(),
+      prevHash: lastHash,
+      event: event || {},
+    };
+    const hash = hashEntry(lastHash, body);
+    const sealed = { ...body, hash };
+    entries.push(sealed);
+    lastHash = hash;
+    seq += 1;
+    if (sink) await sink(sealed);
+    return sealed;
+  }
+
+  return {
+    record,
+    /** A defensive copy of the chain so far. */
+    entries: () => entries.map((e) => ({ ...e })),
+    head: () => lastHash,
+    /** Verify the in-memory chain. */
+    verify: () => verifyChain(entries),
+  };
+}
+
+/**
+ * Re-walk a chain and confirm every link. Detects modification,
+ * insertion, reordering and truncation-in-the-middle.
+ * @returns {{ok: boolean, brokenAt?: number, reason?: string}}
+ */
+export function verifyChain(records) {
+  if (!Array.isArray(records)) return { ok: false, reason: "not an array" };
+  let prev = GENESIS;
+  for (let i = 0; i < records.length; i++) {
+    const r = records[i];
+    if (!r || typeof r !== "object") return { ok: false, brokenAt: i, reason: "missing entry" };
+    if (r.seq !== i) return { ok: false, brokenAt: i, reason: `seq ${r.seq} != position ${i}` };
+    if (r.prevHash !== prev) return { ok: false, brokenAt: i, reason: "prevHash mismatch (reorder/insert/truncate)" };
+    const { hash, ...body } = r;
+    if (hashEntry(prev, body) !== hash) return { ok: false, brokenAt: i, reason: "hash mismatch (tampered)" };
+    prev = hash;
+  }
+  return { ok: true };
+}
+
+/**
+ * Convenience: record an access-control decision from rbac/catalog in a
+ * consistent shape. `ctx` is duck-typed against the core RequestContext.
+ */
+export function auditDecision(log, ctx, request, decision, module) {
+  const c = ctx || {};
+  return log.record({
+    kind: "access-decision",
+    module: module || "unknown",
+    principalId: c.principalId ?? null,
+    auth: c.auth ?? null,
+    correlationId: c.correlationId ?? null,
+    request: {
+      tool: (request && request.tool) ?? null,
+      source: (request && request.source) ?? null,
+      service: (request && request.service) ?? null,
+    },
+    allow: !!(decision && decision.allow),
+    reason: (decision && decision.reason) ?? null,
+  });
+}

--- a/enterprise/audit/audit.test.mjs
+++ b/enterprise/audit/audit.test.mjs
@@ -1,0 +1,132 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createAuditLog, verifyChain, auditDecision, canonical } from "./audit.mjs";
+
+const fixedClock = () => {
+  let t = 0;
+  return () => `2026-05-18T00:00:${String(t++).padStart(2, "0")}.000Z`;
+};
+
+test("canonical: stable key order, recursive, primitives", () => {
+  assert.equal(canonical({ b: 1, a: 2 }), '{"a":2,"b":1}');
+  assert.equal(canonical({ a: { d: 4, c: 3 } }), '{"a":{"c":3,"d":4}}');
+  assert.equal(canonical([3, { y: 1, x: 2 }]), '[3,{"x":2,"y":1}]');
+  assert.equal(canonical("s"), '"s"');
+  assert.equal(canonical(null), "null");
+});
+
+test("append builds a verifiable hash chain from genesis", async () => {
+  const log = createAuditLog({ now: fixedClock() });
+  await log.record({ kind: "a" });
+  await log.record({ kind: "b" });
+  await log.record({ kind: "c" });
+  const e = log.entries();
+  assert.equal(e.length, 3);
+  assert.deepEqual([e[0].seq, e[1].seq, e[2].seq], [0, 1, 2]);
+  assert.equal(e[0].prevHash, "0".repeat(64));
+  assert.equal(e[1].prevHash, e[0].hash);
+  assert.equal(e[2].prevHash, e[1].hash);
+  assert.equal(log.verify().ok, true);
+  assert.equal(log.head(), e[2].hash);
+});
+
+test("modifying any field breaks verification at that entry", async () => {
+  const log = createAuditLog({ now: fixedClock() });
+  await log.record({ kind: "x", v: 1 });
+  await log.record({ kind: "y", v: 2 });
+  await log.record({ kind: "z", v: 3 });
+  const tampered = log.entries();
+  tampered[1].event.v = 999; // silent edit
+  const r = verifyChain(tampered);
+  assert.equal(r.ok, false);
+  assert.equal(r.brokenAt, 1);
+  assert.match(r.reason, /tampered/);
+});
+
+test("reordering entries is detected", async () => {
+  const log = createAuditLog({ now: fixedClock() });
+  await log.record({ n: 1 });
+  await log.record({ n: 2 });
+  const e = log.entries();
+  const swapped = [e[1], e[0]];
+  const r = verifyChain(swapped);
+  assert.equal(r.ok, false);
+  assert.equal(r.brokenAt, 0);
+});
+
+test("truncating the middle is detected (seq/prevHash gap)", async () => {
+  const log = createAuditLog({ now: fixedClock() });
+  await log.record({ n: 1 });
+  await log.record({ n: 2 });
+  await log.record({ n: 3 });
+  const e = log.entries();
+  const dropped = [e[0], e[2]]; // remove the middle
+  const r = verifyChain(dropped);
+  assert.equal(r.ok, false);
+  assert.equal(r.brokenAt, 1);
+});
+
+test("appending a forged entry without the real prevHash is detected", async () => {
+  const log = createAuditLog({ now: fixedClock() });
+  await log.record({ n: 1 });
+  const e = log.entries();
+  e.push({ seq: 1, ts: "t", prevHash: "f".repeat(64), event: { forged: true }, hash: "deadbeef" });
+  const r = verifyChain(e);
+  assert.equal(r.ok, false);
+  assert.equal(r.brokenAt, 1);
+});
+
+test("sink receives each sealed entry exactly once, in order", async () => {
+  const seen = [];
+  const log = createAuditLog({ now: fixedClock(), sink: (x) => seen.push(x.event.k) });
+  await log.record({ k: "first" });
+  await log.record({ k: "second" });
+  assert.deepEqual(seen, ["first", "second"]);
+  assert.equal(verifyChain(log.entries()).ok, true);
+});
+
+test("async sink is awaited", async () => {
+  const order = [];
+  const log = createAuditLog({
+    now: fixedClock(),
+    sink: async (x) => { await Promise.resolve(); order.push(x.seq); },
+  });
+  await log.record({ a: 1 });
+  await log.record({ a: 2 });
+  assert.deepEqual(order, [0, 1]);
+});
+
+test("auditDecision records a consistent access-decision shape", async () => {
+  const log = createAuditLog({ now: fixedClock() });
+  const ctx = { principalId: "key:bob", auth: "apikey", correlationId: "corr-1" };
+  await auditDecision(
+    log,
+    ctx,
+    { tool: "query_metrics", source: "prom-eu", service: "payment-service" },
+    { allow: false, reason: "denied — no bound role" },
+    "rbac"
+  );
+  const [e] = log.entries();
+  assert.equal(e.event.kind, "access-decision");
+  assert.equal(e.event.module, "rbac");
+  assert.equal(e.event.principalId, "key:bob");
+  assert.equal(e.event.allow, false);
+  assert.equal(e.event.request.tool, "query_metrics");
+  assert.match(e.event.reason, /no bound role/);
+  assert.equal(verifyChain(log.entries()).ok, true);
+});
+
+test("auditDecision tolerates missing ctx/request/decision", async () => {
+  const log = createAuditLog({ now: fixedClock() });
+  await auditDecision(log, undefined, undefined, undefined, undefined);
+  const [e] = log.entries();
+  assert.equal(e.event.principalId, null);
+  assert.equal(e.event.module, "unknown");
+  assert.equal(e.event.allow, false);
+  assert.equal(verifyChain(log.entries()).ok, true);
+});
+
+test("verifyChain rejects non-arrays and empty is trivially ok", () => {
+  assert.equal(verifyChain(null).ok, false);
+  assert.equal(verifyChain([]).ok, true);
+});

--- a/enterprise/audit/index.mjs
+++ b/enterprise/audit/index.mjs
@@ -1,0 +1,2 @@
+// Public surface of the FSL Audit module (FSL-1.1-Apache-2.0).
+export { createAuditLog, verifyChain, auditDecision, canonical } from "./audit.mjs";

--- a/enterprise/audit/package.json
+++ b/enterprise/audit/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@observability-mcp/enterprise-audit",
+  "version": "1.0.0",
+  "description": "Tamper-evident append-only audit log for observability-mcp (enterprise tier).",
+  "private": true,
+  "type": "module",
+  "main": "./index.mjs",
+  "license": "FSL-1.1-Apache-2.0",
+  "scripts": {
+    "test": "node --test *.test.mjs"
+  }
+}


### PR DESCRIPTION
## What

Third FSL enterprise module: **`enterprise/audit`** — a tamper-evident, append-only audit log.

- Records access-control decisions (`rbac` / `catalog`) and tool invocations into a **hash chain**: each entry seals `prevHash`, so the integrity of the whole sequence is one re-walk away.
- **`verifyChain(records)`** detects any **modification, reordering, insertion, or mid-log truncation**, returning the exact broken index + reason.
- **Sink-injected**: default in-memory; an operator passes a sink that appends a line to a file or ships to a SIEM. There is **no update or delete path** by construction — append-only.
- Dependency-free (`node:crypto`), duck-typed against the core `RequestContext`. `auditDecision(log, ctx, request, decision, module)` writes a consistent access-decision shape. `canonical()` gives deterministic JSON so logically-equal records hash identically.

## Verification (real, end-to-end)
- `node --test enterprise/audit/*.test.mjs` — **11/11 pass** (chain build, tamper/reorder/truncate/forge detection, async sink ordering, canonicalization, missing-input tolerance)
- Full enterprise suite — **45/45** (rbac 16 + catalog 18 + audit 11)
- OSS exclusion **re-proven**: `npm pack --dry-run` in `mcp-server` → zero `enterprise/` files; Docker build context `./mcp-server`
- No `mcp-server/` files touched → core behaviour provably unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)