### PR TITLE
feat(demo): k3s + workload for the Kubernetes topology connector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Chaos modes are correlated: error-spike also increases CPU + latency + error log
 | Payment Service | http://localhost:8081 | Example service (chaos target) |
 | Order Service | http://localhost:8082 | Example service |
 | Ollama | host.docker.internal:11434 | LLM on Windows host |
+| k3s (demo only) | https://k3s:6443 (in-network) | Single-node Kubernetes for the topology connector. Demo workload in namespace `omcp-demo`. Kubeconfig in the `k3s-kubeconfig` named volume; mcp-server reads it via `KUBECONFIG=/k3s-kubeconfig/kubeconfig-internal.yaml`. |
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ flags pass through after a literal `--`.
 | Web UI | http://localhost:3000 |
 | Health API | http://localhost:3000/api/health |
 
-In the docker-compose demo: Prometheus on `:9090`, Loki on `:3100`, services on `:8080–:8082`.
+In the docker-compose demo: Prometheus on `:9090`, Loki on `:3100`, services on `:8080–:8082`, and a single-node k3s on the internal network (no host port) running a small demo workload (`omcp-demo` namespace, 5 pods across 2 deployments) so the Kubernetes topology connector has something to graph.
 
 **Transports:** Streamable HTTP by default (`/mcp`). For stdio-based clients/catalogs (Claude Desktop, Glama's `mcp-proxy`, etc.) run with `--stdio` (or `MCP_TRANSPORT=stdio`) — one MCP server over stdin/stdout, all logs on stderr so the protocol stream stays clean.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,6 +132,70 @@ services:
       loki:
         condition: service_healthy
 
+  # --- k3s (demo) ---
+  # Single-node Kubernetes for the topology connector demo. Lives on the
+  # observability network so mcp-server can reach the API at https://k3s:6443.
+  # k3s writes its kubeconfig to /output/kubeconfig.yaml; k3s-init rewrites
+  # 127.0.0.1 → k3s and applies the demo workload.
+  k3s:
+    profiles: ["demo"]
+    image: rancher/k3s:v1.31.3-k3s1
+    command:
+      - server
+      - --tls-san=k3s
+      - --disable=traefik
+      - --disable=metrics-server
+      - --disable=servicelb
+    privileged: true
+    tmpfs:
+      - /run
+      - /var/run
+    environment:
+      - K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml
+      - K3S_KUBECONFIG_MODE=666
+    volumes:
+      - k3s-server:/var/lib/rancher/k3s
+      - k3s-kubeconfig:/output
+    healthcheck:
+      test: ["CMD-SHELL", "kubectl get --raw=/healthz | grep -q ok"]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+      start_period: 30s
+    restart: unless-stopped
+    networks:
+      - observability
+
+  # Rewrites the k3s kubeconfig so the server URL is reachable inside the
+  # docker network, then waits for node-Ready and applies the demo workload.
+  # One-shot — mcp-server depends on it completing successfully.
+  k3s-init:
+    profiles: ["demo"]
+    image: rancher/k3s:v1.31.3-k3s1
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        until [ -f /output/kubeconfig.yaml ]; do sleep 1; done
+        sed 's|https://127.0.0.1:6443|https://k3s:6443|g' /output/kubeconfig.yaml > /output/kubeconfig-internal.yaml
+        export KUBECONFIG=/output/kubeconfig-internal.yaml
+        until kubectl get nodes 2>/dev/null | grep -qE '\sReady\s'; do
+          echo "waiting for node Ready..."
+          sleep 2
+        done
+        kubectl apply -f /workload/workload.yaml
+        kubectl -n omcp-demo rollout status deployment/omcp-demo-echo --timeout=120s
+        kubectl -n omcp-demo rollout status deployment/omcp-demo-frontend --timeout=120s
+        echo "k3s demo workload ready"
+    volumes:
+      - k3s-kubeconfig:/output
+      - ./examples/kubernetes:/workload:ro
+    depends_on:
+      k3s:
+        condition: service_healthy
+    networks:
+      - observability
+
   # --- MCP Server ---
   mcp-server:
     build:
@@ -141,6 +205,12 @@ services:
     environment:
       - PROMETHEUS_URL=http://prometheus:9090
       - LOKI_URL=http://loki:3100
+      # The kubernetes source in config/sources.yaml reads this. In
+      # non-demo runs the file simply isn't present and the source
+      # reports "down" — connector failures don't block startup.
+      - KUBECONFIG=/k3s-kubeconfig/kubeconfig-internal.yaml
+    volumes:
+      - k3s-kubeconfig:/k3s-kubeconfig:ro
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/sources"]
       interval: 10s
@@ -149,9 +219,14 @@ services:
     restart: unless-stopped
     networks:
       - observability
-    # No depends_on prometheus/loki — they live in the demo profile and
-    # mcp-server must be able to start standalone (pointing at external
-    # backends or with sources added later via the Web UI).
+    # depends_on entries here all belong to the demo profile. When demo
+    # is not active, compose silently drops them — mcp-server still
+    # starts standalone (pointing at external backends or with sources
+    # added later via the Web UI).
+    depends_on:
+      k3s-init:
+        condition: service_completed_successfully
+        required: false
 
   # --- AI Agent (demo) ---
   agent:
@@ -174,6 +249,8 @@ services:
 
 volumes:
   loki-data:
+  k3s-server:
+  k3s-kubeconfig:
 
 networks:
   observability:

--- a/examples/kubernetes/workload.yaml
+++ b/examples/kubernetes/workload.yaml
@@ -1,0 +1,73 @@
+---
+# Demo workload applied to the in-compose k3s by the k3s-init container.
+# Two deployments with multiple replicas so the topology graph has an
+# interesting RUNS_ON pattern (multiple pods sharing the single node).
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: omcp-demo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: omcp-demo-echo
+  namespace: omcp-demo
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: omcp-demo-echo
+  template:
+    metadata:
+      labels:
+        app: omcp-demo-echo
+        tier: backend
+    spec:
+      containers:
+        - name: echo
+          image: ealen/echo-server:0.9.2
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 1
+            periodSeconds: 2
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: omcp-demo-frontend
+  namespace: omcp-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: omcp-demo-frontend
+  template:
+    metadata:
+      labels:
+        app: omcp-demo-frontend
+        tier: frontend
+    spec:
+      containers:
+        - name: echo
+          image: ealen/echo-server:0.9.2
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 1
+            periodSeconds: 2
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi

--- a/mcp-server/config/sources.yaml
+++ b/mcp-server/config/sources.yaml
@@ -24,6 +24,16 @@ sources:
     url: http://loki:3100
     enabled: true
 
+  # Kubernetes topology source (demo). Reads $KUBECONFIG which the
+  # compose file points at the in-network kubeconfig written by the
+  # k3s-init container. In a non-demo run the file is absent and the
+  # connector reports "down" without blocking startup. url/auth are
+  # unused — the connector reads server + credentials from kubeconfig.
+  - name: kubernetes
+    type: kubernetes
+    url: ""
+    enabled: true
+
 settings:
   checkIntervalMs: 30000
   defaultSensitivity: medium


### PR DESCRIPTION
## Summary

- Adds a single-node **k3s** to the demo profile so the Kubernetes topology connector has a real cluster to watch end-to-end. A one-shot `k3s-init` rewrites the kubeconfig for in-network use and applies a small workload (`omcp-demo` namespace, 5 pods across 2 deployments).
- Wires `mcp-server` to that cluster via `KUBECONFIG` mounted from a shared volume and adds a `kubernetes` source to `config/sources.yaml`.
- Non-demo runs are unaffected: `depends_on: k3s-init` is `required: false`, and when the kubeconfig file is absent the connector reports `status: down` without blocking startup.

## Verified locally

Brought the demo up against this branch:

```
counts: { node: 1, replicaset: 4, pod: 7, namespace: 5, deployment: 4 }
relations: { IN_NAMESPACE: 15, OWNED_BY: 11, RUNS_ON: 7 }
chain: k8s:pod:omcp-demo/omcp-demo-echo-…
  RUNS_ON  → k8s:node:cdc0994be932
  OWNED_BY → k8s:replicaset:omcp-demo/omcp-demo-echo-59ffd9c598
             OWNED_BY → k8s:deployment:omcp-demo/omcp-demo-echo
```

`/api/sources` reports all three sources `up`, kubernetes with `signalType: topology`.

## Why k3s (not kind)

k3s runs cleanly as a single privileged container in compose — kind needs Docker-in-Docker. k3s also boots in ~20s on a laptop and disables the bits we don't need (traefik, metrics-server, servicelb).

## Test plan

- [x] Local: `docker compose --profile demo up --build` — all containers healthy, kubernetes source up, full topology chain materialized.
- [x] Local: `docker compose up mcp-server` (no demo profile) — server starts, kubernetes source reports `down` cleanly, no errors.
- [ ] CI `smoke` job runs the full demo and re-asserts all sources up — will be exercised on first push of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)