### PR TITLE
feat(hub): list Kubernetes connector in the catalog

### DIFF
--- a/hub/catalog-schema.json
+++ b/hub/catalog-schema.json
@@ -27,7 +27,7 @@
     "signalTypes": {
       "type": "array",
       "minItems": 1,
-      "items": { "enum": ["metrics", "logs", "traces"] }
+      "items": { "enum": ["metrics", "logs", "traces", "topology"] }
     },
     "screenshots": {
       "type": "array",

--- a/hub/catalog/index.json
+++ b/hub/catalog/index.json
@@ -68,6 +68,25 @@
       ]
     },
     {
+      "name": "kubernetes",
+      "displayName": "Kubernetes",
+      "description": "Watches a Kubernetes cluster (in-cluster or via kubeconfig) and exposes pods, nodes, deployments, replicasets and namespaces as an infrastructure topology graph. Edges: RUNS_ON (pod→node), OWNED_BY (pod→rs→deployment), IN_NAMESPACE. Built on @kubernetes/client-node Informers — no polling.",
+      "tier": "official",
+      "builtin": true,
+      "signalTypes": [
+        "topology"
+      ],
+      "latest": "0.1.0",
+      "versions": [
+        {
+          "version": "0.1.0",
+          "releasedAt": "2026-05-23",
+          "serverCompat": ">=1.7.0",
+          "changelog": "Initial release: watch-based topology graph (pods, nodes, deployments, replicasets, namespaces) with incremental change events. Bundled with the server image — no install step."
+        }
+      ]
+    },
+    {
       "name": "loki",
       "displayName": "Grafana Loki",
       "description": "LogQL-based logs backend. Service discovery from log streams and label-scoped log queries.",

--- a/hub/catalog/kubernetes.json
+++ b/hub/catalog/kubernetes.json
@@ -1,0 +1,19 @@
+{
+  "catalogVersion": 1,
+  "name": "kubernetes",
+  "displayName": "Kubernetes",
+  "description": "Watches a Kubernetes cluster (in-cluster or via kubeconfig) and exposes pods, nodes, deployments, replicasets and namespaces as an infrastructure topology graph. Edges: RUNS_ON (pod→node), OWNED_BY (pod→rs→deployment), IN_NAMESPACE. Built on @kubernetes/client-node Informers — no polling.",
+  "vendor": "observability-mcp",
+  "homepage": "https://github.com/ThoTischner/observability-mcp",
+  "tier": "official",
+  "builtin": true,
+  "signalTypes": ["topology"],
+  "versions": [
+    {
+      "version": "0.1.0",
+      "releasedAt": "2026-05-23",
+      "serverCompat": ">=1.7.0",
+      "changelog": "Initial release: watch-based topology graph (pods, nodes, deployments, replicasets, namespaces) with incremental change events. Bundled with the server image — no install step."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `hub/catalog/kubernetes.json` so the new Kubernetes connector (#200) shows up in the Connector Hub catalog alongside the other official built-ins.
- Extends `catalog-schema.json` `signalTypes` enum with `"topology"` to model graph-shaped connectors (the SDK manifest schema was already updated for this in #200).
- Regenerates `hub/catalog/index.json` deterministically via `build-catalog.mjs` (now 7 connectors).

## Test plan
- [x] `node hub/build-catalog.mjs` validates every entry and rebuilds the index
- [x] `node --test hub/build-catalog.test.mjs` — 6/6 pass, including the "committed index.json is in sync with entries" check
- [ ] CI smoke + analyze + unit-tests + trivy + CodeQL green

🤖 Generated with [Claude Code](https://claude.com/claude-code)