### PR TITLE
feat: Kubernetes topology connector (watch-based)

### DIFF
--- a/.github/integration/kubernetes/workload.yaml
+++ b/.github/integration/kubernetes/workload.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: omcp-it
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: omcp-it-echo
+  namespace: omcp-it
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: omcp-it-echo
+  template:
+    metadata:
+      labels:
+        app: omcp-it-echo
+    spec:
+      containers:
+        - name: echo
+          image: ealen/echo-server:0.9.2
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 1
+            periodSeconds: 2
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi

--- a/.github/workflows/kubernetes-connector-it.yml
+++ b/.github/workflows/kubernetes-connector-it.yml
@@ -1,0 +1,86 @@
+name: Kubernetes connector integration test
+
+# Spins up a kind cluster, deploys a tiny test workload, then runs the
+# Kubernetes topology connector against the cluster's real API server
+# (using makeInformer's actual list+watch). Asserts the expected graph
+# (pod → replicaset → deployment, pod → node, pod → namespace) appears.
+#
+# Cheap (~2 min) and runs only on PRs/pushes that touch the connector,
+# the integration script, the workload manifest, or this workflow.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'mcp-server/src/connectors/kubernetes*'
+      - 'mcp-server/src/connectors/interface.ts'
+      - 'mcp-server/src/types.ts'
+      - 'mcp-server/scripts/kubernetes-it.ts'
+      - '.github/integration/kubernetes/**'
+      - '.github/workflows/kubernetes-connector-it.yml'
+  pull_request:
+    paths:
+      - 'mcp-server/src/connectors/kubernetes*'
+      - 'mcp-server/src/connectors/interface.ts'
+      - 'mcp-server/src/types.ts'
+      - 'mcp-server/scripts/kubernetes-it.ts'
+      - '.github/integration/kubernetes/**'
+      - '.github/workflows/kubernetes-connector-it.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  k8s-it:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'mcp-server/package-lock.json'
+
+      - name: Install mcp-server deps
+        working-directory: mcp-server
+        run: npm ci --no-audit --no-fund
+
+      - name: Unit tests (kubernetes-graph + connector)
+        working-directory: mcp-server
+        run: npx tsx --test src/connectors/kubernetes-graph.test.ts src/connectors/kubernetes.test.ts src/connectors/topology.test.ts
+
+      - name: Set up kind cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          version: v0.24.0
+          node_image: kindest/node:v1.31.0
+          cluster_name: omcp-it
+          wait: 90s
+
+      - name: Apply test workload
+        run: |
+          kubectl apply -f .github/integration/kubernetes/workload.yaml
+          kubectl -n omcp-it rollout status deployment/omcp-it-echo --timeout=120s
+
+      - name: Show workload state
+        run: |
+          kubectl -n omcp-it get all
+          kubectl get nodes
+
+      - name: Run connector against the live cluster
+        working-directory: mcp-server
+        env:
+          K8S_IT_TIMEOUT_MS: '60000'
+        run: npx tsx scripts/kubernetes-it.ts
+
+      - name: Dump diagnostics on failure
+        if: failure()
+        run: |
+          kubectl get pods -A
+          kubectl -n omcp-it describe deployment omcp-it-echo || true
+          kubectl -n omcp-it describe rs || true
+          kubectl -n omcp-it describe pod || true

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.6.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@kubernetes/client-node": "^1.4.0",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "express": "^5.2.1",
         "express-rate-limit": "^8.5.2",
@@ -483,6 +484,69 @@
         "hono": "^4"
       }
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@kubernetes/client-node": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-1.4.0.tgz",
+      "integrity": "sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/js-yaml": "^4.0.1",
+        "@types/node": "^24.0.0",
+        "@types/node-fetch": "^2.6.13",
+        "@types/stream-buffers": "^3.0.3",
+        "form-data": "^4.0.0",
+        "hpagent": "^1.2.0",
+        "isomorphic-ws": "^5.0.0",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^10.3.0",
+        "node-fetch": "^2.7.0",
+        "openid-client": "^6.1.3",
+        "rfc4648": "^1.3.0",
+        "socks-proxy-agent": "^8.0.4",
+        "stream-buffers": "^3.0.2",
+        "tar-fs": "^3.0.9",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -589,17 +653,25 @@
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
       "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/qs": {
@@ -637,6 +709,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/stream-buffers": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/stream-buffers/-/stream-buffers-3.0.8.tgz",
+      "integrity": "sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -648,6 +729,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -688,6 +778,117 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/bintrees": {
       "version": "1.0.2",
@@ -755,6 +956,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/content-disposition": {
@@ -845,6 +1058,15 @@
         }
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -883,6 +1105,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -908,6 +1139,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -968,6 +1214,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
       }
     },
     "node_modules/eventsource": {
@@ -1058,6 +1313,12 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -1093,6 +1354,43 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -1198,6 +1496,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -1217,6 +1530,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/http-errors": {
@@ -1291,6 +1613,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/jose": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
@@ -1312,6 +1643,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -1323,6 +1663,24 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1394,6 +1752,35 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1442,6 +1829,19 @@
       "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.4.tgz",
+      "integrity": "sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.2",
+        "oauth4webapi": "^3.8.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -1496,6 +1896,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/qs": {
       "version": "6.14.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
@@ -1543,6 +1953,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfc4648": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.4.tgz",
+      "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
+      "license": "MIT"
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -1720,6 +2136,44 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1727,6 +2181,52 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/stream-buffers": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.3.tgz",
+      "integrity": "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
       }
     },
     "node_modules/tdigest": {
@@ -1738,6 +2238,24 @@
         "bintrees": "1.0.2"
       }
     },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1746,6 +2264,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/tsx": {
       "version": "4.22.2",
@@ -1815,7 +2339,6 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -1834,6 +2357,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -1856,6 +2395,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -42,6 +42,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
+    "@kubernetes/client-node": "^1.4.0",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "express": "^5.2.1",
     "express-rate-limit": "^8.5.2",

--- a/mcp-server/plugins/kubernetes/index.js
+++ b/mcp-server/plugins/kubernetes/index.js
@@ -1,0 +1,8 @@
+// Filesystem plugin shim — re-exports the built-in implementation, same
+// pattern as plugins/prometheus and plugins/loki.
+
+import { KubernetesConnector } from "../../dist/connectors/kubernetes.js";
+
+export default function create() {
+  return new KubernetesConnector();
+}

--- a/mcp-server/plugins/kubernetes/manifest.json
+++ b/mcp-server/plugins/kubernetes/manifest.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "name": "kubernetes",
+  "displayName": "Kubernetes",
+  "version": "0.1.0",
+  "description": "Watches a Kubernetes cluster (in-cluster or via kubeconfig) and exposes pods, nodes, deployments, replicasets and namespaces as an infrastructure topology graph. Edges: RUNS_ON (pod→node), OWNED_BY (pod→rs→deployment), IN_NAMESPACE.",
+  "signalTypes": ["topology"],
+  "license": "Apache-2.0",
+  "capabilities": {},
+  "compat": {
+    "serverVersion": ">=1.7.0"
+  }
+}

--- a/mcp-server/plugins/kubernetes/package.json
+++ b/mcp-server/plugins/kubernetes/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@observability-mcp/connector-kubernetes",
+  "version": "0.1.0",
+  "description": "Kubernetes topology connector for observability-mcp.",
+  "private": true,
+  "type": "module",
+  "main": "./index.js",
+  "license": "Apache-2.0",
+  "observabilityMcp": {
+    "kind": "connector",
+    "name": "kubernetes",
+    "manifest": "./manifest.json"
+  }
+}

