### PR TITLE
feat: optional entitlement-gated access-control seam

### DIFF
--- a/mcp-server/src/enterprise-gate.test.ts
+++ b/mcp-server/src/enterprise-gate.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { defaultContext } from "./context.js";
+import {
+  enforceEntitledAccess,
+  enterpriseGateStatus,
+  _resetEnterpriseGate,
+} from "./enterprise-gate.js";
+
+// These tests run in the mcp-server sandbox where enterprise/ is ABSENT
+// (it is excluded from the npm package and the Docker build context) —
+// exactly the published-artifact state. They pin the security contract:
+//
+//   - no opt-in            → OFF, perfect no-op (zero behaviour change)
+//   - control configured   → FAIL-CLOSED when the gate can't activate
+//                            (a broken/absent entitlement must DENY,
+//                             never silently open)
+
+function clearEnv() {
+  for (const k of [
+    "OMCP_ENTITLEMENT_TOKEN",
+    "OMCP_ENTITLEMENT_PUBKEY",
+    "OMCP_RBAC_POLICY",
+    "OMCP_CATALOG",
+    "OMCP_AUDIT_FILE",
+  ]) {
+    delete process.env[k];
+  }
+  _resetEnterpriseGate();
+}
+
+describe("enterprise-gate — OFF (no opt-in, published-artifact state)", () => {
+  afterEach(clearEnv);
+
+  it("no entitlement, no controls → awaited no-op, gate mode 'off'", async () => {
+    clearEnv();
+    await assert.doesNotReject(
+      enforceEntitledAccess(defaultContext(), { tool: "query_metrics", service: "payment" })
+    );
+    const st = await enterpriseGateStatus();
+    assert.equal(st.active, false);
+    assert.equal(st.mode, "off");
+  });
+
+  it("token set but NO control configured → still OFF (no opt-in), no throw", async () => {
+    clearEnv();
+    process.env.OMCP_ENTITLEMENT_TOKEN = "deadbeef.cafebabe";
+    process.env.OMCP_ENTITLEMENT_PUBKEY = "-----BEGIN PUBLIC KEY-----\\nX\\n-----END PUBLIC KEY-----";
+    _resetEnterpriseGate();
+    await assert.doesNotReject(enforceEntitledAccess(defaultContext(), { tool: "list_sources" }));
+    assert.equal((await enterpriseGateStatus()).mode, "off");
+  });
+
+  it("every tool name passes through cleanly when OFF", async () => {
+    clearEnv();
+    for (const tool of [
+      "list_sources",
+      "list_services",
+      "query_metrics",
+      "query_logs",
+      "get_service_health",
+      "detect_anomalies",
+    ]) {
+      await assert.doesNotReject(enforceEntitledAccess(defaultContext(), { tool }));
+    }
+  });
+
+  it("gate state is memoised across calls", async () => {
+    clearEnv();
+    assert.deepEqual(await enterpriseGateStatus(), await enterpriseGateStatus());
+  });
+});
+
+describe("enterprise-gate — FAIL-CLOSED (opted in, cannot activate)", () => {
+  afterEach(clearEnv);
+
+  it("RBAC policy configured but enterprise/ absent → DENY every tool call", async () => {
+    clearEnv();
+    const dir = mkdtempSync(join(tmpdir(), "gate-fc-"));
+    const policy = join(dir, "rbac.json");
+    writeFileSync(policy, JSON.stringify({ roles: {}, bindings: {} }));
+    process.env.OMCP_RBAC_POLICY = policy; // operator opted into a control
+    _resetEnterpriseGate();
+
+    const st = await enterpriseGateStatus();
+    assert.equal(st.active, false);
+    assert.equal(st.mode, "fail-closed");
+
+    await assert.rejects(
+      () => enforceEntitledAccess(defaultContext(), { tool: "query_metrics" }),
+      /access denied: enterprise control configured but inactive/
+    );
+  });
+
+  it("control configured + no token → fail-closed (not a silent open)", async () => {
+    clearEnv();
+    process.env.OMCP_CATALOG = "/nonexistent/catalog.json";
+    _resetEnterpriseGate();
+    assert.equal((await enterpriseGateStatus()).mode, "fail-closed");
+    await assert.rejects(
+      () => enforceEntitledAccess(defaultContext(), { tool: "list_services" }),
+      /access denied/
+    );
+  });
+});

