### PR TITLE
feat(enterprise): Ed25519 entitlement token verification (FSL-1.1-Apache-2.0)

### DIFF
--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -23,6 +23,7 @@ operator.
 | [`rbac/`](./rbac) | Role-based access control: a pure policy evaluator + an enforcement guard that maps a request's principal/roles to an allow/deny decision over tools, sources, and services. Default-deny. |
 | [`catalog/`](./catalog) | Governed product catalog: publish named **products** (curated bundles of sources/services/tools) and **grants** of products to principals; pure evaluator + enforcement guard. Default-deny. Composes with `rbac/` (both must allow). |
 | [`audit/`](./audit) | Append-only, tamper-evident audit log: hash-chained access-control decisions and tool invocations; `verifyChain` detects any modification, reorder, insertion or mid-log truncation. Sink-injected (file/SIEM), dependency-free (`node:crypto`). |
+| [`entitlement/`](./entitlement) | Ed25519-signed entitlement tokens: an issuer signs `{ sub, tier, features, iat, exp }`; the deployment verifies offline and gates feature activation. Default-deny on any structural/signature/expiry failure. Dependency-free (`node:crypto`). |
 
 ## Integration contract
 

--- a/enterprise/entitlement/entitlement.mjs
+++ b/enterprise/entitlement/entitlement.mjs
@@ -1,0 +1,127 @@
+// Ed25519-signed entitlement token verification (FSL-1.1-Apache-2.0).
+//
+// An entitlement token authorises which enterprise features an operator
+// deployment may switch on. Format (compact, URL-safe, dependency-free):
+//
+//     base64url(canonicalPayloadJSON) "." base64url(ed25519Signature)
+//
+// Payload claims:
+//   { sub, tier, features: string[], iat, exp }   (iat/exp = epoch seconds)
+//
+// The issuer (us) signs with an Ed25519 private key; the deployment
+// verifies with the embedded/configured public key. Verification is
+// DEFAULT-DENY: any structural, signature, or temporal failure yields
+// { valid:false } and `requireFeature` throws — a missing or bad token
+// never silently unlocks a feature.
+//
+// Pure crypto via node:crypto only. The clock is injectable so expiry
+// logic is deterministically testable.
+
+import { sign as edSign, verify as edVerify } from "node:crypto";
+
+// Deterministic JSON (stable recursive key order) so the exact bytes
+// signed by the issuer are the exact bytes verified here.
+export function canonical(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return "[" + value.map(canonical).join(",") + "]";
+  const keys = Object.keys(value).sort();
+  return "{" + keys.map((k) => JSON.stringify(k) + ":" + canonical(value[k])).join(",") + "}";
+}
+
+const b64url = (buf) =>
+  Buffer.from(buf).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+
+function b64urlDecode(str) {
+  const pad = str.length % 4 === 0 ? "" : "=".repeat(4 - (str.length % 4));
+  return Buffer.from(str.replace(/-/g, "+").replace(/_/g, "/") + pad, "base64");
+}
+
+/** Issuer side (also used by tests/tooling): sign a payload. */
+export function signEntitlement(payload, privateKey) {
+  const bytes = Buffer.from(canonical(payload), "utf8");
+  const sig = edSign(null, bytes, privateKey);
+  return `${b64url(bytes)}.${b64url(sig)}`;
+}
+
+/**
+ * Verify an entitlement token.
+ * @param token      "<b64url payload>.<b64url sig>"
+ * @param publicKey  Ed25519 public key (KeyObject or PEM string)
+ * @param opts.now   () => epoch seconds (injectable; default real clock)
+ * @param opts.skew  allowed clock skew in seconds for iat (default 60)
+ * @returns {{valid:boolean, reason:string, claims?:object}}
+ */
+export function verifyEntitlement(token, publicKey, opts = {}) {
+  const now = typeof opts.now === "function" ? opts.now : () => Math.floor(Date.now() / 1000);
+  const skew = Number.isFinite(opts.skew) ? opts.skew : 60;
+
+  if (typeof token !== "string" || token.indexOf(".") < 0) {
+    return { valid: false, reason: "malformed token" };
+  }
+  const [p, s] = token.split(".");
+  if (!p || !s) return { valid: false, reason: "malformed token (missing segment)" };
+
+  let payloadBytes;
+  let claims;
+  try {
+    payloadBytes = b64urlDecode(p);
+    claims = JSON.parse(payloadBytes.toString("utf8"));
+  } catch {
+    return { valid: false, reason: "payload not valid base64url JSON" };
+  }
+  if (!claims || typeof claims !== "object") {
+    return { valid: false, reason: "payload is not an object" };
+  }
+
+  let sigOk = false;
+  try {
+    sigOk = edVerify(null, payloadBytes, publicKey, b64urlDecode(s));
+  } catch {
+    return { valid: false, reason: "signature could not be verified (bad key?)" };
+  }
+  if (!sigOk) return { valid: false, reason: "signature mismatch" };
+
+  // Re-canonicalise: reject a token whose JSON encoding isn't canonical,
+  // so the signed bytes are unambiguous (defence against payload reshaping).
+  if (canonical(claims) !== payloadBytes.toString("utf8")) {
+    return { valid: false, reason: "payload not in canonical form" };
+  }
+
+  const t = now();
+  if (typeof claims.exp === "number" && t >= claims.exp) {
+    return { valid: false, reason: "token expired" };
+  }
+  if (typeof claims.iat === "number" && claims.iat > t + skew) {
+    return { valid: false, reason: "token not yet valid (iat in the future)" };
+  }
+
+  return { valid: true, reason: "ok", claims };
+}
+
+/** True iff the verified claims grant a feature ("*" = all features). */
+export function hasFeature(claims, feature) {
+  if (!claims || !Array.isArray(claims.features)) return false;
+  return claims.features.includes("*") || claims.features.includes(feature);
+}
+
+export class EntitlementError extends Error {
+  constructor(reason) {
+    super(`Entitlement denied: ${reason}`);
+    this.name = "EntitlementError";
+    this.code = "ENTITLEMENT_DENIED";
+    this.reason = reason;
+  }
+}
+
+/**
+ * Gate: verify the token AND require a feature. Throws EntitlementError
+ * on any failure (default-deny). Returns the verified claims on success.
+ */
+export function requireFeature(token, publicKey, feature, opts = {}) {
+  const res = verifyEntitlement(token, publicKey, opts);
+  if (!res.valid) throw new EntitlementError(res.reason);
+  if (!hasFeature(res.claims, feature)) {
+    throw new EntitlementError(`feature '${feature}' not entitled`);
+  }
+  return res.claims;
+}