--- a/mcp-server/scripts/kubernetes-it.ts
+++ b/mcp-server/scripts/kubernetes-it.ts
@@ -1,0 +1,110 @@
+// Live integration check for the Kubernetes topology connector.
+//
+// Assumes a working kubeconfig in $KUBECONFIG or ~/.kube/config that
+// points at a reachable cluster, and that the manifests in
+// .github/integration/kubernetes/workload.yaml have already been applied
+// (the GH Actions job and the local "make k8s-it" recipe both do this).
+//
+// Drives the connector through real watch events, then asserts the
+// expected graph appeared. Exits non-zero on the first failure.
+
+import { setTimeout as sleep } from "node:timers/promises";
+import { KubernetesConnector } from "../src/connectors/kubernetes.js";
+import { createInformerFactory } from "../src/connectors/kubernetes-client.js";
+import { setDefaultInformerFactoryProvider } from "../src/connectors/kubernetes.js";
+import type { SourceConfig } from "../src/types.js";
+
+const NS = process.env.K8S_IT_NAMESPACE ?? "omcp-it";
+const APP = process.env.K8S_IT_APP ?? "omcp-it-echo";
+const TIMEOUT_MS = Number(process.env.K8S_IT_TIMEOUT_MS ?? "60000");
+
+setDefaultInformerFactoryProvider(createInformerFactory);
+
+const cfg: SourceConfig = {
+  name: "kind-cluster",
+  type: "kubernetes",
+  url: "",
+  enabled: true,
+};
+
+function fail(msg: string): never {
+  console.error("FAIL:", msg);
+  process.exit(1);
+}
+
+async function main() {
+  const conn = new KubernetesConnector();
+  console.log("connecting to cluster...");
+  await conn.connect(cfg);
+
+  const health = await conn.healthCheck();
+  console.log("healthCheck:", health);
+  if (health.status !== "up") fail(`healthCheck not up: ${health.message}`);
+
+  const deadline = Date.now() + TIMEOUT_MS;
+  let snap = await conn.getTopologySnapshot();
+  while (Date.now() < deadline) {
+    snap = await conn.getTopologySnapshot();
+    const podOk = snap.resources.some(
+      (r) => r.kind === "pod" && r.labels.app === APP && r.id.startsWith(`k8s:pod:${NS}/`),
+    );
+    const depOk = snap.resources.some(
+      (r) => r.id === `k8s:deployment:${NS}/${APP}`,
+    );
+    const nodeOk = snap.resources.some((r) => r.kind === "node");
+    const nsOk = snap.resources.some((r) => r.id === `k8s:namespace:${NS}`);
+    if (podOk && depOk && nodeOk && nsOk) break;
+    await sleep(1000);
+  }
+
+  console.log("snapshot:", {
+    revision: snap.revision,
+    resources: snap.resources.length,
+    edges: snap.edges.length,
+  });
+
+  const pod = snap.resources.find(
+    (r) => r.kind === "pod" && r.labels.app === APP,
+  );
+  if (!pod) fail(`no pod with label app=${APP} found in namespace ${NS}`);
+  const dep = snap.resources.find((r) => r.id === `k8s:deployment:${NS}/${APP}`);
+  if (!dep) fail(`deployment ${NS}/${APP} not in graph`);
+  if (!snap.resources.some((r) => r.id === `k8s:namespace:${NS}`)) {
+    fail(`namespace ${NS} not in graph`);
+  }
+  if (!snap.resources.some((r) => r.kind === "node")) fail("no node resources discovered");
+
+  // RUNS_ON: pod → node
+  const runsOn = snap.edges.find((e) => e.from === pod.id && e.relation === "RUNS_ON");
+  if (!runsOn) fail(`pod ${pod.id} has no RUNS_ON edge`);
+  if (!runsOn.to.startsWith("k8s:node:")) fail(`RUNS_ON target is not a node: ${runsOn.to}`);
+
+  // OWNED_BY chain: pod → replicaset → deployment
+  const ownedBy = snap.edges.find((e) => e.from === pod.id && e.relation === "OWNED_BY");
+  if (!ownedBy) fail(`pod ${pod.id} has no OWNED_BY edge`);
+  if (!ownedBy.to.startsWith(`k8s:replicaset:${NS}/`)) {
+    fail(`pod OWNED_BY target is not a replicaset: ${ownedBy.to}`);
+  }
+  const rsOwned = snap.edges.find(
+    (e) => e.from === ownedBy.to && e.relation === "OWNED_BY" && e.to === dep.id,
+  );
+  if (!rsOwned) fail(`replicaset ${ownedBy.to} has no OWNED_BY → ${dep.id}`);
+
+  // IN_NAMESPACE
+  if (!snap.edges.some((e) => e.from === pod.id && e.relation === "IN_NAMESPACE")) {
+    fail(`pod ${pod.id} has no IN_NAMESPACE edge`);
+  }
+
+  console.log("OK — full topology chain present:");
+  console.log(`  ${pod.id}`);
+  console.log(`    RUNS_ON   → ${runsOn.to}`);
+  console.log(`    OWNED_BY  → ${ownedBy.to}`);
+  console.log(`             OWNED_BY → ${dep.id}`);
+
+  await conn.disconnect();
+}
+
+main().catch((err) => {
+  console.error("integration check threw:", err);
+  process.exit(1);
+});