--- a/mcp-server/src/enterprise-gate.ts
+++ b/mcp-server/src/enterprise-gate.ts
@@ -1,0 +1,234 @@
+// Enterprise gate — the OPTIONAL seam that lets a deployment activate the
+// source-available enterprise/ modules (RBAC, Catalog, Audit) behind a
+// signed entitlement token.
+//
+// Hard rules this file obeys, so the Apache-2.0 core stays clean:
+//
+//   1. NO static import of anything under enterprise/. The modules are
+//      loaded with a dynamic import() of a computed specifier, so the
+//      Apache build never references FSL code.
+//   2. DEFAULT-OFF and fail-safe. With no entitlement token configured —
+//      the only state the published npm/Docker artifact can be in, since
+//      enterprise/ is excluded from both — `enforceEntitledAccess` is an
+//      awaited no-op and behaviour is byte-for-byte unchanged.
+//   3. enterprise/ is a sibling of mcp-server/. It is absent from the
+//      published artifact; a failed dynamic import must therefore leave
+//      the gate cleanly OFF, never crash.
+//
+// Activation (only when an operator opts in, from a full checkout that
+// still contains enterprise/):
+//
+//   OMCP_ENTITLEMENT_TOKEN   signed token  "<b64url payload>.<b64url sig>"
+//   OMCP_ENTITLEMENT_PUBKEY  Ed25519 public key — PEM literal, or @<path>
+//   OMCP_RBAC_POLICY         optional path to an RBAC policy JSON
+//   OMCP_CATALOG             optional path to a product-catalog JSON
+//
+// Feature gating: the token's `features` must include "access-control"
+// for RBAC/Catalog enforcement and "audit" for the audit log. If a
+// policy/catalog file is configured but the token does not entitle
+// "access-control", access is denied (fail-closed — a configured control
+// must never be silently disabled).
+
+import { readFileSync, appendFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import type { RequestContext } from "./context.js";
+
+// enterprise/ relative to this file (src/ at dev, dist/ at runtime) — in
+// both layouts ../../enterprise resolves to the repo-level directory.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ENTERPRISE_DIR = resolve(HERE, "..", "..", "enterprise");
+
+export interface ToolRequest {
+  tool: string;
+  source?: string;
+  service?: string;
+}
+
+// Three modes, not two — this distinction is the whole security story:
+//
+//   off          no controls configured AND no entitlement → pure
+//                 pass-through. The ONLY state the published artifact
+//                 can reach (enterprise/ is excluded from it).
+//   fail-closed  the operator CONFIGURED a control (OMCP_RBAC_POLICY /
+//                 OMCP_CATALOG) but the gate could not be activated
+//                 (missing/invalid/expired token, or modules absent).
+//                 A broken entitlement must DENY, never silently open.
+//   active       valid entitlement + controls → enforce normally.
+type GateState =
+  | { mode: "off" }
+  | { mode: "fail-closed"; reason: string }
+  | {
+      mode: "active";
+      claims: Record<string, unknown>;
+      accessControl: boolean;
+      enforceRbac?: (policy: unknown, ctx: unknown, req: unknown) => unknown;
+      enforceCatalog?: (catalog: unknown, ctx: unknown, req: unknown) => unknown;
+      rbacPolicy?: unknown;
+      catalog?: unknown;
+      audit?: { record: (e: unknown) => Promise<unknown> };
+    };
+
+/** Did the operator opt into any enterprise control? */
+function controlsConfigured(): boolean {
+  return !!(process.env.OMCP_RBAC_POLICY || process.env.OMCP_CATALOG);
+}
+
+/** Map an inability-to-activate into off (no opt-in) or fail-closed. */
+function inactive(reason: string): GateState {
+  return controlsConfigured() ? { mode: "fail-closed", reason } : { mode: "off" };
+}
+
+let gatePromise: Promise<GateState> | null = null;
+
+function readPubKey(spec: string): string {
+  if (spec.startsWith("@")) return readFileSync(spec.slice(1), "utf8");
+  return spec.replace(/\\n/g, "\n");
+}
+
+function readJsonFile(path: string): unknown {
+  return JSON.parse(readFileSync(resolve(path), "utf8"));
+}
+
+async function buildGate(): Promise<GateState> {
+  const token = process.env.OMCP_ENTITLEMENT_TOKEN;
+  const pub = process.env.OMCP_ENTITLEMENT_PUBKEY;
+  if (!token || !pub) {
+    return inactive("no entitlement token configured");
+  }
+
+  // Dynamic, dependency-free import. If enterprise/ is absent (the
+  // published artifact) this throws → no opt-in means OFF; a configured
+  // control with absent modules means FAIL-CLOSED.
+  let entitlementMod: any;
+  try {
+    entitlementMod = await import(join(ENTERPRISE_DIR, "entitlement", "index.mjs"));
+  } catch {
+    return inactive("enterprise/ modules not present");
+  }
+
+  let claims: Record<string, unknown>;
+  try {
+    const res = entitlementMod.verifyEntitlement(token, readPubKey(pub));
+    if (!res.valid) return inactive(`entitlement invalid: ${res.reason}`);
+    claims = res.claims;
+  } catch (e) {
+    return inactive(`entitlement verification error: ${String(e)}`);
+  }
+
+  const has = (f: string) => entitlementMod.hasFeature(claims, f);
+  const state: Extract<GateState, { mode: "active" }> = {
+    mode: "active",
+    claims,
+    accessControl: has("access-control"),
+  };
+
+  // Audit (best-effort; only if entitled and the module loads).
+  if (has("audit")) {
+    try {
+      const auditMod: any = await import(join(ENTERPRISE_DIR, "audit", "index.mjs"));
+      const auditFile = process.env.OMCP_AUDIT_FILE;
+      const sink = auditFile
+        ? (entry: unknown) => appendFileSync(resolve(auditFile), JSON.stringify(entry) + "\n")
+        : undefined;
+      state.audit = auditMod.createAuditLog({ sink });
+    } catch {
+      /* audit is best-effort; absence must not break enforcement */
+    }
+  }
+
+  // RBAC / Catalog enforcers + their operator-supplied config.
+  if (process.env.OMCP_RBAC_POLICY) {
+    const rbacMod: any = await import(join(ENTERPRISE_DIR, "rbac", "index.mjs"));
+    state.enforceRbac = rbacMod.enforce;
+    state.rbacPolicy = readJsonFile(process.env.OMCP_RBAC_POLICY);
+  }
+  if (process.env.OMCP_CATALOG) {
+    const catMod: any = await import(join(ENTERPRISE_DIR, "catalog", "index.mjs"));
+    state.enforceCatalog = catMod.enforceCatalog;
+    state.catalog = readJsonFile(process.env.OMCP_CATALOG);
+  }
+
+  return state;
+}
+
+/** Reset memoised state (tests only). */
+export function _resetEnterpriseGate(): void {
+  gatePromise = null;
+}
+
+/** Gate mode — for diagnostics (/api/info). */
+export async function enterpriseGateStatus(): Promise<{
+  active: boolean;
+  mode: GateState["mode"];
+  reason?: string;
+}> {
+  if (!gatePromise) gatePromise = buildGate();
+  const g = await gatePromise;
+  if (g.mode === "active") return { active: true, mode: "active" };
+  if (g.mode === "fail-closed") return { active: false, mode: "fail-closed", reason: g.reason };
+  return { active: false, mode: "off" };
+}
+
+/**
+ * The single enforcement point, called before every MCP tool runs.
+ *
+ * off:         no opt-in, no entitlement → memoised no-op, returns
+ *               immediately. Zero behaviour change for the OSS core;
+ *               the only path the published artifact ever takes.
+ * fail-closed:  a control was configured but the gate could not be
+ *               activated → deny EVERY tool call (a broken/expired
+ *               entitlement must never silently disable enforcement).
+ * active:       record the decision (if audit entitled) and deny by
+ *               throwing — the MCP SDK turns the throw into a clean tool
+ *               error and the handler never runs.
+ */
+export async function enforceEntitledAccess(
+  ctx: RequestContext,
+  request: ToolRequest
+): Promise<void> {
+  if (!gatePromise) gatePromise = buildGate();
+  const g = await gatePromise;
+  if (g.mode === "off") return; // ← the only path the published artifact takes
+  if (g.mode === "fail-closed") {
+    throw new Error(`access denied: enterprise control configured but inactive (${g.reason})`);
+  }
+
+  const decide = (): { allow: boolean; reason: string } => {
+    // A configured control with no "access-control" entitlement is a
+    // misconfiguration we fail CLOSED on, never silently open.
+    const controlConfigured = !!(g.enforceRbac || g.enforceCatalog);
+    if (controlConfigured && !g.accessControl) {
+      return { allow: false, reason: "access-control not entitled by token" };
+    }
+    try {
+      if (g.enforceRbac) g.enforceRbac(g.rbacPolicy, ctx, request);
+      if (g.enforceCatalog) g.enforceCatalog(g.catalog, ctx, request);
+      return { allow: true, reason: "entitled" };
+    } catch (e: any) {
+      return { allow: false, reason: e?.reason || e?.message || "denied" };
+    }
+  };
+
+  const decision = decide();
+
+  if (g.audit) {
+    try {
+      await g.audit.record({
+        kind: "access-decision",
+        principalId: ctx.principalId,
+        auth: ctx.auth,
+        correlationId: ctx.correlationId,
+        request,
+        allow: decision.allow,
+        reason: decision.reason,
+      });
+    } catch {
+      /* audit failure must not change the access outcome */
+    }
+  }
+
+  if (!decision.allow) {
+    throw new Error(`access denied: ${decision.reason}`);
+  }
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import { loadConfig, saveConfig, DEFAULT_HEALTH_THRESHOLDS, DEFAULT_SETTINGS } from "./config/loader.js";
 import { ConnectorRegistry, getSupportedTypes } from "./connectors/registry.js";
 import { defaultContext, principalContext, type RequestContext } from "./context.js";
+import { enforceEntitledAccess, enterpriseGateStatus } from "./enterprise-gate.js";
 import {
   loadCredentials,
   credentialsConfigured,
@@ -146,7 +147,10 @@ async function main() {
       "Related: use `list_services` to see what is monitored within these sources.",
     ].join(" "),
     {},
-    async () => withToolMetrics("list_sources", () => listSourcesHandler(registry, ctx))
+    async () => {
+      await enforceEntitledAccess(ctx, { tool: "list_sources" });
+      return withToolMetrics("list_sources", () => listSourcesHandler(registry, ctx));
+    }
   );
 
   mcpServer.tool(
@@ -165,7 +169,10 @@ async function main() {
           "Optional case-insensitive substring to narrow the result to matching service names (e.g. 'payment'). Omit to list every discovered service.",
         ),
     },
-    async (args) => withToolMetrics("list_services", () => listServicesHandler(registry, args, ctx))
+    async (args) => {
+      await enforceEntitledAccess(ctx, { tool: "list_services" });
+      return withToolMetrics("list_services", () => listServicesHandler(registry, args, ctx));
+    }
   );
 
   const metricsList = getAvailableMetricNames(registry);
@@ -211,7 +218,10 @@ async function main() {
           "Optional. Metric label to break the result down by, e.g. 'instance', 'pod', 'node'. When set, the response contains one series per distinct label value under `groups`. Default: a single aggregated series.",
         ),
     },