--- a/enterprise/entitlement/entitlement.test.mjs
+++ b/enterprise/entitlement/entitlement.test.mjs
@@ -1,0 +1,118 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync, sign as edSign } from "node:crypto";
+import {
+  signEntitlement,
+  verifyEntitlement,
+  hasFeature,
+  requireFeature,
+  canonical,
+  EntitlementError,
+} from "./entitlement.mjs";
+
+const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+const { publicKey: otherPub } = generateKeyPairSync("ed25519");
+
+const T0 = 1_700_000_000; // fixed "now"
+const clock = (t = T0) => () => t;
+
+function token(over = {}) {
+  // canonical() sorts keys, so payload object key order here is irrelevant.
+  const payload = { sub: "org-acme", tier: "enterprise", features: ["rbac", "audit"], iat: T0 - 10, exp: T0 + 3600, ...over };
+  return signEntitlement(payload, privateKey);
+}
+
+test("canonical produces stable, recursively-sorted JSON", () => {
+  assert.equal(canonical({ b: 1, a: { d: 2, c: 3 } }), '{"a":{"c":3,"d":2},"b":1}');
+});
+
+test("a freshly signed token verifies and returns claims", () => {
+  const r = verifyEntitlement(token(), publicKey, { now: clock() });
+  assert.equal(r.valid, true);
+  assert.equal(r.claims.sub, "org-acme");
+  assert.deepEqual(r.claims.features, ["rbac", "audit"]);
+});
+
+test("wrong public key → signature mismatch (default-deny)", () => {
+  const r = verifyEntitlement(token(), otherPub, { now: clock() });
+  assert.equal(r.valid, false);
+  assert.match(r.reason, /signature mismatch/);
+});
+
+test("tampering the payload after signing is rejected", () => {
+  const t = token();
+  const [p, s] = t.split(".");
+  const claims = JSON.parse(Buffer.from(p.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString());
+  claims.features.push("entitlement"); // privilege escalation attempt
+  const forgedPayload = Buffer.from(JSON.stringify(claims)).toString("base64")
+    .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  const r = verifyEntitlement(`${forgedPayload}.${s}`, publicKey, { now: clock() });
+  assert.equal(r.valid, false); // sig no longer matches the changed bytes
+});
+
+test("expired token is denied", () => {
+  const r = verifyEntitlement(token({ exp: T0 - 1 }), publicKey, { now: clock() });
+  assert.equal(r.valid, false);
+  assert.match(r.reason, /expired/);
+});
+
+test("not-yet-valid token (iat in the future beyond skew) is denied", () => {
+  const r = verifyEntitlement(token({ iat: T0 + 1000 }), publicKey, { now: clock(), skew: 60 });
+  assert.equal(r.valid, false);
+  assert.match(r.reason, /not yet valid/);
+});
+
+test("iat within skew window is accepted", () => {
+  const r = verifyEntitlement(token({ iat: T0 + 30 }), publicKey, { now: clock(), skew: 60 });
+  assert.equal(r.valid, true);
+});
+
+test("malformed tokens are denied, never thrown", () => {
+  for (const bad of ["", "no-dot", "a.b.c", ".", "x.", ".y", 42, null]) {
+    const r = verifyEntitlement(bad, publicKey, { now: clock() });
+    assert.equal(r.valid, false);
+  }
+});
+
+test("non-canonical payload encoding is rejected even if signature is valid", () => {
+  // Sign deliberately non-canonical JSON bytes (keys unsorted) → the
+  // signature is valid for those bytes but verify must reject the shape.
+  const raw = Buffer.from('{"b":2,"a":1}', "utf8");
+  const sig = edSign(null, raw, privateKey);
+  const b = (x) => Buffer.from(x).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  const r = verifyEntitlement(`${b(raw)}.${b(sig)}`, publicKey, { now: clock() });
+  assert.equal(r.valid, false);
+  assert.match(r.reason, /canonical/);
+});
+
+test("hasFeature honours explicit list and the '*' wildcard", () => {
+  assert.equal(hasFeature({ features: ["rbac"] }, "rbac"), true);
+  assert.equal(hasFeature({ features: ["rbac"] }, "audit"), false);
+  assert.equal(hasFeature({ features: ["*"] }, "anything"), true);
+  assert.equal(hasFeature({}, "x"), false);
+  assert.equal(hasFeature(null, "x"), false);
+});
+
+test("requireFeature returns claims when entitled", () => {
+  const claims = requireFeature(token(), publicKey, "audit", { now: clock() });
+  assert.equal(claims.sub, "org-acme");
+});
+
+test("requireFeature throws EntitlementError when token invalid", () => {
+  assert.throws(
+    () => requireFeature(token({ exp: T0 - 1 }), publicKey, "rbac", { now: clock() }),
+    (e) => e instanceof EntitlementError && e.code === "ENTITLEMENT_DENIED" && /expired/.test(e.reason)
+  );
+});
+
+test("requireFeature throws when the feature is not entitled", () => {
+  assert.throws(
+    () => requireFeature(token({ features: ["rbac"] }), publicKey, "catalog", { now: clock() }),
+    (e) => e instanceof EntitlementError && /feature 'catalog' not entitled/.test(e.reason)
+  );
+});
+
+test("a wildcard token entitles every feature", () => {
+  const claims = requireFeature(token({ features: ["*"] }), publicKey, "entitlement", { now: clock() });
+  assert.ok(claims);
+});

--- a/enterprise/entitlement/index.mjs
+++ b/enterprise/entitlement/index.mjs
@@ -1,0 +1,9 @@
+// Public surface of the FSL Entitlement module (FSL-1.1-Apache-2.0).
+export {
+  signEntitlement,
+  verifyEntitlement,
+  hasFeature,
+  requireFeature,
+  canonical,
+  EntitlementError,
+} from "./entitlement.mjs";

--- a/enterprise/entitlement/package.json
+++ b/enterprise/entitlement/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@observability-mcp/enterprise-entitlement",
+  "version": "1.0.0",
+  "description": "Ed25519-signed entitlement token verification for observability-mcp (enterprise tier).",
+  "private": true,
+  "type": "module",
+  "main": "./index.mjs",
+  "license": "FSL-1.1-Apache-2.0",
+  "scripts": {
+    "test": "node --test *.test.mjs"
+  }
+}


