### PR TITLE
fix(enterprise/audit): canonical() must drop undefined keys like JSON

### DIFF
--- a/enterprise/audit/audit.mjs
+++ b/enterprise/audit/audit.mjs
@@ -17,10 +17,30 @@ const GENESIS = "0".repeat(64);
 
 // Deterministic JSON: object keys sorted recursively, so the hash of a
 // logically-equal record is stable regardless of insertion order.
+//
+// CRITICAL: this MUST mirror JSON.stringify's treatment of values that
+// have no JSON representation, because entries are hashed here but
+// persisted via JSON.stringify and re-verified after a JSON round-trip.
+// JSON drops object keys whose value is undefined / a function / a
+// symbol, and renders those as null inside arrays. If canonical() kept
+// them, an untampered log would fail re-verification the moment a record
+// carried an absent field (e.g. a tool call with no `source`). So:
+//   - object key with no-JSON value  → omitted (like JSON.stringify)
+//   - array element with no-JSON val → "null" (like JSON.stringify)
+//   - bare no-JSON value             → "null" (robust; never persisted)
+function isJsonless(v) {
+  return v === undefined || typeof v === "function" || typeof v === "symbol";
+}
+
 export function canonical(value) {
+  if (isJsonless(value)) return "null";
   if (value === null || typeof value !== "object") return JSON.stringify(value);
-  if (Array.isArray(value)) return "[" + value.map(canonical).join(",") + "]";
-  const keys = Object.keys(value).sort();
+  if (Array.isArray(value)) {
+    return "[" + value.map((v) => (isJsonless(v) ? "null" : canonical(v))).join(",") + "]";
+  }
+  const keys = Object.keys(value)
+    .filter((k) => !isJsonless(value[k]))
+    .sort();
   return "{" + keys.map((k) => JSON.stringify(k) + ":" + canonical(value[k])).join(",") + "}";
 }
 

--- a/enterprise/audit/audit.test.mjs
+++ b/enterprise/audit/audit.test.mjs
@@ -130,3 +130,27 @@ test("verifyChain rejects non-arrays and empty is trivially ok", () => {
   assert.equal(verifyChain(null).ok, false);
   assert.equal(verifyChain([]).ok, true);
 });
+
+// Regression: an event with absent (undefined) fields — exactly what the
+// enterprise gate emits for a tool call with no `source` — must still
+// verify AFTER a JSON persist→reload round-trip. canonical() must drop
+// undefined keys the same way JSON.stringify does, or the tamper-evidence
+// is silently broken in real use. (Found via a live gate test.)
+test("canonical mirrors JSON for undefined keys (no-JSON values)", () => {
+  assert.equal(canonical({ a: undefined, b: 1 }), canonical(JSON.parse(JSON.stringify({ a: undefined, b: 1 }))));
+  assert.equal(canonical({ a: undefined, b: 1 }), '{"b":1}');
+  assert.equal(canonical([1, undefined, 2]), "[1,null,2]"); // JSON.stringify → [1,null,2]
+  assert.equal(canonical(undefined), "null");
+  assert.equal(canonical({ f: () => 1, s: Symbol("x"), keep: "y" }), '{"keep":"y"}');
+});
+
+test("a persisted+reloaded chain with undefined fields re-verifies", async () => {
+  const file = [];
+  const log = createAuditLog({ now: fixedClock(), sink: (e) => file.push(JSON.stringify(e)) });
+  // The exact shape enterprise-gate emits when a tool omits source/service:
+  await log.record({ kind: "access-decision", request: { tool: "query_metrics", source: undefined, service: "pay" }, allow: true });
+  await log.record({ kind: "access-decision", request: { tool: "list_services", source: undefined, service: undefined }, allow: false });
+  assert.equal(log.verify().ok, true); // in-memory
+  const reloaded = file.map((l) => JSON.parse(l)); // what a verifier on disk sees
+  assert.deepEqual(verifyChain(reloaded), { ok: true });
+});


### PR DESCRIPTION
## The bug (found by a live end-to-end test, not unit tests)

Testing the enterprise gate **active** against the running stack (real entitlement token + RBAC + audit) surfaced a genuine correctness defect in the FSL audit primitive:

The hash chain is computed over `canonical(entry)` but **persisted via `JSON.stringify`** and re-verified after a JSON round-trip. `canonical()` kept object keys whose value is `undefined`; `JSON.stringify` drops them. So any persisted record with an absent field — e.g. the gate's `request` object for a tool call with no `source`/`service` — **failed `verifyChain` on reload with no tampering at all**. The chain links (seq/prevHash) were intact; only the hash recompute diverged. Net effect: the audit log's tamper-evidence was silently broken in normal operation.

Live evidence (4 real decisions logged by the gate): chain structurally intact, but `verifyChain` on the reloaded file → `{ok:false, brokenAt:1, "hash mismatch"}`.

## The fix

`canonical()` now mirrors `JSON.stringify` for values with no JSON representation (`undefined`/function/symbol): omit such object keys, emit `null` in array position. **Behaviour is unchanged for every JSON-clean input** (existing chains and the 11 prior audit tests unaffected), and **tamper detection is unchanged** (a flipped field is still caught — verified).

## Verification (real)
- Minimal reproduction with the real module: before → `{ok:false}` on reload; after → `{ok:true}`, tamper still `{ok:false, brokenAt:0}`
- +2 regression tests pinning the persist→reload contract and the JSON-mirroring of `canonical`
- Full enterprise suite **68/68** (was 66)
- `enterprise/` only — OSS npm/Docker artifact unaffected (still zero FSL paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)