--- a/mcp-server/src/connectors/interface.ts
+++ b/mcp-server/src/connectors/interface.ts
@@ -9,6 +9,10 @@ import type {
   LogResult,
   SourceConfig,
   MetricDefinition,
+  Resource,
+  Edge,
+  TopologySnapshot,
+  TopologyChangeListener,
 } from "../types.js";
 
 export interface ObservabilityConnector {
@@ -31,4 +35,35 @@ export interface ObservabilityConnector {
 
   queryMetrics?(params: MetricQuery): Promise<MetricResult>;
   queryLogs?(params: LogQuery): Promise<LogResult>;
+
+  // --- Topology (optional capability) ---
+  // Connectors that expose an infrastructure graph implement these methods.
+  // Backends that only emit metrics/logs leave them undefined.
+
+  /** Current in-memory resource list. Should be O(1) — backed by the watch cache. */
+  listResources?(): Promise<Resource[]>;
+  /** Current in-memory edge list. Should be O(1) — backed by the watch cache. */
+  listEdges?(): Promise<Edge[]>;
+  /** Atomic snapshot of resources+edges with a monotonic revision counter. */
+  getTopologySnapshot?(): Promise<TopologySnapshot>;
+  /** Subscribe to incremental changes. Returns an unsubscribe function. */
+  watchTopology?(listener: TopologyChangeListener): () => void;
+}
+
+/** Narrowing guard: connectors that implement the topology capability. */
+export function isTopologyProvider(
+  c: ObservabilityConnector,
+): c is ObservabilityConnector &
+  Required<
+    Pick<
+      ObservabilityConnector,
+      "listResources" | "listEdges" | "getTopologySnapshot" | "watchTopology"
+    >
+  > {
+  return (
+    typeof c.listResources === "function" &&
+    typeof c.listEdges === "function" &&
+    typeof c.getTopologySnapshot === "function" &&
+    typeof c.watchTopology === "function"
+  );
 }

--- a/mcp-server/src/connectors/kubernetes-client.ts
+++ b/mcp-server/src/connectors/kubernetes-client.ts
@@ -1,0 +1,126 @@
+// Thin adapter around @kubernetes/client-node. Kept in its own file so
+// the connector class itself stays SDK-free and unit-testable. The
+// loader imports this lazily so installations that don't configure a
+// kubernetes source don't pay the import cost.
+
+import {
+  KubeConfig,
+  CoreV1Api,
+  AppsV1Api,
+  makeInformer,
+  type Informer as K8sInformer,
+  type KubernetesObject,
+  type V1Pod,
+  type V1Node,
+  type V1Deployment,
+  type V1ReplicaSet,
+  type V1Namespace,
+} from "@kubernetes/client-node";
+import type { SourceConfig } from "../types.js";
+import type { Informer, InformerFactory } from "./kubernetes.js";
+import type {
+  KubePod,
+  KubeNode,
+  KubeDeployment,
+  KubeReplicaSet,
+  KubeNamespace,
+} from "./kubernetes-graph.js";
+
+function buildKubeConfig(config: SourceConfig): KubeConfig {
+  const kc = new KubeConfig();
+  if (config.auth?.type === "bearer" && config.auth.token && config.url) {
+    // Explicit cluster + bearer-token config (e.g. remote cluster).
+    kc.loadFromOptions({
+      clusters: [
+        {
+          name: config.name,
+          server: config.url,
+          skipTLSVerify: !!(config.tls?.skipVerify ?? config.tlsSkipVerify),
+          caFile: config.tls?.caCert,
+        },
+      ],
+      users: [{ name: config.name, token: config.auth.token }],
+      contexts: [{ name: config.name, cluster: config.name, user: config.name }],
+      currentContext: config.name,
+    });
+    return kc;
+  }
+  // Fall through: in-cluster (ServiceAccount) or KUBECONFIG/~/.kube/config.
+  // In @kubernetes/client-node v1.x, loadFromCluster() no longer throws
+  // when env+files are missing — it silently produces "https://undefined:undefined".
+  // Detect in-cluster context by the well-known env vars instead.
+  const inCluster =
+    !!process.env.KUBERNETES_SERVICE_HOST && !!process.env.KUBERNETES_SERVICE_PORT;
+  if (inCluster) {
+    kc.loadFromCluster();
+  } else {
+    kc.loadFromDefault();
+  }
+  return kc;
+}
+
+function wrapInformer<T extends KubernetesObject>(inf: K8sInformer<T>): Informer<T> {
+  return {
+    on(event, handler) {
+      // @kubernetes/client-node Informer emits 'add' | 'update' | 'delete' | 'error'.
+      inf.on(event as "add", handler as (o: T) => void);
+    },
+    async start() {
+      await inf.start();
+    },
+    async stop() {
+      await inf.stop();
+    },
+  };
+}
+
+export async function createInformerFactory(config: SourceConfig): Promise<InformerFactory> {
+  const kc = buildKubeConfig(config);
+  const core = kc.makeApiClient(CoreV1Api);
+  const apps = kc.makeApiClient(AppsV1Api);
+
+  // In @kubernetes/client-node v1+, list*() resolves directly to the
+  // KubernetesListObject (with `items`), not the v0.x `{ body, response }`.
+  const podInformer = makeInformer<V1Pod>(kc, "/api/v1/pods", () =>
+    core.listPodForAllNamespaces(),
+  );
+  const nodeInformer = makeInformer<V1Node>(kc, "/api/v1/nodes", () => core.listNode());
+  const nsInformer = makeInformer<V1Namespace>(kc, "/api/v1/namespaces", () =>
+    core.listNamespace(),
+  );
+  const depInformer = makeInformer<V1Deployment>(kc, "/apis/apps/v1/deployments", () =>
+    apps.listDeploymentForAllNamespaces(),
+  );
+  const rsInformer = makeInformer<V1ReplicaSet>(kc, "/apis/apps/v1/replicasets", () =>
+    apps.listReplicaSetForAllNamespaces(),
+  );
+
+  return {
+    pods: () => wrapInformer<V1Pod>(podInformer) as unknown as Informer<KubePod>,
+    nodes: () => wrapInformer<V1Node>(nodeInformer) as unknown as Informer<KubeNode>,
+    deployments: () =>
+      wrapInformer<V1Deployment>(depInformer) as unknown as Informer<KubeDeployment>,
+    replicaSets: () =>
+      wrapInformer<V1ReplicaSet>(rsInformer) as unknown as Informer<KubeReplicaSet>,
+    namespaces: () => wrapInformer<V1Namespace>(nsInformer) as unknown as Informer<KubeNamespace>,
+    async healthCheck() {
+      const start = Date.now();
+      try {
+        // /version is unauthenticated on most clusters and exists on all.
+        await core.getAPIResources();
+        return { ok: true, latencyMs: Date.now() - start };
+      } catch (err) {
+        return { ok: false, latencyMs: Date.now() - start, message: String(err) };
+      }
+    },
+    async close() {
+      await Promise.all([
+        podInformer.stop().catch(() => {}),
+        nodeInformer.stop().catch(() => {}),
+        nsInformer.stop().catch(() => {}),
+        depInformer.stop().catch(() => {}),
+        rsInformer.stop().catch(() => {}),
+      ]);
+    },
+  };
+}

--- a/mcp-server/src/connectors/kubernetes-graph.test.ts
+++ b/mcp-server/src/connectors/kubernetes-graph.test.ts
@@ -1,0 +1,181 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  TopologyStore,
+  podResource,
+  podEdges,
+  nodeResource,
+  deploymentResource,
+  replicaSetResource,
+  replicaSetEdges,
+  namespacedId,
+  clusterScopedId,
+  type KubePod,
+} from "./kubernetes-graph.js";
+
+const SRC = "test-cluster";
+
+const samplePod: KubePod = {
+  metadata: {
+    name: "checkout-7f89d",
+    namespace: "default",
+    uid: "pod-uid-1",
+    labels: { app: "checkout" },
+    ownerReferences: [{ kind: "ReplicaSet", name: "checkout-7f89", uid: "rs-uid-1" }],
+  },
+  spec: { nodeName: "worker-1" },
+  status: { phase: "Running" },
+};
+
+describe("kubernetes-graph: resource builders", () => {
+  it("podResource produces a stable namespaced ID and preserves labels/uid", () => {
+    const r = podResource(SRC, samplePod);
+    assert.ok(r);
+    assert.equal(r!.id, "k8s:pod:default/checkout-7f89d");
+    assert.equal(r!.kind, "pod");
+    assert.equal(r!.source, SRC);
+    assert.deepEqual(r!.labels, { app: "checkout" });
+    assert.equal((r!.attributes as { uid?: string }).uid, "pod-uid-1");
+    assert.equal((r!.attributes as { phase?: string }).phase, "Running");
+  });
+
+  it("returns undefined when metadata is missing", () => {
+    assert.equal(podResource(SRC, {}), undefined);
+    assert.equal(podResource(SRC, { metadata: { name: "x" } }), undefined); // no namespace
+  });
+
+  it("nodeResource is cluster-scoped (no namespace in ID)", () => {
+    const r = nodeResource(SRC, {
+      metadata: { name: "worker-1" },
+      status: { conditions: [{ type: "Ready", status: "True" }] },
+    });
+    assert.equal(r!.id, "k8s:node:worker-1");
+    assert.equal((r!.attributes as { ready?: string }).ready, "True");
+  });
+
+  it("deploymentResource builds a namespaced ID", () => {
+    const r = deploymentResource(SRC, {
+      metadata: { name: "checkout", namespace: "default" },
+    });
+    assert.equal(r!.id, "k8s:deployment:default/checkout");
+  });
+
+  it("replicaSetResource builds a namespaced ID", () => {
+    const r = replicaSetResource(SRC, {
+      metadata: { name: "checkout-7f89", namespace: "default" },
+    });
+    assert.equal(r!.id, "k8s:replicaset:default/checkout-7f89");
+  });
+});
+
+describe("kubernetes-graph: edge builders", () => {
+  it("podEdges emits RUNS_ON, IN_NAMESPACE and OWNED_BY", () => {
+    const edges = podEdges(SRC, samplePod);
+    const rels = edges.map((e) => e.relation).sort();
+    assert.deepEqual(rels, ["IN_NAMESPACE", "OWNED_BY", "RUNS_ON"]);
+    const runs = edges.find((e) => e.relation === "RUNS_ON");
+    assert.equal(runs!.to, "k8s:node:worker-1");
+    assert.equal(runs!.confidence, 1.0);
+    assert.equal(runs!.source, SRC);
+    const owned = edges.find((e) => e.relation === "OWNED_BY");
+    assert.equal(owned!.to, "k8s:replicaset:default/checkout-7f89");
+  });
+
+  it("podEdges skips RUNS_ON when the pod has no nodeName yet (Pending)", () => {
+    const pending: KubePod = {
+      metadata: { name: "p", namespace: "default" },
+      status: { phase: "Pending" },
+    };
+    const edges = podEdges(SRC, pending);
+    assert.equal(edges.find((e) => e.relation === "RUNS_ON"), undefined);
+    assert.ok(edges.find((e) => e.relation === "IN_NAMESPACE"));
+  });
+
+  it("replicaSetEdges chains OWNED_BY to a Deployment", () => {
+    const edges = replicaSetEdges(SRC, {
+      metadata: {
+        name: "checkout-7f89",
+        namespace: "default",
+        ownerReferences: [{ kind: "Deployment", name: "checkout" }],
+      },
+    });
+    const owned = edges.find((e) => e.relation === "OWNED_BY");
+    assert.ok(owned);
+    assert.equal(owned!.to, "k8s:deployment:default/checkout");
+  });
+
+  it("ignores unknown owner kinds (forward-compat)", () => {
+    const edges = podEdges(SRC, {
+      metadata: {
+        name: "p",
+        namespace: "default",
+        ownerReferences: [{ kind: "FrobnicatorSet", name: "x" }],
+      },
+    });
+    assert.equal(edges.find((e) => e.relation === "OWNED_BY"), undefined);
+  });
+});
+
+describe("TopologyStore", () => {
+  it("upsertResource adds resource + edges and emits diffs", () => {
+    const store = new TopologyStore(SRC);
+    const events: string[] = [];
+    store.subscribe((e) => events.push(e.type));
+
+    const r = podResource(SRC, samplePod)!;
+    store.upsertResource(r, podEdges(SRC, samplePod));
+    assert.equal(store.listResources().length, 1);
+    assert.equal(store.listEdges().length, 3);
+    assert.ok(events.includes("resource_added"));
+    assert.equal(events.filter((t) => t === "edge_added").length, 3);
+    assert.ok(store.revision > 0);
+  });
+
+  it("update replaces edges atomically — emits removed/added for diff only", () => {
+    const store = new TopologyStore(SRC);
+    store.upsertResource(podResource(SRC, samplePod)!, podEdges(SRC, samplePod));
+    const events: string[] = [];
+    store.subscribe((e) => events.push(e.type));
+
+    // Pod moved to a new node — RUNS_ON edge should be replaced, others stable.
+    const moved: KubePod = { ...samplePod, spec: { nodeName: "worker-2" } };
+    store.upsertResource(podResource(SRC, moved)!, podEdges(SRC, moved));
+
+    assert.equal(events.filter((t) => t === "edge_added").length, 1);
+    assert.equal(events.filter((t) => t === "edge_removed").length, 1);
+    assert.equal(events.filter((t) => t === "resource_updated").length, 1);
+
+    const runs = store.listEdges().find((e) => e.relation === "RUNS_ON");
+    assert.equal(runs!.to, "k8s:node:worker-2");
+  });
+
+  it("removeResource drops the resource and all its outgoing edges", () => {
+    const store = new TopologyStore(SRC);
+    store.upsertResource(podResource(SRC, samplePod)!, podEdges(SRC, samplePod));
+    const id = namespacedId("pod", "default", "checkout-7f89d");
+    store.removeResource(id);
+    assert.equal(store.listResources().length, 0);
+    assert.equal(store.listEdges().length, 0);
+  });
+
+  it("snapshot() carries the current revision counter", () => {
+    const store = new TopologyStore(SRC);
+    const r0 = store.revision;
+    store.upsertResource(nodeResource(SRC, { metadata: { name: "n1" } })!, []);
+    const snap = store.snapshot();
+    assert.ok(snap.revision > r0);
+    assert.equal(snap.source, SRC);
+    assert.equal(snap.resources[0].id, clusterScopedId("node", "n1"));
+  });
+
+  it("subscriber errors don't kill the store", () => {
+    const store = new TopologyStore(SRC);
+    store.subscribe(() => {
+      throw new Error("boom");
+    });
+    let saw = 0;
+    store.subscribe(() => saw++);
+    store.upsertResource(nodeResource(SRC, { metadata: { name: "n1" } })!, []);
+    assert.ok(saw > 0);
+  });
+});

