### PR TITLE
feat(enterprise): admin-gated catalog editing (Phase 3)

### DIFF
--- a/mcp-server/src/enterprise-gate.test.ts
+++ b/mcp-server/src/enterprise-gate.test.ts
@@ -12,6 +12,7 @@ import {
   enterpriseCatalogView,
   enterpriseAuditTail,
   validatePolicyShape,
+  validateCatalogShape,
   authorizeAdmin,
   _resetEnterpriseGate,
 } from "./enterprise-gate.js";
@@ -208,5 +209,40 @@ describe("enterprise-gate — P2 admin RBAC write", () => {
     assert.equal(r.ok, false);
     // gate is fail-closed here → still 409 (not active); never silently allows
     assert.equal(r.ok, false);
+  });
+});
+
+describe("enterprise-gate — P3 catalog write validation", () => {
+  it("validateCatalogShape accepts a well-formed catalog", () => {
+    assert.equal(
+      validateCatalogShape({
+        products: { p: { sources: ["*"], services: ["a"] } },
+        grants: { who: ["p"] },
+        defaultProducts: [],
+      }),
+      null
+    );
+  });
+
+  it("validateCatalogShape rejects malformed shapes", () => {
+    assert.match(validateCatalogShape(null) || "", /must be a JSON object/);
+    assert.match(validateCatalogShape({ grants: {} }) || "", /products must be an object/);
+    assert.match(validateCatalogShape({ products: {} }) || "", /grants must be an object/);
+    assert.match(
+      validateCatalogShape({ products: { p: {} }, grants: {} }) || "",
+      /product 'p.sources' must be an array/
+    );
+    assert.match(
+      validateCatalogShape({ products: { p: { sources: [], services: "x" } }, grants: {} }) || "",
+      /product 'p.services' must be an array/
+    );
+    assert.match(
+      validateCatalogShape({ products: {}, grants: { g: "x" } }) || "",
+      /grant 'g' must be an array/
+    );
+    assert.match(
+      validateCatalogShape({ products: {}, grants: {}, defaultProducts: 1 }) || "",
+      /defaultProducts must be an array/
+    );
   });
 });

--- a/mcp-server/src/enterprise-gate.ts
+++ b/mcp-server/src/enterprise-gate.ts
@@ -481,3 +481,74 @@ export async function updateRbacPolicy(
   _resetEnterpriseGate(); // next enforcement rebuilds with the new policy
   return { ok: true, status: 200 };
 }