### PR DESCRIPTION
## What

Fourth and final FSL enterprise module: **`enterprise/entitlement`** — offline Ed25519 entitlement-token verification, completing the enterprise FSL tier (RBAC → Catalog → Audit → **Entitlement**).

- An issuer signs a compact, URL-safe token `base64url(canonicalPayload).base64url(ed25519Sig)` with claims `{ sub, tier, features, iat, exp }`.
- The deployment verifies it **offline** with the public key and gates which enterprise features may activate.
- **Default-deny**: any structural / signature / non-canonical / expiry / not-yet-valid failure → `{ valid:false }`, and `requireFeature` throws `EntitlementError`. A missing or forged token never silently unlocks a feature.
- Canonical JSON binds the exact signed bytes (rejects payload-reshaping attacks even when a signature is otherwise valid). Dependency-free (`node:crypto`); clock injectable.
- API: `signEntitlement` (issuer/tooling), `verifyEntitlement`, `hasFeature` (`*` wildcard), `requireFeature`, `canonical`, `EntitlementError`.

## Verification (real, end-to-end)
- `node --test enterprise/entitlement/*.test.mjs` — **14/14 pass** with a real generated Ed25519 keypair: valid verify, wrong-key, post-sign tamper, expiry, iat-skew window, non-canonical-encoding rejection, malformed tokens, feature gating
- Full enterprise suite — **59/59** (rbac 16 + catalog 18 + audit 11 + entitlement 14)
- OSS exclusion **re-proven**: `npm pack --dry-run` in `mcp-server` → zero `enterprise/` files; Docker build context `./mcp-server`
- No `mcp-server/` files touched → core behaviour provably unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)