### PR TITLE
feat(enterprise): admin-gated RBAC policy editing (Phase 2)

### DIFF
--- a/mcp-server/src/enterprise-gate.test.ts
+++ b/mcp-server/src/enterprise-gate.test.ts
@@ -11,6 +11,8 @@ import {
   enterprisePolicyView,
   enterpriseCatalogView,
   enterpriseAuditTail,
+  validatePolicyShape,
+  authorizeAdmin,
   _resetEnterpriseGate,
 } from "./enterprise-gate.js";
 
@@ -158,5 +160,53 @@ describe("enterprise-gate — read-only console introspection", () => {
   it("audit tail: not configured when no audit file", async () => {
     clearEnv();
     assert.deepEqual(await enterpriseAuditTail(10), { configured: false });
+  });
+});
+
+describe("enterprise-gate — P2 admin RBAC write", () => {
+  afterEach(clearEnv);
+
+  it("validatePolicyShape accepts a well-formed policy", () => {
+    assert.equal(
+      validatePolicyShape({ roles: { a: { tools: ["*"] } }, bindings: { p: ["a"] }, defaultRoles: [] }),
+      null
+    );
+  });
+
+  it("validatePolicyShape rejects malformed shapes", () => {
+    assert.match(validatePolicyShape(null) || "", /must be a JSON object/);
+    assert.match(validatePolicyShape([]) || "", /must be a JSON object/);
+    assert.match(validatePolicyShape({ bindings: {} }) || "", /roles must be an object/);
+    assert.match(validatePolicyShape({ roles: {} }) || "", /bindings must be an object/);
+    assert.match(
+      validatePolicyShape({ roles: {}, bindings: {}, defaultRoles: "x" }) || "",
+      /defaultRoles must be an array/
+    );
+    assert.match(
+      validatePolicyShape({ roles: { r: { tools: "x" } }, bindings: {} }) || "",
+      /role 'r.tools' must be an array/
+    );
+    assert.match(
+      validatePolicyShape({ roles: {}, bindings: { p: "x" } }) || "",
+      /binding 'p' must be an array/
+    );
+  });
+
+  it("authorizeAdmin denies when the gate is not active", async () => {
+    clearEnv(); // no entitlement → mode off
+    const r = await authorizeAdmin("someone");
+    assert.equal(r.ok, false);
+    assert.equal(r.status, 409);
+    assert.match(r.error ?? "", /gate not active/);
+  });
+
+  it("authorizeAdmin requires a principal once a control is configured", async () => {
+    clearEnv();
+    process.env.OMCP_RBAC_POLICY = "/tmp/none.json"; // fail-closed (no token)
+    _resetEnterpriseGate();
+    const r = await authorizeAdmin(null);
+    assert.equal(r.ok, false);
+    // gate is fail-closed here → still 409 (not active); never silently allows
+    assert.equal(r.ok, false);
   });
 });

--- a/mcp-server/src/enterprise-gate.ts
+++ b/mcp-server/src/enterprise-gate.ts
@@ -29,7 +29,7 @@
 // "access-control", access is denied (fail-closed — a configured control
 // must never be silently disabled).
 
-import { readFileSync, appendFileSync } from "node:fs";
+import { readFileSync, appendFileSync, writeFileSync, renameSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve } from "node:path";
 import type { RequestContext } from "./context.js";