--- a/mcp-server/src/connectors/kubernetes-graph.ts
+++ b/mcp-server/src/connectors/kubernetes-graph.ts
@@ -1,0 +1,309 @@
+// Pure graph-building helpers for the Kubernetes connector.
+//
+// All Kubernetes object → Resource/Edge translation lives here so it can
+// be unit-tested without a live API server. The connector class
+// (kubernetes.ts) wires these into the watch event handlers.
+
+import type { Resource, Edge, TopologySnapshot, TopologyChangeEvent } from "../types.js";
+
+// Minimal shape of a Kubernetes object — we only consume the bits we
+// need, so we don't pull the full @kubernetes/client-node types into
+// modules that don't depend on the SDK.
+export interface KubeObjectMeta {
+  name?: string;
+  namespace?: string;
+  uid?: string;
+  labels?: Record<string, string>;
+  ownerReferences?: Array<{ kind: string; name: string; uid?: string }>;
+}
+
+export interface KubePod {
+  metadata?: KubeObjectMeta;
+  spec?: { nodeName?: string };
+  status?: { phase?: string };
+}
+
+export interface KubeNode {
+  metadata?: KubeObjectMeta;
+  status?: { conditions?: Array<{ type: string; status: string }> };
+}
+
+export interface KubeDeployment {
+  metadata?: KubeObjectMeta;
+}
+
+export interface KubeReplicaSet {
+  metadata?: KubeObjectMeta;
+}
+
+export interface KubeNamespace {
+  metadata?: KubeObjectMeta;
+}
+
+// --- Canonical IDs ------------------------------------------------------
+
+export function namespacedId(kind: string, namespace: string, name: string): string {
+  return `k8s:${kind}:${namespace}/${name}`;
+}
+
+export function clusterScopedId(kind: string, name: string): string {
+  return `k8s:${kind}:${name}`;
+}
+
+// --- Resource builders --------------------------------------------------
+
+const baseLabels = (m?: KubeObjectMeta): Record<string, string> => ({ ...(m?.labels ?? {}) });
+const baseAttrs = (m?: KubeObjectMeta): Record<string, unknown> =>
+  m?.uid ? { uid: m.uid } : {};
+
+export function podResource(source: string, pod: KubePod): Resource | undefined {
+  const name = pod.metadata?.name;
+  const namespace = pod.metadata?.namespace;
+  if (!name || !namespace) return undefined;
+  return {
+    id: namespacedId("pod", namespace, name),
+    kind: "pod",
+    name,
+    source,
+    labels: baseLabels(pod.metadata),
+    attributes: {
+      ...baseAttrs(pod.metadata),
+      ...(pod.status?.phase ? { phase: pod.status.phase } : {}),
+      ...(pod.spec?.nodeName ? { nodeName: pod.spec.nodeName } : {}),
+    },
+  };
+}
+
+export function nodeResource(source: string, node: KubeNode): Resource | undefined {
+  const name = node.metadata?.name;
+  if (!name) return undefined;
+  const ready = node.status?.conditions?.find((c) => c.type === "Ready")?.status;
+  return {
+    id: clusterScopedId("node", name),
+    kind: "node",
+    name,
+    source,
+    labels: baseLabels(node.metadata),
+    attributes: { ...baseAttrs(node.metadata), ...(ready ? { ready } : {}) },
+  };
+}
+
+export function deploymentResource(source: string, d: KubeDeployment): Resource | undefined {
+  const name = d.metadata?.name;
+  const namespace = d.metadata?.namespace;
+  if (!name || !namespace) return undefined;
+  return {
+    id: namespacedId("deployment", namespace, name),
+    kind: "deployment",
+    name,
+    source,
+    labels: baseLabels(d.metadata),
+    attributes: baseAttrs(d.metadata),
+  };
+}
+
+export function replicaSetResource(source: string, rs: KubeReplicaSet): Resource | undefined {
+  const name = rs.metadata?.name;
+  const namespace = rs.metadata?.namespace;
+  if (!name || !namespace) return undefined;
+  return {
+    id: namespacedId("replicaset", namespace, name),
+    kind: "replicaset",
+    name,
+    source,
+    labels: baseLabels(rs.metadata),
+    attributes: baseAttrs(rs.metadata),
+  };
+}
+
+export function namespaceResource(source: string, ns: KubeNamespace): Resource | undefined {
+  const name = ns.metadata?.name;
+  if (!name) return undefined;
+  return {
+    id: clusterScopedId("namespace", name),
+    kind: "namespace",
+    name,
+    source,
+    labels: baseLabels(ns.metadata),
+    attributes: baseAttrs(ns.metadata),
+  };
+}
+
+// --- Edge builders ------------------------------------------------------
+
+const KNOWN_OWNER_KINDS: Record<string, string> = {
+  Deployment: "deployment",
+  ReplicaSet: "replicaset",
+  StatefulSet: "statefulset",
+  DaemonSet: "daemonset",
+  Job: "job",
+  CronJob: "cronjob",
+};
+
+function ownerEdges(
+  source: string,
+  fromId: string,
+  meta: KubeObjectMeta | undefined,
+  namespace: string,
+): Edge[] {
+  const out: Edge[] = [];
+  for (const ref of meta?.ownerReferences ?? []) {
+    const kind = KNOWN_OWNER_KINDS[ref.kind];
+    if (!kind) continue;
+    out.push({
+      from: fromId,
+      to: namespacedId(kind, namespace, ref.name),
+      relation: "OWNED_BY",
+      source,
+      confidence: 1.0,
+    });
+  }
+  return out;
+}
+
+export function podEdges(source: string, pod: KubePod): Edge[] {
+  const name = pod.metadata?.name;
+  const namespace = pod.metadata?.namespace;
+  if (!name || !namespace) return [];
+  const fromId = namespacedId("pod", namespace, name);
+  const edges: Edge[] = [
+    {
+      from: fromId,
+      to: clusterScopedId("namespace", namespace),
+      relation: "IN_NAMESPACE",
+      source,
+      confidence: 1.0,
+    },
+  ];
+  if (pod.spec?.nodeName) {
+    edges.push({
+      from: fromId,
+      to: clusterScopedId("node", pod.spec.nodeName),
+      relation: "RUNS_ON",
+      source,
+      confidence: 1.0,
+    });
+  }
+  edges.push(...ownerEdges(source, fromId, pod.metadata, namespace));
+  return edges;
+}
+
+export function replicaSetEdges(source: string, rs: KubeReplicaSet): Edge[] {
+  const name = rs.metadata?.name;
+  const namespace = rs.metadata?.namespace;
+  if (!name || !namespace) return [];
+  const fromId = namespacedId("replicaset", namespace, name);
+  return [
+    {
+      from: fromId,
+      to: clusterScopedId("namespace", namespace),
+      relation: "IN_NAMESPACE",
+      source,
+      confidence: 1.0,
+    },
+    ...ownerEdges(source, fromId, rs.metadata, namespace),
+  ];
+}
+
+export function deploymentEdges(source: string, d: KubeDeployment): Edge[] {
+  const name = d.metadata?.name;
+  const namespace = d.metadata?.namespace;
+  if (!name || !namespace) return [];
+  return [
+    {
+      from: namespacedId("deployment", namespace, name),
+      to: clusterScopedId("namespace", namespace),
+      relation: "IN_NAMESPACE",
+      source,
+      confidence: 1.0,
+    },
+  ];
+}
+
+// --- Graph store --------------------------------------------------------
+
+/**
+ * In-memory store of the connector's current view of the cluster. The
+ * watch event handlers call add/remove and the store emits incremental
+ * change events to subscribers.
+ *
+ * Edges are tracked per-owner-resource so when a pod is deleted we can
+ * cleanly remove its outgoing edges without scanning the whole edge map.
+ */
+export class TopologyStore {
+  private resources = new Map<string, Resource>();
+  private edgesByOwner = new Map<string, Edge[]>(); // ownerId → outgoing edges
+  private rev = 0;
+  private listeners = new Set<(e: TopologyChangeEvent) => void>();
+
+  constructor(private readonly source: string) {}
+
+  get revision(): number {
+    return this.rev;
+  }
+
+  subscribe(listener: (e: TopologyChangeEvent) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private emit(e: TopologyChangeEvent): void {
+    this.rev++;
+    for (const l of this.listeners) {
+      try {
+        l(e);
+      } catch {
+        // listener errors must not poison the watch loop
+      }
+    }
+  }
+
+  upsertResource(r: Resource, ownedEdges: Edge[]): void {
+    const existed = this.resources.has(r.id);
+    this.resources.set(r.id, r);
+
+    // Replace edges originating from this resource atomically.
+    const prev = this.edgesByOwner.get(r.id) ?? [];
+    this.edgesByOwner.set(r.id, ownedEdges);
+
+    this.emit({ type: existed ? "resource_updated" : "resource_added", resource: r });
+    // Diff edges so subscribers see precise add/remove.
+    const prevKeys = new Set(prev.map(edgeKey));
+    const nextKeys = new Set(ownedEdges.map(edgeKey));
+    for (const e of prev) if (!nextKeys.has(edgeKey(e))) this.emit({ type: "edge_removed", edge: e });
+    for (const e of ownedEdges) if (!prevKeys.has(edgeKey(e))) this.emit({ type: "edge_added", edge: e });
+  }
+
+  removeResource(id: string): void {
+    const r = this.resources.get(id);
+    if (!r) return;
+    this.resources.delete(id);
+    const prev = this.edgesByOwner.get(id) ?? [];
+    this.edgesByOwner.delete(id);
+    for (const e of prev) this.emit({ type: "edge_removed", edge: e });
+    this.emit({ type: "resource_removed", resource: r });
+  }
+
+  listResources(): Resource[] {
+    return Array.from(this.resources.values());
+  }
+
+  listEdges(): Edge[] {
+    const out: Edge[] = [];
+    for (const arr of this.edgesByOwner.values()) out.push(...arr);
+    return out;
+  }
+
+  snapshot(): TopologySnapshot {
+    return {
+      source: this.source,
+      resources: this.listResources(),
+      edges: this.listEdges(),
+      revision: this.rev,
+    };
+  }
+}
+
+function edgeKey(e: Edge): string {
+  return `${e.from}|${e.relation}|${e.to}`;
+}

--- a/mcp-server/src/connectors/kubernetes.test.ts
+++ b/mcp-server/src/connectors/kubernetes.test.ts
@@ -1,0 +1,164 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { KubernetesConnector, type Informer, type InformerFactory } from "./kubernetes.js";
+import { isTopologyProvider } from "./interface.js";
+import type {
+  KubePod,
+  KubeNode,
+  KubeDeployment,
+  KubeReplicaSet,
+  KubeNamespace,
+} from "./kubernetes-graph.js";
+import type { SourceConfig, TopologyChangeEvent } from "../types.js";
+
+// --- Fake informer harness ---------------------------------------------
+// We hand-roll a tiny event emitter so tests can drive add/update/delete
+// events synchronously without spinning up a real watch stream.
+
+type Handler<T> = (obj: T) => void;
+type EvtName = "add" | "update" | "delete" | "error";
+
+class FakeInformer<T> implements Informer<T> {
+  private handlers: Partial<Record<EvtName, Array<Handler<T> | ((e: unknown) => void)>>> = {};
+  started = false;
+  stopped = false;
+
+  on(event: EvtName, handler: Handler<T> | ((e: unknown) => void)): void {
+    (this.handlers[event] ??= []).push(handler);
+  }
+  async start() {
+    this.started = true;
+  }
+  async stop() {
+    this.stopped = true;
+  }
+
+  emit(event: "add" | "update" | "delete", obj: T): void {
+    for (const h of this.handlers[event] ?? []) (h as Handler<T>)(obj);
+  }
+}
+
+function makeFakeFactory() {
+  const pods = new FakeInformer<KubePod>();
+  const nodes = new FakeInformer<KubeNode>();
+  const deps = new FakeInformer<KubeDeployment>();
+  const rs = new FakeInformer<KubeReplicaSet>();
+  const ns = new FakeInformer<KubeNamespace>();
+  const factory: InformerFactory = {
+    pods: () => pods,
+    nodes: () => nodes,
+    deployments: () => deps,
+    replicaSets: () => rs,
+    namespaces: () => ns,
+    async healthCheck() {
+      return { ok: true, latencyMs: 1 };
+    },
+    async close() {},
+  };
+  return { factory, pods, nodes, deps, rs, ns };
+}
+
+const CFG: SourceConfig = {
+  name: "test-cluster",
+  type: "kubernetes",
+  url: "",
+  enabled: true,
+};
+
+describe("KubernetesConnector", () => {
+  it("implements the TopologyProvider capability", async () => {
+    const { factory } = makeFakeFactory();
+    const conn = new KubernetesConnector(async () => factory);
+    await conn.connect(CFG);
+    assert.equal(isTopologyProvider(conn), true);
+    assert.equal(conn.signalType, "topology");
+    await conn.disconnect();
+  });
+
+  it("starts every informer on connect and stops them on disconnect", async () => {
+    const fake = makeFakeFactory();
+    const conn = new KubernetesConnector(async () => fake.factory);
+    await conn.connect(CFG);
+    for (const inf of [fake.pods, fake.nodes, fake.deps, fake.rs, fake.ns]) {
+      assert.equal(inf.started, true);
+    }
+    await conn.disconnect();
+    for (const inf of [fake.pods, fake.nodes, fake.deps, fake.rs, fake.ns]) {
+      assert.equal(inf.stopped, true);
+    }
+  });
+
+  it("builds the graph from watch events", async () => {
+    const fake = makeFakeFactory();
+    const conn = new KubernetesConnector(async () => fake.factory);
+    await conn.connect(CFG);
+
+    fake.nodes.emit("add", { metadata: { name: "worker-1" } });
+    fake.ns.emit("add", { metadata: { name: "default" } });
+    fake.deps.emit("add", { metadata: { name: "checkout", namespace: "default" } });
+    fake.rs.emit("add", {
+      metadata: {
+        name: "checkout-7f89",
+        namespace: "default",
+        ownerReferences: [{ kind: "Deployment", name: "checkout" }],
+      },
+    });
+    fake.pods.emit("add", {
+      metadata: {
+        name: "checkout-7f89d",
+        namespace: "default",
+        ownerReferences: [{ kind: "ReplicaSet", name: "checkout-7f89" }],
+      },
+      spec: { nodeName: "worker-1" },
+    });
+
+    const snap = await conn.getTopologySnapshot();
+    const ids = snap.resources.map((r) => r.id).sort();
+    assert.deepEqual(ids, [
+      "k8s:deployment:default/checkout",
+      "k8s:namespace:default",
+      "k8s:node:worker-1",
+      "k8s:pod:default/checkout-7f89d",
+      "k8s:replicaset:default/checkout-7f89",
+    ]);
+    // Full RCA chain present: pod → rs → deployment, pod → node, * → namespace.
+    const e = snap.edges;
+    assert.ok(e.some((x) => x.from === "k8s:pod:default/checkout-7f89d" && x.relation === "RUNS_ON"));
+    assert.ok(e.some((x) => x.from === "k8s:pod:default/checkout-7f89d" && x.relation === "OWNED_BY"));
+    assert.ok(e.some((x) => x.from === "k8s:replicaset:default/checkout-7f89" && x.relation === "OWNED_BY"));
+    await conn.disconnect();
+  });
+
+  it("removes a pod's edges when the pod is deleted", async () => {
+    const fake = makeFakeFactory();
+    const conn = new KubernetesConnector(async () => fake.factory);
+    await conn.connect(CFG);
+    const pod: KubePod = {
+      metadata: { name: "p1", namespace: "default" },
+      spec: { nodeName: "n1" },
+    };
+    fake.pods.emit("add", pod);
+    assert.equal((await conn.listEdges()).length > 0, true);
+    fake.pods.emit("delete", pod);
+    assert.equal((await conn.listResources()).length, 0);
+    assert.equal((await conn.listEdges()).length, 0);
+    await conn.disconnect();
+  });
+
+  it("watchTopology delivers a resync then live diffs", async () => {
+    const fake = makeFakeFactory();
+    const conn = new KubernetesConnector(async () => fake.factory);
+    await conn.connect(CFG);
+    fake.nodes.emit("add", { metadata: { name: "n0" } });
+
+    const events: TopologyChangeEvent[] = [];
+    const unsub = conn.watchTopology((e) => events.push(e));
+    await new Promise((r) => setImmediate(r));
+    assert.equal(events[0]?.type, "resync");
+
+    fake.nodes.emit("add", { metadata: { name: "n1" } });
+    assert.ok(events.some((e) => e.type === "resource_added"));
+    unsub();
+    await conn.disconnect();
+  });
+});

--- a/mcp-server/src/connectors/kubernetes.ts
+++ b/mcp-server/src/connectors/kubernetes.ts
@@ -1,0 +1,255 @@
+import type { ObservabilityConnector } from "./interface.js";
+import type {
+  SourceConfig,
+  ConnectorHealth,
+  ServiceInfo,
+  MetricDefinition,
+  Resource,
+  Edge,
+  TopologySnapshot,
+  TopologyChangeListener,
+  SignalType,
+} from "../types.js";
+import {
+  TopologyStore,
+  podResource,
+  podEdges,
+  nodeResource,
+  deploymentResource,
+  deploymentEdges,
+  replicaSetResource,
+  replicaSetEdges,
+  namespaceResource,
+  namespacedId,
+  clusterScopedId,
+  type KubePod,
+  type KubeNode,
+  type KubeDeployment,
+  type KubeReplicaSet,
+  type KubeNamespace,
+} from "./kubernetes-graph.js";
+
+// Minimal informer abstraction so the connector is unit-testable without
+// a live cluster. The real implementation in createInformerFactory wraps
+// @kubernetes/client-node's makeInformer; the test suite swaps in a fake
+// factory and drives events synchronously.
+export interface Informer<T> {
+  on(event: "add" | "update", handler: (obj: T) => void): void;
+  on(event: "delete", handler: (obj: T) => void): void;
+  on(event: "error", handler: (err: unknown) => void): void;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}
+
+export interface InformerFactory {
+  pods(): Informer<KubePod>;
+  nodes(): Informer<KubeNode>;
+  deployments(): Informer<KubeDeployment>;
+  replicaSets(): Informer<KubeReplicaSet>;
+  namespaces(): Informer<KubeNamespace>;
+  /** Cheap health probe — should hit /version or /healthz. */
+  healthCheck(): Promise<{ ok: boolean; latencyMs: number; message?: string }>;
+  close(): Promise<void>;
+}
+
+export type InformerFactoryProvider = (config: SourceConfig) => Promise<InformerFactory>;
+
+// Default provider is loaded lazily so tests don't pay the
+// @kubernetes/client-node import cost (and so the module is usable in
+// environments where the SDK isn't installed yet — e.g. unit tests in CI
+// before the dep lands).
+let defaultProvider: InformerFactoryProvider | undefined;
+
+export function setDefaultInformerFactoryProvider(p: InformerFactoryProvider): void {
+  defaultProvider = p;
+}
+
+async function loadDefaultProvider(): Promise<InformerFactoryProvider> {
+  if (defaultProvider) return defaultProvider;
+  const mod = await import("./kubernetes-client.js");
+  defaultProvider = mod.createInformerFactory;
+  return defaultProvider;
+}
+
+export class KubernetesConnector implements ObservabilityConnector {
+  readonly type = "kubernetes";
+  readonly signalType: SignalType = "topology";
+
+  name = "";
+  private store!: TopologyStore;
+  private factory?: InformerFactory;
+  private informers: Informer<unknown>[] = [];
+  private providerOverride?: InformerFactoryProvider;
+
+  /** Constructor injection used by tests. */
+  constructor(provider?: InformerFactoryProvider) {
+    this.providerOverride = provider;
+  }
+
+  async connect(config: SourceConfig): Promise<void> {
+    this.name = config.name;
+    this.store = new TopologyStore(config.name);
+    const provider = this.providerOverride ?? (await loadDefaultProvider());
+    this.factory = await provider(config);
+
+    // Wire each informer to the store. Pure builders translate Kube
+    // objects → Resource/Edge; the store dedupes and emits diffs.
+    const pods = this.factory.pods();
+    pods.on("add", (p) => this.applyPod(p));
+    pods.on("update", (p) => this.applyPod(p));
+    pods.on("delete", (p) => {
+      const id = idOfPod(p);
+      if (id) this.store.removeResource(id);
+    });
+    pods.on("error", (err) => logWatchError(this.name, "pods", err));
+
+    const nodes = this.factory.nodes();
+    nodes.on("add", (n) => this.applyNode(n));
+    nodes.on("update", (n) => this.applyNode(n));
+    nodes.on("delete", (n) => {
+      const id = idOfNode(n);
+      if (id) this.store.removeResource(id);
+    });
+    nodes.on("error", (err) => logWatchError(this.name, "nodes", err));
+
+    const deps = this.factory.deployments();
+    deps.on("add", (d) => this.applyDeployment(d));
+    deps.on("update", (d) => this.applyDeployment(d));
+    deps.on("delete", (d) => {
+      const id = idOfNamespaced("deployment", d);
+      if (id) this.store.removeResource(id);
+    });
+    deps.on("error", (err) => logWatchError(this.name, "deployments", err));
+
+    const rs = this.factory.replicaSets();
+    rs.on("add", (r) => this.applyReplicaSet(r));
+    rs.on("update", (r) => this.applyReplicaSet(r));
+    rs.on("delete", (r) => {
+      const id = idOfNamespaced("replicaset", r);
+      if (id) this.store.removeResource(id);
+    });
+    rs.on("error", (err) => logWatchError(this.name, "replicasets", err));
+
+    const ns = this.factory.namespaces();
+    ns.on("add", (n) => this.applyNamespace(n));
+    ns.on("update", (n) => this.applyNamespace(n));
+    ns.on("delete", (n) => {
+      const name = n.metadata?.name;
+      if (name) this.store.removeResource(clusterScopedId("namespace", name));
+    });
+    ns.on("error", (err) => logWatchError(this.name, "namespaces", err));
+
+    this.informers = [pods, nodes, deps, rs, ns];
+    await Promise.all(this.informers.map((i) => i.start()));
+  }
+
+  private applyPod(p: KubePod): void {
+    const r = podResource(this.name, p);
+    if (!r) return;
+    this.store.upsertResource(r, podEdges(this.name, p));
+  }
+
+  private applyNode(n: KubeNode): void {
+    const r = nodeResource(this.name, n);
+    if (!r) return;
+    this.store.upsertResource(r, []);
+  }
+
+  private applyDeployment(d: KubeDeployment): void {
+    const r = deploymentResource(this.name, d);
+    if (!r) return;
+    this.store.upsertResource(r, deploymentEdges(this.name, d));
+  }
+
+  private applyReplicaSet(rs: KubeReplicaSet): void {
+    const r = replicaSetResource(this.name, rs);
+    if (!r) return;
+    this.store.upsertResource(r, replicaSetEdges(this.name, rs));
+  }
+
+  private applyNamespace(n: KubeNamespace): void {
+    const r = namespaceResource(this.name, n);
+    if (!r) return;
+    this.store.upsertResource(r, []);
+  }
+
+  async healthCheck(): Promise<ConnectorHealth> {
+    if (!this.factory) return { status: "down", latencyMs: 0, message: "not connected" };
+    const r = await this.factory.healthCheck();
+    return { status: r.ok ? "up" : "down", latencyMs: r.latencyMs, message: r.message };
+  }
+
+  async disconnect(): Promise<void> {
+    await Promise.all(this.informers.map((i) => i.stop().catch(() => {})));
+    this.informers = [];
+    await this.factory?.close().catch(() => {});
+    this.factory = undefined;
+  }
+
+  // Topology has no metric/service surface — these stay empty/inert.
+  getDefaultMetrics(): MetricDefinition[] {
+    return [];
+  }
+  getMetrics(): MetricDefinition[] {
+    return [];
+  }
+  async listServices(): Promise<ServiceInfo[]> {
+    return [];
+  }
+
+  // --- Topology capability ---
+  async listResources(): Promise<Resource[]> {
+    return this.store?.listResources() ?? [];
+  }
+  async listEdges(): Promise<Edge[]> {
+    return this.store?.listEdges() ?? [];
+  }
+  async getTopologySnapshot(): Promise<TopologySnapshot> {
+    return (
+      this.store?.snapshot() ?? {
+        source: this.name,
+        resources: [],
+        edges: [],
+        revision: 0,
+      }
+    );
+  }
+  watchTopology(listener: TopologyChangeListener): () => void {
+    if (!this.store) return () => {};
+    // Initial resync so subscribers see the current state without
+    // racing the next watch event.
+    queueMicrotask(() => listener({ type: "resync", snapshot: this.store.snapshot() }));
+    return this.store.subscribe(listener);
+  }
+}
+
+// --- helpers ---
+
+function idOfPod(p: KubePod): string | undefined {
+  const n = p.metadata?.name;
+  const ns = p.metadata?.namespace;
+  if (!n || !ns) return undefined;
+  return namespacedId("pod", ns, n);
+}
+
+function idOfNode(n: KubeNode): string | undefined {
+  return n.metadata?.name ? clusterScopedId("node", n.metadata.name) : undefined;
+}
+
+function idOfNamespaced(
+  kind: string,
+  obj: { metadata?: { name?: string; namespace?: string } },
+): string | undefined {
+  const n = obj.metadata?.name;
+  const ns = obj.metadata?.namespace;
+  if (!n || !ns) return undefined;
+  return namespacedId(kind, ns, n);
+}
+
+function logWatchError(source: string, kind: string, err: unknown): void {
+  // AbortError is what makeInformer emits when we cleanly stop the watch
+  // (disconnect, process shutdown) — not actually an error to surface.
+  const msg = String(err);
+  if (msg.includes("AbortError") || /aborted a request/i.test(msg)) return;
+  console.warn("k8s watch error: source=%s kind=%s err=%s", source, kind, msg);
+}

--- a/mcp-server/src/connectors/loader.ts
+++ b/mcp-server/src/connectors/loader.ts
@@ -7,6 +7,7 @@ import type { ConnectorFactory, ConnectorManifest } from "../sdk/index.js";
 import { manifestSchema } from "../sdk/manifest-schema.js";
 import { PrometheusConnector } from "./prometheus.js";
 import { LokiConnector } from "./loki.js";
+import { KubernetesConnector } from "./kubernetes.js";
 import { sanitizeForLog } from "../util/sanitize.js";
 import { instrumentConnector } from "../metrics/instrument-connector.js";
 import {
@@ -133,6 +134,11 @@ export class PluginLoader {
       name: "loki",
       source: "builtin",
       factory: () => new LokiConnector(),
+    });
+    this.register({
+      name: "kubernetes",
+      source: "builtin",
+      factory: () => new KubernetesConnector(),
     });
   }
 

