### PR TITLE
feat: read-only enterprise console API (Phase 1a)

### DIFF
--- a/mcp-server/src/enterprise-gate.test.ts
+++ b/mcp-server/src/enterprise-gate.test.ts
@@ -7,6 +7,10 @@ import { defaultContext } from "./context.js";
 import {
   enforceEntitledAccess,
   enterpriseGateStatus,
+  enterpriseGateInfo,
+  enterprisePolicyView,
+  enterpriseCatalogView,
+  enterpriseAuditTail,
   _resetEnterpriseGate,
 } from "./enterprise-gate.js";
 
@@ -104,5 +108,55 @@ describe("enterprise-gate — FAIL-CLOSED (opted in, cannot activate)", () => {
       () => enforceEntitledAccess(defaultContext(), { tool: "list_services" }),
       /access denied/
     );
+  });
+});
+
+describe("enterprise-gate — read-only console introspection", () => {
+  afterEach(clearEnv);
+
+  it("gateInfo: off → entitlement null, no token ever exposed", async () => {
+    clearEnv();
+    process.env.OMCP_ENTITLEMENT_TOKEN = "SECRET.SHOULD-NEVER-LEAK";
+    process.env.OMCP_ENTITLEMENT_PUBKEY = "x";
+    _resetEnterpriseGate();
+    const info = await enterpriseGateInfo();
+    assert.equal(info.active, false);
+    assert.equal(info.entitlement, null);
+    assert.equal("rbacConfigured" in info, true);
+    const dump = JSON.stringify(info);
+    assert.equal(dump.includes("SECRET"), false, "token must never appear in gate info");
+  });
+
+  it("gateInfo: configured-flags reflect env", async () => {
+    clearEnv();
+    process.env.OMCP_RBAC_POLICY = "/tmp/x.json";
+    process.env.OMCP_AUDIT_FILE = "/tmp/a.jsonl";
+    _resetEnterpriseGate();
+    const info = await enterpriseGateInfo();
+    assert.equal(info.rbacConfigured, true);
+    assert.equal(info.catalogConfigured, false);
+    assert.equal(info.auditConfigured, true);
+  });
+
+  it("policy/catalog view: not configured vs file error", () => {
+    clearEnv();
+    assert.deepEqual(enterprisePolicyView(), { configured: false });
+    assert.deepEqual(enterpriseCatalogView(), { configured: false });
+    const dir = mkdtempSync(join(tmpdir(), "gate-ro-"));
+    const f = join(dir, "p.json");
+    writeFileSync(f, '{"roles":{"a":{"tools":["*"]}},"bindings":{}}');
+    process.env.OMCP_RBAC_POLICY = f;
+    const v = enterprisePolicyView();
+    assert.equal(v.configured, true);
+    assert.deepEqual(Object.keys((v as any).data.roles), ["a"]);
+    process.env.OMCP_RBAC_POLICY = "/no/such/file.json";
+    const e = enterprisePolicyView();
+    assert.equal(e.configured, true);
+    assert.ok((e as any).error);
+  });
+
+  it("audit tail: not configured when no audit file", async () => {
+    clearEnv();
+    assert.deepEqual(await enterpriseAuditTail(10), { configured: false });
   });
 });

--- a/mcp-server/src/enterprise-gate.ts
+++ b/mcp-server/src/enterprise-gate.ts
@@ -232,3 +232,93 @@ export async function enforceEntitledAccess(
     throw new Error(`access denied: ${decision.reason}`);
   }
 }