@@ -81,6 +81,34 @@ function inactive(reason: string): GateState {
 
 let gatePromise: Promise<GateState> | null = null;
 
+// Audit log: a process singleton, created once and reused across every
+// gate rebuild so the hash chain is continuous for the life of the
+// process (a gate reset must never start a new chain segment mid-file).
+let auditLogPromise: Promise<{ record: (e: unknown) => Promise<unknown> } | null> | null = null;
+
+async function getAuditLog(): Promise<{ record: (e: unknown) => Promise<unknown> } | null> {
+  if (!auditLogPromise) {
+    auditLogPromise = (async () => {
+      try {
+        const auditMod: any = await import(join(ENTERPRISE_DIR, "audit", "index.mjs"));
+        const auditFile = process.env.OMCP_AUDIT_FILE;
+        const sink = auditFile
+          ? (entry: unknown) => appendFileSync(resolve(auditFile), JSON.stringify(entry) + "\n")
+          : undefined;
+        return auditMod.createAuditLog({ sink });
+      } catch {
+        return null; // audit is best-effort; absence must not break enforcement
+      }
+    })();
+  }
+  return auditLogPromise;
+}
+
+/** Tests only: also drops the audit singleton for full isolation. */
+export function _resetEnterpriseAudit(): void {
+  auditLogPromise = null;
+}
+
 function readPubKey(spec: string): string {
   if (spec.startsWith("@")) return readFileSync(spec.slice(1), "utf8");
   return spec.replace(/\\n/g, "\n");
@@ -123,18 +151,14 @@ async function buildGate(): Promise<GateState> {
     accessControl: has("access-control"),
   };
 
-  // Audit (best-effort; only if entitled and the module loads).
+  // Audit (best-effort; only if entitled and the module loads). The log
+  // is a PROCESS singleton, deliberately decoupled from the gate memo:
+  // resetting the gate (e.g. after an admin policy edit) must NOT sever
+  // the hash chain — an audited policy change that breaks tamper-evidence
+  // would defeat the point of auditing it.
   if (has("audit")) {
-    try {
-      const auditMod: any = await import(join(ENTERPRISE_DIR, "audit", "index.mjs"));
-      const auditFile = process.env.OMCP_AUDIT_FILE;
-      const sink = auditFile
-        ? (entry: unknown) => appendFileSync(resolve(auditFile), JSON.stringify(entry) + "\n")
-        : undefined;
-      state.audit = auditMod.createAuditLog({ sink });
-    } catch {
-      /* audit is best-effort; absence must not break enforcement */
-    }
+    const log = await getAuditLog();
+    if (log) state.audit = log;
   }
 
   // RBAC / Catalog enforcers + their operator-supplied config.
@@ -321,4 +345,139 @@ export async function enterpriseAuditTail(limit = 50) {
   }
   const n = Math.max(1, Math.min(limit || 50, 500));
   return { configured: true as const, total: all.length, chain, entries: all.slice(-n) };
+}
+
+// ----------------------------------------------------------------------
+// Phase 2: admin-gated RBAC policy write.
+//
+// Editing the RBAC policy IS editing the security configuration, so the
+// write path is NOT on the open local plane: it requires an API-key
+// principal that the CURRENT policy grants the reserved admin capability
+// `enterprise:admin`. First admin is bootstrapped via the policy file.
+// Every change is recorded to the audit log, and a policy that would
+// strip the writer's own admin capability is rejected (anti-lockout).
+// ----------------------------------------------------------------------
+
+export const ADMIN_CAP = "enterprise:admin";
+
+/** Structural validation — never trust a PUT body. */
+export function validatePolicyShape(p: any): string | null {
+  if (!p || typeof p !== "object" || Array.isArray(p)) return "policy must be a JSON object";
+  if (typeof p.roles !== "object" || p.roles === null || Array.isArray(p.roles)) return "policy.roles must be an object";
+  if (typeof p.bindings !== "object" || p.bindings === null || Array.isArray(p.bindings)) return "policy.bindings must be an object";
+  if (p.defaultRoles !== undefined && !Array.isArray(p.defaultRoles)) return "policy.defaultRoles must be an array";
+  for (const [name, role] of Object.entries(p.roles as Record<string, any>)) {
+    if (!role || typeof role !== "object") return `role '${name}' must be an object`;
+    for (const k of ["tools", "sources", "services"]) {
+      if (role[k] !== undefined && !Array.isArray(role[k])) return `role '${name}.${k}' must be an array`;
+    }
+  }
+  for (const [pr, roles] of Object.entries(p.bindings as Record<string, any>)) {
+    if (!Array.isArray(roles)) return `binding '${pr}' must be an array of role names`;
+  }
+  return null;
+}
+
+async function rbacEnforcer(): Promise<((policy: unknown, ctx: unknown, req: unknown) => unknown) | null> {
+  try {
+    const m: any = await import(join(ENTERPRISE_DIR, "rbac", "index.mjs"));
+    return m.enforce;
+  } catch {
+    return null;
+  }
+}
+
+/** Does `policy` grant `principalId` the reserved admin capability? */
+async function policyGrantsAdmin(policy: unknown, principalId: string): Promise<boolean> {
+  const enforce = await rbacEnforcer();
+  if (!enforce) return false;
+  try {
+    enforce(policy, { principalId, auth: "apikey" }, { tool: ADMIN_CAP });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface AdminResult {
+  ok: boolean;
+  status: number;
+  error?: string;
+}
+
+/**
+ * Authorize an admin action for `principalId` against the CURRENT
+ * on-disk policy (read fresh, never the memoised copy).
+ */
+export async function authorizeAdmin(principalId: string | null): Promise<AdminResult> {
+  if (!gatePromise) gatePromise = buildGate();
+  const g = await gatePromise;
+  if (g.mode !== "active") return { ok: false, status: 409, error: `gate not active (mode: ${g.mode})` };
+  if (!process.env.OMCP_RBAC_POLICY) return { ok: false, status: 409, error: "no RBAC policy configured" };
+  if (!principalId) return { ok: false, status: 401, error: "authentication required" };
+  let current: unknown;
+  try {
+    current = JSON.parse(readFileSync(resolve(process.env.OMCP_RBAC_POLICY), "utf8"));
+  } catch (e) {
+    return { ok: false, status: 500, error: `current policy unreadable: ${String(e)}` };
+  }
+  if (!(await policyGrantsAdmin(current, principalId))) {
+    return { ok: false, status: 403, error: `principal '${principalId}' lacks the '${ADMIN_CAP}' capability` };
+  }
+  return { ok: true, status: 200 };
+}
+
+/**
+ * Replace the RBAC policy. Caller must have passed authorizeAdmin first.
+ * Validates, blocks self-lockout, writes atomically, audits, and
+ * invalidates the gate memo so enforcement picks up the new policy.
+ */
+export async function updateRbacPolicy(
+  principalId: string,
+  next: unknown
+): Promise<AdminResult> {
+  const shapeErr = validatePolicyShape(next);
+  if (shapeErr) return { ok: false, status: 400, error: shapeErr };
+  if (!(await policyGrantsAdmin(next, principalId))) {
+    return {
+      ok: false,
+      status: 400,
+      error: `refused: the new policy would remove '${principalId}' own '${ADMIN_CAP}' capability (anti-lockout)`,
+    };
+  }
+  const path = resolve(process.env.OMCP_RBAC_POLICY as string);
+  let before = "";
+  try {
+    before = readFileSync(path, "utf8");
+  } catch {
+    /* first write — no prior */
+  }
+  const serialized = JSON.stringify(next, null, 2) + "\n";
+  try {
+    const tmp = path + ".tmp-" + process.pid;
+    writeFileSync(tmp, serialized);
+    renameSync(tmp, path); // atomic replace
+  } catch (e) {
+    return { ok: false, status: 500, error: `write failed: ${String(e)}` };
+  }
+
+  // Audit the change (best-effort; never blocks the write outcome).
+  try {
+    if (!gatePromise) gatePromise = buildGate();
+    const g = await gatePromise;
+    if (g.mode === "active" && g.audit) {
+      await g.audit.record({
+        kind: "policy-change",
+        target: "rbac",
+        principalId,
+        bytesBefore: before.length,
+        bytesAfter: serialized.length,
+      });
+    }
+  } catch {
+    /* audit failure must not fail the write */
+  }
+
+  _resetEnterpriseGate(); // next enforcement rebuilds with the new policy
+  return { ok: true, status: 200 };
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -16,6 +16,8 @@ import {
   enterprisePolicyView,
   enterpriseCatalogView,
   enterpriseAuditTail,
+  authorizeAdmin,
+  updateRbacPolicy,
 } from "./enterprise-gate.js";
 import {
   loadCredentials,
@@ -487,6 +489,20 @@ async function main() {
     } catch (e) {
       res.status(500).json({ error: String(e) });
     }
+  });
+  // Phase 2: edit the RBAC policy. NOT on the open local plane — requires
+  // an API-key principal the CURRENT policy grants `enterprise:admin`.
+  app.put("/api/enterprise/policy", async (req, res) => {
+    const cred = resolveToken(
+      extractToken(req.headers as Record<string, unknown>),
+      loadCredentials()
+    );
+    const principal = cred ? cred.name : null;
+    const authz = await authorizeAdmin(principal);
+    if (!authz.ok) return res.status(authz.status).json({ error: authz.error });
+    const result = await updateRbacPolicy(principal as string, req.body);
+    if (!result.ok) return res.status(result.status).json({ error: result.error });
+    res.json({ ok: true });
   });
 
   // Server-side proxy of the connector hub catalog (so the browser

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -790,8 +790,20 @@
       </div>
       <div class="ent-grid">
         <div class="card">
-          <div class="card-header"><h2>Access control (RBAC)</h2></div>
+          <div class="card-header"><h2>Access control (RBAC)</h2>
+            <button class="btn btn-sm" id="ent-rbac-editbtn" onclick="entToggleRbacEdit(true)">Edit policy</button>
+          </div>
           <div id="ent-rbac"><div class="empty">Loading…</div></div>
+          <div id="ent-rbac-editor" class="hidden" style="margin-top:12px">
+            <div class="form-hint" style="margin-bottom:6px">Editing the policy requires an admin API key (a principal the current policy grants <code>enterprise:admin</code>).</div>
+            <input type="password" id="ent-admin-token" placeholder="Admin API key (Bearer)" style="width:100%;margin-bottom:8px">
+            <textarea id="ent-rbac-json" rows="14" spellcheck="false" style="width:100%;font-family:'JetBrains Mono',monospace;font-size:12px"></textarea>
+            <div id="ent-rbac-msg" style="margin:8px 0;font-size:12px"></div>
+            <div style="display:flex;gap:8px;justify-content:flex-end">
+              <button class="btn btn-ghost btn-sm" onclick="entToggleRbacEdit(false)">Cancel</button>
+              <button class="btn btn-primary btn-sm" onclick="entSaveRbac()">Save policy</button>
+            </div>
+          </div>
         </div>
         <div class="card">
           <div class="card-header"><h2>Catalog &amp; products</h2></div>
@@ -965,6 +977,31 @@ async function loadEnterprise(){
         <table class="dtable"><thead><tr><th>#</th><th>Principal</th><th>Tool</th><th>Decision</th><th>Reason</th></tr></thead><tbody>${rows||'<tr><td colspan=5>no decisions yet</td></tr>'}</tbody></table>`;
     }
   }catch{ document.getElementById('ent-audit').innerHTML='<div class="empty">Audit unavailable.</div>'; }
+}
+function entToggleRbacEdit(on){
+  const ed=document.getElementById('ent-rbac-editor'), btn=document.getElementById('ent-rbac-editbtn');
+  document.getElementById('ent-rbac-msg').textContent='';
+  if(on){
+    fetch('/api/enterprise/policy').then(r=>r.json()).then(p=>{
+      document.getElementById('ent-rbac-json').value = p&&p.configured&&p.data ? JSON.stringify(p.data,null,2) : '{\n  "roles": {},\n  "bindings": {}\n}';
+    });
+    ed.classList.remove('hidden'); btn.classList.add('hidden');
+  } else { ed.classList.add('hidden'); btn.classList.remove('hidden'); }
+}
+async function entSaveRbac(){
+  const msg=document.getElementById('ent-rbac-msg');
+  const tok=document.getElementById('ent-admin-token').value.trim();
+  let body;
+  try { body=JSON.parse(document.getElementById('ent-rbac-json').value); }
+  catch(e){ msg.style.color='var(--danger)'; msg.textContent='Invalid JSON: '+e.message; return; }
+  if(!tok){ msg.style.color='var(--danger)'; msg.textContent='Admin API key required.'; return; }
+  msg.style.color='var(--text-muted)'; msg.textContent='Saving…';
+  try{
+    const r=await fetch('/api/enterprise/policy',{method:'PUT',headers:{'Content-Type':'application/json','Authorization':'Bearer '+tok},body:JSON.stringify(body)});
+    const d=await r.json().catch(()=>({}));
+    if(r.ok){ msg.style.color='var(--success)'; msg.textContent='Policy updated.'; toast('RBAC policy saved'); entToggleRbacEdit(false); loadEnterprise(); }
+    else { msg.style.color='var(--danger)'; msg.textContent='Rejected ('+r.status+'): '+(d.error||'unknown'); }
+  }catch(e){ msg.style.color='var(--danger)'; msg.textContent='Request failed: '+e.message; }
 }
 
 function escHtml(s){return String(s==null?'':s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));}