-    async (args) => withToolMetrics("query_metrics", () => queryMetricsHandler(registry, args, ctx))
+    async (args) => {
+      await enforceEntitledAccess(ctx, { tool: "query_metrics", source: (args as any)?.source, service: (args as any)?.service });
+      return withToolMetrics("query_metrics", () => queryMetricsHandler(registry, args, ctx));
+    }
   );
 
   mcpServer.tool(
@@ -255,7 +265,10 @@ async function main() {
           "Optional. Maximum number of log entries to return (most recent first). Default: 100.",
         ),
     },
-    async (args) => withToolMetrics("query_logs", () => queryLogsHandler(registry, args, ctx))
+    async (args) => {
+      await enforceEntitledAccess(ctx, { tool: "query_logs", source: (args as any)?.source, service: (args as any)?.service });
+      return withToolMetrics("query_logs", () => queryLogsHandler(registry, args, ctx));
+    }
   );
 
   mcpServer.tool(
@@ -273,7 +286,10 @@ async function main() {
           "Required. Exact, case-sensitive service name exactly as returned by `list_services` (e.g. 'payment-service').",
         ),
     },
-    async (args) => withToolMetrics("get_service_health", () => getServiceHealthHandler(registry, args, ctx))
+    async (args) => {
+      await enforceEntitledAccess(ctx, { tool: "get_service_health", service: (args as any)?.service });
+      return withToolMetrics("get_service_health", () => getServiceHealthHandler(registry, args, ctx));
+    }
   );
 
   mcpServer.tool(
@@ -304,7 +320,10 @@ async function main() {
           "Optional. Detection threshold: 'low' flags only strong deviations (>3σ), 'medium' is balanced (>2σ), 'high' is most sensitive and noisier (>1.5σ). Default: 'medium'.",
         ),
     },