--- a/mcp-server/src/connectors/topology.test.ts
+++ b/mcp-server/src/connectors/topology.test.ts
@@ -1,0 +1,182 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isTopologyProvider, type ObservabilityConnector } from "./interface.js";
+import type {
+  Resource,
+  Edge,
+  TopologyChangeEvent,
+  TopologySnapshot,
+} from "../types.js";
+
+// A minimal connector that exposes no topology methods.
+function makeMetricsOnlyConnector(): ObservabilityConnector {
+  return {
+    name: "m1",
+    type: "prometheus",
+    signalType: "metrics",
+    async connect() {},
+    async healthCheck() {
+      return { status: "up", latencyMs: 0 };
+    },
+    async disconnect() {},
+    getDefaultMetrics() {
+      return [];
+    },
+    getMetrics() {
+      return [];
+    },
+    async listServices() {
+      return [];
+    },
+  };
+}
+
+// A fake topology connector that returns a tiny, well-formed graph.
+function makeTopologyConnector(): ObservabilityConnector {
+  const resources: Resource[] = [
+    {
+      id: "k8s:pod:default/checkout-7f89d",
+      kind: "pod",
+      name: "checkout-7f89d",
+      source: "kind-cluster",
+      labels: { app: "checkout" },
+      attributes: { uid: "11111111-1111-1111-1111-111111111111" },
+    },
+    {
+      id: "k8s:node:worker-1",
+      kind: "node",
+      name: "worker-1",
+      source: "kind-cluster",
+      labels: {},
+    },
+  ];
+  const edges: Edge[] = [
+    {
+      from: "k8s:pod:default/checkout-7f89d",
+      to: "k8s:node:worker-1",
+      relation: "RUNS_ON",
+      source: "kind-cluster",
+      confidence: 1.0,
+    },
+  ];
+  return {
+    name: "kind-cluster",
+    type: "kubernetes",
+    signalType: "topology",
+    async connect() {},
+    async healthCheck() {
+      return { status: "up", latencyMs: 0 };
+    },
+    async disconnect() {},
+    getDefaultMetrics() {
+      return [];
+    },
+    getMetrics() {
+      return [];
+    },
+    async listServices() {
+      return [];
+    },
+    async listResources() {
+      return resources;
+    },
+    async listEdges() {
+      return edges;
+    },
+    async getTopologySnapshot(): Promise<TopologySnapshot> {
+      return { source: "kind-cluster", resources, edges, revision: 1 };
+    },
+    watchTopology(listener) {
+      // emit an initial resync, then a no-op unsubscribe
+      queueMicrotask(() =>
+        listener({
+          type: "resync",
+          snapshot: { source: "kind-cluster", resources, edges, revision: 1 },
+        }),
+      );
+      return () => {};
+    },
+  };
+}
+
+describe("isTopologyProvider", () => {
+  it("returns false for metrics-only connectors", () => {
+    assert.equal(isTopologyProvider(makeMetricsOnlyConnector()), false);
+  });
+
+  it("returns true when all four topology methods are present", () => {
+    assert.equal(isTopologyProvider(makeTopologyConnector()), true);
+  });
+
+  it("returns false if any topology method is missing", () => {
+    const conn = makeTopologyConnector();
+    // Strip one method — partial topology support is not a TopologyProvider.
+    delete (conn as Partial<ObservabilityConnector>).watchTopology;
+    assert.equal(isTopologyProvider(conn), false);
+  });
+});
+
+describe("topology data model", () => {
+  it("Resource.id follows the k8s:<kind>:<namespace>/<name> shape for namespaced kinds", async () => {
+    const conn = makeTopologyConnector();
+    assert.ok(isTopologyProvider(conn));
+    const resources = await conn.listResources();
+    const pod = resources.find((r) => r.kind === "pod");
+    assert.ok(pod, "expected a pod resource");
+    assert.match(pod.id, /^k8s:pod:[^/]+\/.+$/);
+  });
+
+  it("Resource.id for cluster-scoped kinds has no namespace segment", async () => {
+    const conn = makeTopologyConnector();
+    assert.ok(isTopologyProvider(conn));
+    const resources = await conn.listResources();
+    const node = resources.find((r) => r.kind === "node");
+    assert.ok(node, "expected a node resource");
+    assert.match(node.id, /^k8s:node:[^/]+$/);
+  });
+
+  it("every Resource and Edge carries a non-empty source", async () => {
+    const conn = makeTopologyConnector();
+    assert.ok(isTopologyProvider(conn));
+    const snap = await conn.getTopologySnapshot();
+    for (const r of snap.resources) assert.ok(r.source.length > 0);
+    for (const e of snap.edges) assert.ok(e.source.length > 0);
+  });
+
+  it("Edge endpoints reference existing Resource ids", async () => {
+    const conn = makeTopologyConnector();
+    assert.ok(isTopologyProvider(conn));
+    const snap = await conn.getTopologySnapshot();
+    const ids = new Set(snap.resources.map((r) => r.id));
+    for (const e of snap.edges) {
+      assert.ok(ids.has(e.from), `dangling edge.from: ${e.from}`);
+      assert.ok(ids.has(e.to), `dangling edge.to: ${e.to}`);
+    }
+  });
+
+  it("confidence is bounded to [0,1]", async () => {
+    const conn = makeTopologyConnector();
+    assert.ok(isTopologyProvider(conn));
+    const edges = await conn.listEdges();
+    for (const e of edges) {
+      assert.ok(e.confidence >= 0 && e.confidence <= 1);
+    }
+  });
+});
+
+describe("watchTopology", () => {
+  it("delivers a resync event with the current snapshot", async () => {
+    const conn = makeTopologyConnector();
+    assert.ok(isTopologyProvider(conn));
+    const events: TopologyChangeEvent[] = [];
+    const unsubscribe = conn.watchTopology((e) => events.push(e));
+    // Allow the queued microtask to fire.
+    await new Promise((resolve) => setImmediate(resolve));
+    unsubscribe();
+    assert.equal(events.length, 1);
+    assert.equal(events[0].type, "resync");
+    if (events[0].type === "resync") {
+      assert.ok(events[0].snapshot.revision >= 1);
+    }
+  });
+});

