### PR TITLE
docs: enterprise gate operator guide + token-mint CLI & examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ flags pass through after a literal `--`.
 - [Troubleshooting](docs/troubleshooting.md) — common pitfalls and fixes
 - [Security](docs/security.md) — automation pipeline, vulnerability reporting, built-in protections
 - [Airgapped deployment](docs/airgapped-deployment.md) — mirroring images, private plugins, GitOps-friendly config
+- [Enterprise access-control gate](docs/enterprise-gate.md) — optional RBAC / catalog / audit behind a signed entitlement token (off by default)
 - [Connector Hub](https://thotischner.github.io/observability-mcp/hub/) — browse versioned, signed connectors (catalog: [`hub/`](hub/README.md))
 - [Use cases](USECASES.md) — five scenarios with the prompts that drive them
 

--- a/docs/enterprise-gate.md
+++ b/docs/enterprise-gate.md
@@ -1,0 +1,117 @@
+# Enterprise access-control gate
+
+The MCP server has an **optional** seam that enforces role-based access
+control, a product catalog, and an audit log in front of the six MCP
+tools. It is **off by default** and changes nothing unless an operator
+explicitly opts in.
+
+The seam itself (`mcp-server/src/enterprise-gate.ts`) is Apache-2.0 and
+ships in the published package. The modules it enforces live under
+[`enterprise/`](../enterprise/README.md) and are licensed
+`FSL-1.1-Apache-2.0`. Because they sit outside `mcp-server/`, they are
+**not** in the npm package or the Docker image — activating the gate
+requires running from a full source checkout that still contains
+`enterprise/`.
+
+## Modes
+
+The gate is always in exactly one of three modes, reported at
+`GET /api/info` under `enterpriseGate`:
+
+| Mode | When | Behaviour |
+|---|---|---|
+| `off` | No control configured and no entitlement | No-op. Every tool runs exactly as without the gate. The only mode the published artifact can reach. |
+| `fail-closed` | A control **is** configured (`OMCP_RBAC_POLICY` or `OMCP_CATALOG`) but the gate cannot activate — missing/invalid/**expired** token, or `enterprise/` absent | **Every tool call is denied.** A broken or expired entitlement never silently disables a control you configured. |
+| `active` | A valid entitlement token is present | RBAC + catalog are enforced; each decision is recorded to the audit log; denied calls throw and the tool never runs. |
+
+Only the MCP tool path is gated (it carries the authenticated
+principal). The local `/api/*` management UI is unchanged.
+
+## Environment variables
+
+| Variable | Purpose |
+|---|---|
+| `OMCP_ENTITLEMENT_TOKEN` | The signed token: `<base64url payload>.<base64url sig>` |
+| `OMCP_ENTITLEMENT_PUBKEY` | Ed25519 public key — a PEM literal (`\n`-escaped allowed) or `@/path/to/key.pub` |
+| `OMCP_RBAC_POLICY` | Path to an RBAC policy JSON (enables RBAC) |
+| `OMCP_CATALOG` | Path to a product-catalog JSON (enables the catalog) |
+| `OMCP_AUDIT_FILE` | Optional path; appends one JSON line per access decision |
+
+Feature gating: the token's `features` must include `access-control`
+for RBAC/catalog enforcement and `audit` for the audit log. A policy
+configured without the matching feature is denied (fail-closed).
+
+## Quickstart
+
+**1. Generate an issuer keypair** (OpenSSL — no extra tooling):
+
+```bash
+openssl genpkey -algorithm ed25519        -out issuer-ed25519.pem
+openssl pkey -in issuer-ed25519.pem -pubout -out issuer-ed25519.pub
+```
+
+**2. Mint a token** with the issuer CLI:
+
+```bash
+node enterprise/entitlement/mint.mjs \
+  --key issuer-ed25519.pem \
+  --sub org-acme --tier enterprise \
+  --features access-control,audit --ttl 365d
+```
+
+It prints the token to stdout. (`--ttl` accepts `<n>s|m|h|d`,
+default `365d`.)
+
+**3. Configure the deployment:**
+
+```bash
+export OMCP_ENTITLEMENT_TOKEN="$(cat token.txt)"
+export OMCP_ENTITLEMENT_PUBKEY="@$(pwd)/issuer-ed25519.pub"
+export OMCP_RBAC_POLICY="$(pwd)/enterprise/examples/rbac-policy.json"
+export OMCP_CATALOG="$(pwd)/enterprise/examples/catalog.json"
+export OMCP_AUDIT_FILE="$(pwd)/audit.jsonl"
+```
+
+**4. Verify the mode:**
+
+```bash
+curl -s localhost:3000/api/info | jq .enterpriseGate
+# { "active": true, "mode": "active" }
+```
+
+## Policy and catalog
+
+Working examples live in
+[`enterprise/examples/`](../enterprise/examples) and are exercised by
+the test suite, so they stay correct:
+
+- [`rbac-policy.json`](../enterprise/examples/rbac-policy.json) — roles
+  map principals (the API-key identity, e.g. `key:platform-bot`) to
+  allow-lists over `tools` / `sources` / `services`; `"*"` is a
+  wildcard, `readOnly` blocks mutating tools, `defaultRoles` applies to
+  unbound principals (empty ⇒ default-deny).
+- [`catalog.json`](../enterprise/examples/catalog.json) — named
+  **products** bundle `sources`/`services`; **grants** map principals to
+  products. RBAC answers *which verbs*; the catalog answers *which
+  resource bundle*. A request must pass **both**.
+
+The principal id comes from the API-key auth layer (see
+[Authentication & TLS](auth-and-tls.md)); with no API key configured the
+principal is `anonymous` and, under a default-deny policy, denied.
+
+## Audit log
+
+When `audit` is entitled and `OMCP_AUDIT_FILE` is set, every decision is
+appended as a hash-chained JSON line. The chain is tamper-evident:
+re-walking it detects any modification, reordering, insertion or
+mid-file truncation. Ship the file to your SIEM; treat it as
+append-only.
+
+## Security posture
+
+- **Fail-closed.** A configured control with a missing/invalid/expired
+  token denies all tool calls — it never degrades to open.
+- **No core coupling.** The Apache core never statically imports
+  `enterprise/`; the published artifact is a pure no-op.
+- **Offline.** Token verification is local Ed25519 — no licensing
+  callout, consistent with [offline mode](offline.md).

--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -27,13 +27,25 @@ operator.
 
 ## Integration contract
 
-`rbac/` is dependency-free ESM and duck-typed against the core
+These modules are dependency-free ESM, duck-typed against the core
 `RequestContext` shape (`{ principalId, auth, allowedSources?, ... }`) so the
-Apache core never imports FSL code. An operator wires it at the context seam:
-resolve the principal's roles, then call `enforce(...)` before a tool runs.
+Apache core never imports FSL code. The core wires them at the context seam
+(`mcp-server/src/enterprise-gate.ts`) behind a signed entitlement token —
+**off by default**. Operators do not call these directly; see the
+[**enterprise gate operator guide**](../docs/enterprise-gate.md) for setup
+(keypair, token minting, env vars, the three gate modes).
+
+## Tooling & examples
+
+- [`entitlement/mint.mjs`](./entitlement/mint.mjs) — issuer CLI to mint a
+  signed token: `node enterprise/entitlement/mint.mjs --key priv.pem
+  --sub org --features access-control,audit --ttl 365d`
+- [`examples/rbac-policy.json`](./examples/rbac-policy.json) and
+  [`examples/catalog.json`](./examples/catalog.json) — working configs,
+  exercised by `examples/examples.test.mjs` so they cannot drift from the docs.
 
 ## Tests
 
 ```
-node --test enterprise/rbac/*.test.mjs
+node --test enterprise/*/*.test.mjs
 ```

--- a/enterprise/entitlement/mint.mjs
+++ b/enterprise/entitlement/mint.mjs
@@ -1,0 +1,77 @@
+// Entitlement token minting CLI (FSL-1.1-Apache-2.0).
+//
+// The issuer-side companion to verifyEntitlement: turns an Ed25519
+// private key + a few flags into a signed token a deployment can pin via
+// OMCP_ENTITLEMENT_TOKEN. Dependency-free (node:crypto + this package).
+//
+//   node enterprise/entitlement/mint.mjs \
+//     --key ./issuer-ed25519.pem \
+//     --sub org-acme --tier enterprise \
+//     --features access-control,audit --ttl 365d
+//
+// Key generation (no extra tooling — OpenSSL):
+//   openssl genpkey -algorithm ed25519        -out issuer-ed25519.pem
+//   openssl pkey -in issuer-ed25519.pem -pubout -out issuer-ed25519.pub
+//
+// `--ttl` accepts <n>[s|m|h|d] (default 365d). The pure helpers are
+// exported so the test suite drives them without spawning a process.
+
+import { readFileSync } from "node:fs";
+import { createPrivateKey } from "node:crypto";
+import { signEntitlement } from "./entitlement.mjs";
+
+export function parseTtlSeconds(ttl) {
+  const m = String(ttl).match(/^(\d+)([smhd])$/);
+  if (!m) throw new Error(`invalid --ttl '${ttl}' (use <n>s|m|h|d, e.g. 365d)`);
+  const n = parseInt(m[1], 10);
+  return n * { s: 1, m: 60, h: 3600, d: 86400 }[m[2]];
+}
+
+export function parseArgs(argv) {
+  const out = { sub: undefined, tier: "enterprise", features: [], ttl: "365d", key: undefined };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--sub") out.sub = argv[++i];
+    else if (a === "--tier") out.tier = argv[++i];
+    else if (a === "--features") out.features = String(argv[++i] || "").split(",").map((s) => s.trim()).filter(Boolean);
+    else if (a === "--ttl") out.ttl = argv[++i];
+    else if (a === "--key") out.key = argv[++i];
+    else throw new Error(`unknown argument '${a}'`);
+  }
+  return out;
+}
+
+/** Pure: build the signed token from already-parsed inputs. */
+export function mint({ sub, tier, features, ttlSeconds, privateKey }, now = Math.floor(Date.now() / 1000)) {
+  if (!sub) throw new Error("--sub is required");
+  if (!Array.isArray(features) || features.length === 0) {
+    throw new Error("--features is required (comma-separated, e.g. access-control,audit)");
+  }
+  const payload = { sub, tier: tier || "enterprise", features, iat: now, exp: now + ttlSeconds };
+  return signEntitlement(payload, privateKey);
+}
+
+function main(argv) {
+  let args;
+  try {
+    args = parseArgs(argv);
+    if (!args.key) throw new Error("--key <path to Ed25519 private key PEM> is required");
+    const privateKey = createPrivateKey(readFileSync(args.key, "utf8"));
+    const token = mint({
+      sub: args.sub,
+      tier: args.tier,
+      features: args.features,
+      ttlSeconds: parseTtlSeconds(args.ttl),
+      privateKey,
+    });
+    process.stdout.write(token + "\n");
+  } catch (e) {
+    process.stderr.write(`mint: ${e.message}\n`);
+    process.stderr.write(
+      "usage: mint.mjs --key <priv.pem> --sub <id> [--tier <t>] --features <a,b> [--ttl <365d>]\n"
+    );
+    process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main(process.argv.slice(2));

--- a/enterprise/entitlement/mint.test.mjs
+++ b/enterprise/entitlement/mint.test.mjs
@@ -1,0 +1,54 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+import { parseTtlSeconds, parseArgs, mint } from "./mint.mjs";
+import { verifyEntitlement, hasFeature } from "./entitlement.mjs";
+
+const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+const NOW = 1_700_000_000;
+
+test("parseTtlSeconds handles s/m/h/d and rejects junk", () => {
+  assert.equal(parseTtlSeconds("30s"), 30);
+  assert.equal(parseTtlSeconds("5m"), 300);
+  assert.equal(parseTtlSeconds("2h"), 7200);
+  assert.equal(parseTtlSeconds("365d"), 365 * 86400);
+  assert.throws(() => parseTtlSeconds("1w"), /invalid --ttl/);
+  assert.throws(() => parseTtlSeconds("abc"), /invalid --ttl/);
+});
+
+test("parseArgs reads flags, splits features, defaults tier/ttl", () => {
+  const a = parseArgs(["--sub", "org-acme", "--features", "access-control, audit ", "--key", "k.pem"]);
+  assert.equal(a.sub, "org-acme");
+  assert.deepEqual(a.features, ["access-control", "audit"]);
+  assert.equal(a.tier, "enterprise");
+  assert.equal(a.ttl, "365d");
+  assert.equal(a.key, "k.pem");
+  assert.throws(() => parseArgs(["--bogus"]), /unknown argument/);
+});
+
+test("mint requires sub and at least one feature", () => {
+  assert.throws(() => mint({ features: ["x"], ttlSeconds: 10, privateKey }), /--sub is required/);
+  assert.throws(() => mint({ sub: "o", features: [], ttlSeconds: 10, privateKey }), /--features is required/);
+});
+
+test("a minted token verifies and carries the requested claims", () => {
+  const token = mint(
+    { sub: "org-acme", tier: "enterprise", features: ["access-control", "audit"], ttlSeconds: 3600, privateKey },
+    NOW
+  );
+  const r = verifyEntitlement(token, publicKey, { now: () => NOW + 60 });
+  assert.equal(r.valid, true);
+  assert.equal(r.claims.sub, "org-acme");
+  assert.equal(r.claims.iat, NOW);
+  assert.equal(r.claims.exp, NOW + 3600);
+  assert.equal(hasFeature(r.claims, "access-control"), true);
+  assert.equal(hasFeature(r.claims, "catalog"), false);
+});
+
+test("a minted token is expired once past its ttl (round-trip)", () => {
+  const token = mint({ sub: "o", features: ["audit"], ttlSeconds: 100, privateKey }, NOW);
+  assert.equal(verifyEntitlement(token, publicKey, { now: () => NOW + 50 }).valid, true);
+  const late = verifyEntitlement(token, publicKey, { now: () => NOW + 200 });
+  assert.equal(late.valid, false);
+  assert.match(late.reason, /expired/);
+});

--- a/enterprise/examples/catalog.json
+++ b/enterprise/examples/catalog.json
@@ -1,0 +1,18 @@
+{
+  "products": {
+    "eu-observability": {
+      "description": "All EU metrics + logs backends",
+      "sources": ["prom-eu", "loki-eu"]
+    },
+    "payments": {
+      "description": "Payment-service signals only",
+      "sources": ["prom-eu", "loki-eu"],
+      "services": ["payment-service"]
+    }
+  },
+  "grants": {
+    "key:platform-bot": ["eu-observability"],
+    "key:payments-oncall": ["payments"]
+  },
+  "defaultProducts": []
+}

--- a/enterprise/examples/examples.test.mjs
+++ b/enterprise/examples/examples.test.mjs
@@ -1,0 +1,64 @@
+// Proves the documented example configs are REAL working configs, not
+// illustrative JSON: load them and run them through the actual enforcers
+// with the principals from docs/enterprise-gate.md. If the docs and these
+// files ever drift, this test fails.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { enforce, RbacDeniedError } from "../rbac/index.mjs";
+import { enforceCatalog, CatalogDeniedError } from "../catalog/index.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const policy = JSON.parse(readFileSync(join(HERE, "rbac-policy.json"), "utf8"));
+const catalog = JSON.parse(readFileSync(join(HERE, "catalog.json"), "utf8"));
+
+const ctx = (id) => ({ principalId: id, auth: "apikey", correlationId: "c" });
+
+test("example RBAC policy: sre bot may query, payments-oncall is scoped", () => {
+  // platform-bot (role sre) may query any service.
+  assert.equal(
+    enforce(policy, ctx("key:platform-bot"), { tool: "query_metrics", service: "order-service" }).allow,
+    true
+  );
+  // payments-oncall may read payment-service on prom-eu...
+  assert.equal(
+    enforce(policy, ctx("key:payments-oncall"), {
+      tool: "get_service_health",
+      source: "prom-eu",
+      service: "payment-service",
+    }).allow,
+    true
+  );
+  // ...but not other services, sources, or mutating tools.
+  assert.throws(
+    () => enforce(policy, ctx("key:payments-oncall"), { tool: "query_metrics", service: "order-service" }),
+    RbacDeniedError
+  );
+  assert.throws(
+    () => enforce(policy, ctx("key:payments-oncall"), { tool: "query_metrics", source: "prom-us", service: "payment-service" }),
+    RbacDeniedError
+  );
+  // Unknown principal is default-denied (defaultRoles is empty).
+  assert.throws(() => enforce(policy, ctx("key:stranger"), { tool: "list_sources" }), RbacDeniedError);
+});
+
+test("example catalog: products scope each principal as documented", () => {
+  assert.equal(
+    enforceCatalog(catalog, ctx("key:platform-bot"), { source: "loki-eu", service: "anything" }).allow,
+    true
+  );
+  assert.equal(
+    enforceCatalog(catalog, ctx("key:payments-oncall"), { source: "prom-eu", service: "payment-service" }).allow,
+    true
+  );
+  assert.throws(
+    () => enforceCatalog(catalog, ctx("key:payments-oncall"), { source: "prom-eu", service: "order-service" }),
+    CatalogDeniedError
+  );
+  assert.throws(
+    () => enforceCatalog(catalog, ctx("key:stranger"), { source: "prom-eu" }),
+    CatalogDeniedError
+  );
+});

--- a/enterprise/examples/rbac-policy.json
+++ b/enterprise/examples/rbac-policy.json
@@ -1,0 +1,21 @@
+{
+  "roles": {
+    "admin": { "tools": ["*"], "sources": ["*"], "services": ["*"] },
+    "sre": {
+      "tools": ["list_sources", "list_services", "query_metrics", "query_logs", "get_service_health", "detect_anomalies"],
+      "sources": ["*"],
+      "services": ["*"]
+    },
+    "payments-readonly": {
+      "tools": ["query_metrics", "get_service_health"],
+      "sources": ["prom-eu"],
+      "services": ["payment-service"],
+      "readOnly": true
+    }
+  },
+  "bindings": {
+    "key:platform-bot": ["sre"],
+    "key:payments-oncall": ["payments-readonly"]
+  },
+  "defaultRoles": []
+}


### PR DESCRIPTION
## What

**D-c** — makes the (now load-bearing) enterprise tier *adoptable*, without touching the core.

- **`docs/enterprise-gate.md`** — operator guide: the three gate modes (`off` / `fail-closed` / `active`), every env var, a keypair + token-mint quickstart, policy/catalog reference, audit-log handling, and the security posture. Neutral, same register as the existing `docs/` guides.
- **`enterprise/entitlement/mint.mjs`** — hardening: an issuer CLI to mint a signed token (`--sub/--tier/--features/--ttl/--key`). Operators previously had only a library function; this is the missing ergonomic tool. Pure helpers exported for testing.
- **`enterprise/examples/{rbac-policy,catalog}.json`** — real working configs, exercised by `examples.test.mjs` against the actual enforcers so the documented examples **cannot drift** from reality.
- README + `enterprise/README` cross-links.

## Verification (real, end-to-end)
- Full enterprise suite **66/66** (was 59, +5 mint, +2 examples)
- **Real CLI subprocess round-trip**: `openssl genpkey` → `node enterprise/entitlement/mint.mjs …` → `verifyEntitlement` accepts the minted token (not just the pure helpers)
- OSS tarball: precise check — **zero `enterprise/` FSL paths**; only the Apache seam `dist/enterprise-gate.js` ships (a no-op without `enterprise/`)
- **No `mcp-server/` source changed** → core behaviour provably unaffected

Firewall held: the guide documents capability and configuration only — no strategy/pricing/positioning wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)