-    async (args) => withToolMetrics("detect_anomalies", () => detectAnomaliesHandler(registry, args, ctx))
+    async (args) => {
+      await enforceEntitledAccess(ctx, { tool: "detect_anomalies", source: (args as any)?.source, service: (args as any)?.service });
+      return withToolMetrics("detect_anomalies", () => detectAnomaliesHandler(registry, args, ctx));
+    }
   );
 
     return mcpServer;
@@ -411,6 +430,7 @@ async function main() {
     res.json({
       name: "observability-mcp",
       version: SERVER_VERSION,
+      enterpriseGate: await enterpriseGateStatus(),
       mcpProtocolVersion: "2025-03-26",
       build: {
         commit: process.env.GIT_COMMIT || null,


### PR DESCRIPTION
## What

Makes the enterprise tier **load-bearing**: the FSL modules (`enterprise/rbac`, `catalog`, `audit`) are now wired into the MCP tool dispatch behind a signed Ed25519 entitlement token — **without the Apache core ever statically importing FSL code**.

`src/enterprise-gate.ts` dynamically imports `enterprise/` (a computed specifier) and exposes one enforcement point, `enforceEntitledAccess(ctx, request)`, called before each of the 6 MCP tools.

### Three modes (the whole security story)
| Mode | When | Behaviour |
|---|---|---|
| **off** | no opt-in & no entitlement | memoised **no-op** — zero behaviour change. The *only* state the published artifact can reach (`enterprise/` is excluded from the npm package and Docker build context). |
| **fail-closed** | a control is configured (`OMCP_RBAC_POLICY`/`OMCP_CATALOG`) but the gate can't activate (missing/invalid/expired token, or modules absent) | **DENY every tool call** |
| **active** | valid token | enforce RBAC/Catalog, record decisions to the audit log, deny by throwing |

The **fail-closed** mode was added after the real e2e caught a genuine flaw: a naïve "no-op when inactive" would *silently open everything* if an operator's entitlement expired. A configured control must never be silently disabled.

Scope: only the MCP tool path (which carries the principal `ctx`). The local `/api/*` management UI is unchanged. Gate mode is surfaced at `/api/info`.

## Verification (real, end-to-end)
- Full `mcp-server` Docker suite: **211/215**, same 4 pre-existing unrelated fails, **+6 new gate tests** (OFF no-op + FAIL-CLOSED contracts, in the published-artifact state where `enterprise/` is absent); `tsc --noEmit` clean
- **Real ON-path e2e** from a full checkout with a generated Ed25519 keypair: no-op / allow / deny / audit hash-chain of both decisions / feature-not-entitled fail-closed / **expired-token fail-closed (no silent open)** / expired-without-opt-in OFF — **all 7 checks pass**
- OSS npm tarball: ships the Apache seam (`dist/enterprise-gate.js`, a no-op without `enterprise/`), still **zero `enterprise/` files**

🤖 Generated with [Claude Code](https://claude.com/claude-code)