+
+// ----------------------------------------------------------------------
+// Read-only introspection for the management console. None of these ever
+// expose the entitlement TOKEN or any private key — only the gate mode,
+// the non-secret signed claims, and the operator-supplied policy/catalog/
+// audit which are configuration, not credentials.
+// ----------------------------------------------------------------------
+
+/** Claim keys safe to surface (never the raw token / signature). */
+const SAFE_CLAIM_KEYS = ["sub", "tier", "features", "iat", "exp"] as const;
+
+export interface EnterpriseGateInfo {
+  mode: GateState["mode"];
+  active: boolean;
+  reason?: string;
+  rbacConfigured: boolean;
+  catalogConfigured: boolean;
+  auditConfigured: boolean;
+  entitlement: Record<string, unknown> | null;
+}
+
+export async function enterpriseGateInfo(): Promise<EnterpriseGateInfo> {
+  if (!gatePromise) gatePromise = buildGate();
+  const g = await gatePromise;
+  const base = {
+    mode: g.mode,
+    active: g.mode === "active",
+    reason: g.mode === "fail-closed" ? g.reason : undefined,
+    rbacConfigured: !!process.env.OMCP_RBAC_POLICY,
+    catalogConfigured: !!process.env.OMCP_CATALOG,
+    auditConfigured: !!process.env.OMCP_AUDIT_FILE,
+  };
+  if (g.mode !== "active") return { ...base, entitlement: null };
+  const c = (g.claims || {}) as Record<string, unknown>;
+  const entitlement: Record<string, unknown> = {};
+  for (const k of SAFE_CLAIM_KEYS) if (k in c) entitlement[k] = c[k];
+  return { ...base, entitlement };
+}
+
+function readConfigJson(envVar: "OMCP_RBAC_POLICY" | "OMCP_CATALOG") {
+  const p = process.env[envVar];
+  if (!p) return { configured: false as const };
+  try {
+    return { configured: true as const, data: JSON.parse(readFileSync(resolve(p), "utf8")) };
+  } catch (e) {
+    return { configured: true as const, error: String(e) };
+  }
+}
+
+/** The loaded RBAC policy (read-only view). */
+export function enterprisePolicyView() {
+  return readConfigJson("OMCP_RBAC_POLICY");
+}
+
+/** The loaded product catalog (read-only view). */
+export function enterpriseCatalogView() {
+  return readConfigJson("OMCP_CATALOG");
+}
+
+/** Recent audit decisions + a tamper-evidence check over the whole log. */
+export async function enterpriseAuditTail(limit = 50) {
+  const p = process.env.OMCP_AUDIT_FILE;
+  if (!p) return { configured: false as const };
+  let raw: string;
+  try {
+    raw = readFileSync(resolve(p), "utf8");
+  } catch (e) {
+    return { configured: true as const, error: String(e) };
+  }
+  const all = raw
+    .split("\n")
+    .filter(Boolean)
+    .map((l) => {
+      try {
+        return JSON.parse(l);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean) as unknown[];
+  let chain: unknown = { ok: null };
+  try {
+    const auditMod: any = await import(join(ENTERPRISE_DIR, "audit", "index.mjs"));
+    chain = auditMod.verifyChain(all); // over the FULL log, not just the tail
+  } catch {
+    /* audit module absent → integrity unknown */
+  }
+  const n = Math.max(1, Math.min(limit || 50, 500));
+  return { configured: true as const, total: all.length, chain, entries: all.slice(-n) };
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -9,7 +9,14 @@ import { z } from "zod";
 import { loadConfig, saveConfig, DEFAULT_HEALTH_THRESHOLDS, DEFAULT_SETTINGS } from "./config/loader.js";
 import { ConnectorRegistry, getSupportedTypes } from "./connectors/registry.js";
 import { defaultContext, principalContext, type RequestContext } from "./context.js";
-import { enforceEntitledAccess, enterpriseGateStatus } from "./enterprise-gate.js";
+import {
+  enforceEntitledAccess,
+  enterpriseGateStatus,
+  enterpriseGateInfo,
+  enterprisePolicyView,
+  enterpriseCatalogView,
+  enterpriseAuditTail,
+} from "./enterprise-gate.js";
 import {
   loadCredentials,
   credentialsConfigured,
@@ -454,6 +461,32 @@ async function main() {
   // plugins), with manifest metadata — drives the UI "Connectors" page.
   app.get("/api/connectors", (_req, res) => {
     res.json({ connectors: describeInstalled(getPluginLoader().list()) });
+  });
+
+  // --- Enterprise console (read-only introspection) -------------------
+  // Drives the management UI's Enterprise page. Read-only in this phase;
+  // never exposes the entitlement token or any key. Same trusted-local
+  // management plane as the other /api/* endpoints (see auth-and-tls).
+  app.get("/api/enterprise/status", async (_req, res) => {
+    try {
+      res.json(await enterpriseGateInfo());
+    } catch (e) {
+      res.status(500).json({ error: String(e) });
+    }
+  });
+  app.get("/api/enterprise/policy", (_req, res) => {
+    res.json(enterprisePolicyView());
+  });
+  app.get("/api/enterprise/catalog", (_req, res) => {
+    res.json(enterpriseCatalogView());
+  });
+  app.get("/api/enterprise/audit", async (req, res) => {
+    const limit = Math.min(Number(req.query.limit) || 50, 500);
+    try {
+      res.json(await enterpriseAuditTail(limit));
+    } catch (e) {
+      res.status(500).json({ error: String(e) });
+    }
   });
 
   // Server-side proxy of the connector hub catalog (so the browser


### PR DESCRIPTION
## What

Phase 1a of the enterprise management console: the read-only API the UI will consume. No UI changes here (that's Phase 1b).

`GET /api/enterprise/`:
- **`status`** — gate `mode` (off/fail-closed/active), `active`, the `*Configured` flags, and the **non-secret** signed entitlement claims (`sub/tier/features/iat/exp`). The raw token and any key are never exposed (explicit test guard).
- **`policy`** — the loaded RBAC policy (read-only) or `{configured:false}`.
- **`catalog`** — the loaded product catalog likewise.
- **`audit`** — recent decisions + `verifyChain()` over the **whole** log.

Same trusted-local management plane as the existing `/api/*` endpoints.

## Verification (real, end-to-end)
- mcp-server Docker suite **215/219** (same 4 pre-existing unrelated fails, **+4 new** accessor tests incl. a token-leak guard), `tsc` clean
- **Live e2e against the currently-active gate**: `/status` returns the claims with **no token substring present**; `/policy` + `/catalog` serve the loaded config; `/audit` on a clean session → `chain: {ok:true}`, seq 0–3 with correct allow/deny

## Known follow-up (reported, not a blocker)
The audit chain is **per-process**: a server restart starts a fresh chain segment appended to the same file, so a cross-restart file reads as broken. The endpoint reports this faithfully. A resume-or-rotate improvement is a candidate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)