--- a/mcp-server/src/sdk/index.ts
+++ b/mcp-server/src/sdk/index.ts
@@ -32,6 +32,11 @@ export type {
   LogEntry,
   LogSummary,
   MetricDefinition,
+  Resource,
+  Edge,
+  TopologySnapshot,
+  TopologyChangeEvent,
+  TopologyChangeListener,
 } from "../types.js";
 
 /**
@@ -50,7 +55,7 @@ export interface ConnectorManifest {
   /** Semver of this connector build. */
   version: string;
   description: string;
-  signalTypes: Array<"metrics" | "logs" | "traces">;
+  signalTypes: Array<"metrics" | "logs" | "traces" | "topology">;
   homepage?: string;
   license?: string;
   logo?: string;

--- a/mcp-server/src/sdk/manifest-schema.ts
+++ b/mcp-server/src/sdk/manifest-schema.ts
@@ -17,7 +17,7 @@ export const manifestSchema = z.object({
     message: "version must be semver",
   }),
   description: z.string().min(1),
-  signalTypes: z.array(z.enum(["metrics", "logs", "traces"])).min(1),
+  signalTypes: z.array(z.enum(["metrics", "logs", "traces", "topology"])).min(1),
   homepage: z.string().url().optional(),
   license: z.string().optional(),
   logo: z.string().optional(),

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -1,5 +1,5 @@
 // --- Signal Types ---