### PR DESCRIPTION
## What

Phase 2 — editable RBAC from the console, with the auth model chosen earlier (**API-key + admin-role from the current policy**).

`PUT /api/enterprise/policy`:
- **Not** on the open local plane. Requires an API-key principal that the **current on-disk policy** grants the reserved `enterprise:admin` capability (first admin bootstrapped via the policy file). → `401` no token · `403` not admin · `409` gate inactive.
- Body **structurally validated** → `400` on bad shape.
- **Anti-lockout:** a new policy that would strip the writer's own `enterprise:admin` is refused (`400`).
- **Atomic** write (tmp+rename); the change is recorded as a `policy-change` audit entry; the gate memo is invalidated so enforcement uses the new policy immediately.
- **UI:** the Enterprise page RBAC card gains an editor gated behind an admin API-key field.

## Defect found in live testing → fixed in this PR

Real e2e (not unit tests) showed that resetting the gate after a policy edit also tore down the in-memory audit log, **severing the hash chain mid-file** (`two seq 0` → `chain ok:false`). An audited policy change that breaks tamper-evidence defeats the purpose. Fixed by making the audit log a **process singleton decoupled from the gate memo**. Chain is now continuous across an edit.

## Verification (real, end-to-end)
- mcp-server suite **219/223** (same 4 pre-existing unrelated fails, **+4 new**), `tsc` clean
- Live against the active gate: auth matrix **200 / 403 / 401 / 400 / 400**; after an admin write the gate reloads (deny reason shifts as the new policy takes effect); audit shows `seq0 decision → seq1 policy-change → seq2 reloaded-gate decision → seq3`, **`chain: {ok:true}` unbroken**
- `enterprise/` FSL modules unchanged; OSS artifact unaffected

Next: P3 — editable catalog (same admin-auth model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)