+
+// ----------------------------------------------------------------------
+// Phase 3: admin-gated CATALOG write. Same admin model as the RBAC write
+// (authorizeAdmin is RBAC-based and independent of the catalog, so a
+// catalog edit carries no self-lockout risk). Validate, atomic write,
+// audit, invalidate the gate memo.
+// ----------------------------------------------------------------------
+
+/** Structural validation for a product catalog PUT body. */
+export function validateCatalogShape(c: any): string | null {
+  if (!c || typeof c !== "object" || Array.isArray(c)) return "catalog must be a JSON object";
+  if (typeof c.products !== "object" || c.products === null || Array.isArray(c.products)) return "catalog.products must be an object";
+  if (typeof c.grants !== "object" || c.grants === null || Array.isArray(c.grants)) return "catalog.grants must be an object";
+  if (c.defaultProducts !== undefined && !Array.isArray(c.defaultProducts)) return "catalog.defaultProducts must be an array";
+  for (const [name, prod] of Object.entries(c.products as Record<string, any>)) {
+    if (!prod || typeof prod !== "object") return `product '${name}' must be an object`;
+    if (!Array.isArray(prod.sources)) return `product '${name}.sources' must be an array`;
+    for (const k of ["services", "tools"]) {
+      if (prod[k] !== undefined && !Array.isArray(prod[k])) return `product '${name}.${k}' must be an array`;
+    }
+  }
+  for (const [pr, prods] of Object.entries(c.grants as Record<string, any>)) {
+    if (!Array.isArray(prods)) return `grant '${pr}' must be an array of product names`;
+  }
+  return null;
+}
+
+/**
+ * Replace the product catalog. Caller must have passed authorizeAdmin.
+ * Validates, writes atomically, audits, invalidates the gate memo.
+ */
+export async function updateCatalog(
+  principalId: string,
+  next: unknown
+): Promise<AdminResult> {
+  if (!process.env.OMCP_CATALOG) return { ok: false, status: 409, error: "no catalog configured" };
+  const shapeErr = validateCatalogShape(next);
+  if (shapeErr) return { ok: false, status: 400, error: shapeErr };
+  const path = resolve(process.env.OMCP_CATALOG);
+  let before = "";
+  try {
+    before = readFileSync(path, "utf8");
+  } catch {
+    /* first write */
+  }
+  const serialized = JSON.stringify(next, null, 2) + "\n";
+  try {
+    const tmp = path + ".tmp-" + process.pid;
+    writeFileSync(tmp, serialized);
+    renameSync(tmp, path);
+  } catch (e) {
+    return { ok: false, status: 500, error: `write failed: ${String(e)}` };
+  }
+  try {
+    if (!gatePromise) gatePromise = buildGate();
+    const g = await gatePromise;
+    if (g.mode === "active" && g.audit) {
+      await g.audit.record({
+        kind: "policy-change",
+        target: "catalog",
+        principalId,
+        bytesBefore: before.length,
+        bytesAfter: serialized.length,
+      });
+    }
+  } catch {
+    /* audit failure must not fail the write */
+  }
+  _resetEnterpriseGate();
+  return { ok: true, status: 200 };
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -18,6 +18,7 @@ import {
   enterpriseAuditTail,
   authorizeAdmin,
   updateRbacPolicy,
+  updateCatalog,
 } from "./enterprise-gate.js";
 import {
   loadCredentials,
@@ -501,6 +502,19 @@ async function main() {
     const authz = await authorizeAdmin(principal);
     if (!authz.ok) return res.status(authz.status).json({ error: authz.error });
     const result = await updateRbacPolicy(principal as string, req.body);
+    if (!result.ok) return res.status(result.status).json({ error: result.error });
+    res.json({ ok: true });
+  });
+  // Phase 3: edit the product catalog. Same admin model as the RBAC write.
+  app.put("/api/enterprise/catalog", async (req, res) => {
+    const cred = resolveToken(
+      extractToken(req.headers as Record<string, unknown>),
+      loadCredentials()
+    );
+    const principal = cred ? cred.name : null;
+    const authz = await authorizeAdmin(principal);
+    if (!authz.ok) return res.status(authz.status).json({ error: authz.error });
+    const result = await updateCatalog(principal as string, req.body);
     if (!result.ok) return res.status(result.status).json({ error: result.error });
     res.json({ ok: true });
   });

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -806,8 +806,20 @@
           </div>
         </div>
         <div class="card">
-          <div class="card-header"><h2>Catalog &amp; products</h2></div>
+          <div class="card-header"><h2>Catalog &amp; products</h2>
+            <button class="btn btn-sm" id="ent-cat-editbtn" onclick="entToggleCatEdit(true)">Edit catalog</button>
+          </div>
           <div id="ent-catalog"><div class="empty">Loading…</div></div>
+          <div id="ent-cat-editor" class="hidden" style="margin-top:12px">
+            <div class="form-hint" style="margin-bottom:6px">Editing the catalog requires an admin API key (a principal the current policy grants <code>enterprise:admin</code>).</div>
+            <input type="password" id="ent-cat-token" placeholder="Admin API key (Bearer)" style="width:100%;margin-bottom:8px">
+            <textarea id="ent-cat-json" rows="14" spellcheck="false" style="width:100%;font-family:'JetBrains Mono',monospace;font-size:12px"></textarea>
+            <div id="ent-cat-msg" style="margin:8px 0;font-size:12px"></div>
+            <div style="display:flex;gap:8px;justify-content:flex-end">
+              <button class="btn btn-ghost btn-sm" onclick="entToggleCatEdit(false)">Cancel</button>
+              <button class="btn btn-primary btn-sm" onclick="entSaveCat()">Save catalog</button>
+            </div>
+          </div>
         </div>
       </div>
       <div class="card">
@@ -1000,6 +1012,31 @@ async function entSaveRbac(){
     const r=await fetch('/api/enterprise/policy',{method:'PUT',headers:{'Content-Type':'application/json','Authorization':'Bearer '+tok},body:JSON.stringify(body)});
     const d=await r.json().catch(()=>({}));
     if(r.ok){ msg.style.color='var(--success)'; msg.textContent='Policy updated.'; toast('RBAC policy saved'); entToggleRbacEdit(false); loadEnterprise(); }
+    else { msg.style.color='var(--danger)'; msg.textContent='Rejected ('+r.status+'): '+(d.error||'unknown'); }
+  }catch(e){ msg.style.color='var(--danger)'; msg.textContent='Request failed: '+e.message; }
+}
+function entToggleCatEdit(on){
+  const ed=document.getElementById('ent-cat-editor'), btn=document.getElementById('ent-cat-editbtn');
+  document.getElementById('ent-cat-msg').textContent='';
+  if(on){
+    fetch('/api/enterprise/catalog').then(r=>r.json()).then(p=>{
+      document.getElementById('ent-cat-json').value = p&&p.configured&&p.data ? JSON.stringify(p.data,null,2) : '{\n  "products": {},\n  "grants": {}\n}';
+    });
+    ed.classList.remove('hidden'); btn.classList.add('hidden');
+  } else { ed.classList.add('hidden'); btn.classList.remove('hidden'); }
+}
+async function entSaveCat(){
+  const msg=document.getElementById('ent-cat-msg');
+  const tok=document.getElementById('ent-cat-token').value.trim();
+  let body;
+  try { body=JSON.parse(document.getElementById('ent-cat-json').value); }
+  catch(e){ msg.style.color='var(--danger)'; msg.textContent='Invalid JSON: '+e.message; return; }
+  if(!tok){ msg.style.color='var(--danger)'; msg.textContent='Admin API key required.'; return; }
+  msg.style.color='var(--text-muted)'; msg.textContent='Saving…';
+  try{
+    const r=await fetch('/api/enterprise/catalog',{method:'PUT',headers:{'Content-Type':'application/json','Authorization':'Bearer '+tok},body:JSON.stringify(body)});
+    const d=await r.json().catch(()=>({}));
+    if(r.ok){ msg.style.color='var(--success)'; msg.textContent='Catalog updated.'; toast('Catalog saved'); entToggleCatEdit(false); loadEnterprise(); }
     else { msg.style.color='var(--danger)'; msg.textContent='Rejected ('+r.status+'): '+(d.error||'unknown'); }
   }catch(e){ msg.style.color='var(--danger)'; msg.textContent='Request failed: '+e.message; }
 }