-export type SignalType = "metrics" | "logs" | "traces";
+export type SignalType = "metrics" | "logs" | "traces" | "topology";
 export type HealthStatus = "healthy" | "degraded" | "critical";
 export type Trend = "rising" | "falling" | "stable";
 export type AnomalySeverity = "low" | "medium" | "high";
@@ -157,6 +157,73 @@ export interface LogResult {
   entries: LogEntry[];
   summary: LogSummary;
 }
+
+// --- Topology ---
+
+/**
+ * A discrete infrastructure entity discovered by a topology-aware connector.
+ *
+ * `kind` and the relation strings on Edge are intentionally open (not unions):
+ * future connectors (vCenter, NetBox, SNMP, ...) will introduce new kinds and
+ * relations. Document common values here, but do not hard-restrict the type.
+ *
+ * `id` is a stable, human-readable canonical key. For Kubernetes we use
+ *   `k8s:<kind>:<namespace>/<name>` for namespaced kinds, `k8s:<kind>:<name>`
+ *   for cluster-scoped kinds. Pod names are ephemeral by design — that's
+ *   acceptable since pods are short-lived; deployments/nodes/services are
+ *   stable. Backend identifiers (e.g. K8s metadata.uid) belong in `attributes`.
+ *
+ * `source` is mandatory so a future entity-resolution layer can merge views
+ * from multiple connectors without ambiguity.
+ *
+ * Common kinds (Kubernetes): "pod", "node", "deployment", "service", "namespace".
+ */
+export interface Resource {
+  id: string;
+  kind: string;
+  name: string;
+  source: string;
+  labels: Record<string, string>;
+  attributes?: Record<string, unknown>;
+}
+
+/**
+ * A directed relationship between two Resources.
+ *
+ * Common relations (Kubernetes):
+ *   - "RUNS_ON"      pod -> node, container -> host, vm -> hypervisor
+ *   - "OWNED_BY"     pod -> replicaset/deployment
+ *   - "ROUTES_TO"    service -> pod
+ *   - "IN_NAMESPACE" pod/service/deployment -> namespace
+ *
+ * `confidence` is 0..1. For data that comes straight from an authoritative
+ * source (K8s API), use 1.0. Inferred relations (e.g. label-based matching)
+ * should report lower values.
+ */
+export interface Edge {
+  from: string;
+  to: string;
+  relation: string;
+  source: string;
+  confidence: number;
+}
+
+/** Snapshot of the topology graph as known by a single connector. */
+export interface TopologySnapshot {
+  source: string;
+  resources: Resource[];
+  edges: Edge[];
+  /** Monotonic counter; bumped on each successful watch event apply. */
+  revision: number;
+}
+
+/** Event emitted by a watching connector when its in-memory graph changes. */
+export type TopologyChangeEvent =
+  | { type: "resource_added" | "resource_updated" | "resource_removed"; resource: Resource }
+  | { type: "edge_added" | "edge_removed"; edge: Edge }
+  | { type: "resync"; snapshot: TopologySnapshot };
+
+export type TopologyChangeListener = (event: TopologyChangeEvent) => void;
 
 // --- Health & Anomaly ---
 export interface AnomalyReport {


### PR DESCRIPTION
## Summary

- New connector capability: **topology** — emits an infrastructure graph (`Resource` + `Edge`) alongside the existing metrics/logs surface. `ObservabilityConnector` gets four optional methods (`listResources`, `listEdges`, `getTopologySnapshot`, `watchTopology`) and an `isTopologyProvider` guard; existing Prometheus/Loki connectors are untouched.
- New **Kubernetes connector** as the first implementer. Watches pods, nodes, deployments, replicasets and namespaces via `@kubernetes/client-node` Informers (no polling). Edges captured: `RUNS_ON` (pod→node), `OWNED_BY` (pod→rs→deployment), `IN_NAMESPACE`. Lazy-imports the SDK so deployments without a `kubernetes` source don't pay the cost.
- New **GH Actions job** that spins up `kind`, deploys a tiny workload, and runs the connector against the real API server — asserts the full `pod → rs → deployment` + `pod → node` chain appears in the graph.

## Design notes

- `kind` and `relation` are intentionally **open strings**, not TS unions, so future connectors (vCenter, NetBox, …) can extend without a breaking change.
- `Resource.source` is mandatory — lets a future entity-resolution layer merge views from multiple connectors without ambiguity.
- Pod IDs are `k8s:pod:<ns>/<name>` (human-readable, ephemeral by design — pods are cattle). The K8s `uid` is preserved in `attributes.uid` for later cross-source mapping.
- `shared_namespace` was **deliberately not** introduced as a correlation primitive — too noisy in practice and not portable across non-K8s workloads. `RUNS_ON`-based correlation (pod→node, vm→hypervisor, container→host) is the universal pattern; that's what future correlator work should build on.
- Bug found and fixed live against `kind`: `@kubernetes/client-node` v1.x no longer throws from `loadFromCluster()` when env+files are missing — it silently produces `https://undefined:undefined`. We now detect in-cluster via the well-known env vars.

## Test plan

- [x] Unit tests: 28/28 pass (`topology.test.ts`, `kubernetes-graph.test.ts`, `kubernetes.test.ts`) — guard behavior, ID format, source-required, edge endpoint integrity, confidence bounds, store diff semantics, fake-informer-driven connector wiring.
- [x] Live verified against a real `kind` cluster: 24 resources, 38 edges, full `pod → rs → deployment` + `pod → node` chain present.
- [x] `tsc --noEmit` clean.
- [ ] New `kubernetes-connector-it.yml` workflow runs in CI on first push of this PR.

## Scope

Intentionally narrow: K8s-only for now. No `get_blast_radius` MCP tool, no UI yet, no Services/Endpoints discovery, no vCenter/NetBox/SNMP. Those are follow-up increments once this wedge has users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)