### PR DESCRIPTION
## What

Phase 3 — the final piece. `PUT /api/enterprise/catalog` edits the product catalog from the console, mirroring P2's security model:

- **Same admin auth** (`authorizeAdmin`: an API-key principal the **current RBAC policy** grants `enterprise:admin`). → `401` / `403` / `409`.
- `validateCatalogShape` rejects malformed bodies → `400`. No anti-lockout needed — the admin capability is RBAC-based and independent of the catalog, so a catalog edit can't self-lock.
- Atomic write; change recorded as `policy-change target=catalog`; gate memo invalidated so enforcement uses the new catalog immediately.
- UI: the Enterprise page catalog card gains an admin-token-gated editor.

This completes the enterprise console: **P1a** read API · **P1b** reskin + gate pill · **P2** RBAC edit · **P3** catalog edit.

## Verification (real, end-to-end)
- mcp-server suite **221/225** (same 4 pre-existing unrelated fails, **+2 new**), `tsc` clean
- Live against the active gate: auth matrix **200 / 403 / 401 / 400**; after an admin removes `scoped`'s product grant, `scoped`'s `query_metrics` correctly flips **ALLOW → catalog-DENY** (proves reload); audit shows `seq0 decision(allow) → seq1 policy-change(catalog) → seq2 decision(deny)`, **`chain {ok:true}` unbroken**
- `enterprise/` FSL modules unchanged; OSS artifact unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)