### PR TITLE
feat(tools): MCP tools for topology — get_topology + get_blast_radius

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -103,10 +103,10 @@ jobs:
             -H 'Accept: application/json, text/event-stream' \
             -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' -o "$body"
           echo "--- tools/list ---"; cat "$body"
-          for t in list_sources list_services query_metrics query_logs get_service_health detect_anomalies; do
+          for t in list_sources list_services query_metrics query_logs get_service_health detect_anomalies get_topology get_blast_radius; do
             grep -q "\"$t\"" "$body" || (echo "missing tool: $t"; exit 1)
           done
-          echo "all 6 tools advertised"
+          echo "all 8 tools advertised"
 
       - name: Trigger a chaos mode and verify it sticks
         run: |

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -43,6 +43,7 @@ import { queryMetricsHandler } from "./tools/query-metrics.js";
 import { queryLogsHandler } from "./tools/query-logs.js";
 import { getServiceHealthHandler, setHealthThresholds } from "./tools/get-service-health.js";
 import { detectAnomaliesHandler } from "./tools/detect-anomalies.js";
+import { getTopologyHandler, getBlastRadiusHandler } from "./tools/topology.js";
 import type { Config } from "./types.js";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
@@ -333,6 +334,70 @@ async function main() {
     async (args) => {
       await enforceEntitledAccess(ctx, { tool: "detect_anomalies", source: (args as any)?.source, service: (args as any)?.service });
       return withToolMetrics("detect_anomalies", () => detectAnomaliesHandler(registry, args, ctx));
+    }
+  );
+
+  mcpServer.tool(
+    "get_topology",
+    [
+      "Return the infrastructure topology graph (Resources and Edges) from every topology-capable connector.",
+      "When to use: when an agent needs to reason about which workload runs on which host, who owns whom, or which scope (namespace/project/folder) a resource belongs to. Pair with `get_blast_radius` for shared-host RCA.",
+      "Behavior: read-only, no side effects. Returns `{ sources, resources, edges, total, truncated }`. Filters compose: `source` to one connector, `kind` to one resource type (e.g. 'pod', 'node', 'deployment'), `scope` to members of a namespace/folder/project. Output is capped by `limit` (default 500, max 5000) and edges referencing dropped resources are removed.",
+      "Related: `get_blast_radius` to evaluate the impact of a host failure; `list_sources` to discover topology-capable connectors.",
+    ].join(" "),
+    {
+      source: z
+        .string()
+        .optional()
+        .describe(
+          "Optional. Restrict the graph to one topology connector by source name (see `list_sources`). Default: merge across all connectors.",
+        ),
+      kind: z
+        .string()
+        .optional()
+        .describe(
+          "Optional. Restrict to resources of one kind. Common values for Kubernetes: 'pod', 'node', 'deployment', 'replicaset', 'namespace'. Other connectors may emit different kinds (e.g. 'vm', 'hypervisor', 'volume'). Default: all kinds.",
+        ),
+      scope: z
+        .string()
+        .optional()
+        .describe(
+          "Optional. Restrict to resources contained in a scope (anything pointed to by `IN_NAMESPACE` edges). Pass the scope's resource id (e.g. 'k8s:namespace:default') or its name (e.g. 'default'). Default: no scope filter.",
+        ),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(5000)
+        .optional()
+        .describe(
+          "Optional. Maximum resources to return; edges are trimmed to the kept set. Default 500, max 5000.",
+        ),
+    },
+    async (args) => {
+      await enforceEntitledAccess(ctx, { tool: "get_topology", source: (args as any)?.source });
+      return withToolMetrics("get_topology", () => getTopologyHandler(registry, args, ctx));
+    }
+  );
+
+  mcpServer.tool(
+    "get_blast_radius",
+    [
+      "Given a resource, return who else fails if its underlying host(s) fail.",
+      "When to use: cross-cutting RCA — when several services degrade together and you suspect a shared host. Works for any RUNS_ON relationship: pod→node, vm→hypervisor, container→host.",
+      "Behavior: read-only, no side effects. Resolves `resource` to a Resource (accepts canonical id, exact name, or unique substring), determines its host(s) via RUNS_ON, then lists every other resource that runs on those hosts, bucketed by ownership root (the terminal `OWNED_BY` target — e.g. the Deployment, not the ReplicaSet). If the target is itself a host, its tenants are reported. Returns a structured error if the resource is ambiguous or unknown.",
+      "Related: `get_topology` for the full graph; `get_service_health` for the per-service verdict on each co-tenant.",
+    ].join(" "),
+    {
+      resource: z
+        .string()
+        .describe(
+          "Required. Resource to evaluate. Accepts the canonical id (e.g. 'k8s:pod:default/checkout-7f89d'), the exact resource name (e.g. 'checkout-7f89d'), or a unique substring of either.",
+        ),
+    },
+    async (args) => {
+      await enforceEntitledAccess(ctx, { tool: "get_blast_radius" });
+      return withToolMetrics("get_blast_radius", () => getBlastRadiusHandler(registry, args, ctx));
     }
   );
 

--- a/mcp-server/src/tools/topology.test.ts
+++ b/mcp-server/src/tools/topology.test.ts
@@ -1,0 +1,240 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { ConnectorRegistry } from "../connectors/registry.js";
+import { PluginLoader } from "../connectors/loader.js";
+import type { ObservabilityConnector } from "../connectors/interface.js";
+import type {
+  Resource,
+  Edge,
+  TopologySnapshot,
+  TopologyChangeListener,
+  SourceConfig,
+  ConnectorHealth,
+  ServiceInfo,
+  MetricDefinition,
+} from "../types.js";
+import {
+  getTopologyHandler,
+  getBlastRadiusHandler,
+  resolveResource,
+} from "./topology.js";
+
+// --- A minimal stand-alone topology connector used as test fixture -----
+// Lets the suite drive the tool handlers without a real K8s cluster.
+
+class FakeTopologyConnector implements ObservabilityConnector {
+  readonly type = "fake";
+  readonly signalType = "topology" as const;
+  name = "fake-cluster";
+  private resources: Resource[];
+  private edges: Edge[];
+
+  constructor(resources: Resource[], edges: Edge[]) {
+    this.resources = resources;
+    this.edges = edges;
+  }
+  async connect(c: SourceConfig) { this.name = c.name; }
+  async healthCheck(): Promise<ConnectorHealth> { return { status: "up", latencyMs: 1 }; }
+  async disconnect() {}
+  getDefaultMetrics(): MetricDefinition[] { return []; }
+  getMetrics(): MetricDefinition[] { return []; }
+  async listServices(): Promise<ServiceInfo[]> { return []; }
+  async listResources(): Promise<Resource[]> { return this.resources; }
+  async listEdges(): Promise<Edge[]> { return this.edges; }
+  async getTopologySnapshot(): Promise<TopologySnapshot> {
+    return { source: this.name, resources: this.resources, edges: this.edges, revision: 1 };
+  }
+  watchTopology(_l: TopologyChangeListener) { return () => {}; }
+}
+
+// Build a small but realistic topology covering both happy and edge cases:
+// two services, two hosts, ownership chain, one orphan, one cross-kind link.
+function fixture(): { resources: Resource[]; edges: Edge[] } {
+  const r: Resource[] = [
+    // Hosts
+    { id: "k8s:node:n1", kind: "node", name: "n1", source: "fake", labels: {} },
+    { id: "k8s:node:n2", kind: "node", name: "n2", source: "fake", labels: {} },
+    // Scope
+    { id: "k8s:namespace:prod", kind: "namespace", name: "prod", source: "fake", labels: {} },
+    { id: "k8s:namespace:staging", kind: "namespace", name: "staging", source: "fake", labels: {} },
+    // Ownership roots (deployments)
+    { id: "k8s:deployment:prod/api", kind: "deployment", name: "api", source: "fake", labels: {} },
+    { id: "k8s:deployment:prod/db",  kind: "deployment", name: "db",  source: "fake", labels: {} },
+    // Intermediate
+    { id: "k8s:replicaset:prod/api-1", kind: "replicaset", name: "api-1", source: "fake", labels: {} },
+    // Workloads
+    { id: "k8s:pod:prod/api-aaa", kind: "pod", name: "api-aaa", source: "fake", labels: { app: "api" } },
+    { id: "k8s:pod:prod/api-bbb", kind: "pod", name: "api-bbb", source: "fake", labels: { app: "api" } },
+    { id: "k8s:pod:prod/db-aaa",  kind: "pod", name: "db-aaa",  source: "fake", labels: { app: "db" } },
+    // Orphan with no RUNS_ON (e.g. pending)
+    { id: "k8s:pod:staging/pending-1", kind: "pod", name: "pending-1", source: "fake", labels: {} },
+  ];
+  const e: Edge[] = [
+    // ownership chain
+    { from: "k8s:pod:prod/api-aaa", to: "k8s:replicaset:prod/api-1", relation: "OWNED_BY", source: "fake", confidence: 1 },
+    { from: "k8s:pod:prod/api-bbb", to: "k8s:replicaset:prod/api-1", relation: "OWNED_BY", source: "fake", confidence: 1 },
+    { from: "k8s:replicaset:prod/api-1", to: "k8s:deployment:prod/api", relation: "OWNED_BY", source: "fake", confidence: 1 },
+    { from: "k8s:pod:prod/db-aaa", to: "k8s:deployment:prod/db", relation: "OWNED_BY", source: "fake", confidence: 1 },
+    // RUNS_ON — api-aaa shares n1 with db-aaa (blast-radius case);
+    // api-bbb alone on n2 (no shared-host case)
+    { from: "k8s:pod:prod/api-aaa", to: "k8s:node:n1", relation: "RUNS_ON", source: "fake", confidence: 1 },
+    { from: "k8s:pod:prod/db-aaa",  to: "k8s:node:n1", relation: "RUNS_ON", source: "fake", confidence: 1 },
+    { from: "k8s:pod:prod/api-bbb", to: "k8s:node:n2", relation: "RUNS_ON", source: "fake", confidence: 1 },
+    // IN_NAMESPACE
+    { from: "k8s:pod:prod/api-aaa", to: "k8s:namespace:prod", relation: "IN_NAMESPACE", source: "fake", confidence: 1 },
+    { from: "k8s:pod:prod/api-bbb", to: "k8s:namespace:prod", relation: "IN_NAMESPACE", source: "fake", confidence: 1 },
+    { from: "k8s:pod:prod/db-aaa",  to: "k8s:namespace:prod", relation: "IN_NAMESPACE", source: "fake", confidence: 1 },
+    { from: "k8s:deployment:prod/api", to: "k8s:namespace:prod", relation: "IN_NAMESPACE", source: "fake", confidence: 1 },
+    { from: "k8s:deployment:prod/db",  to: "k8s:namespace:prod", relation: "IN_NAMESPACE", source: "fake", confidence: 1 },
+    { from: "k8s:replicaset:prod/api-1", to: "k8s:namespace:prod", relation: "IN_NAMESPACE", source: "fake", confidence: 1 },
+    { from: "k8s:pod:staging/pending-1", to: "k8s:namespace:staging", relation: "IN_NAMESPACE", source: "fake", confidence: 1 },
+  ];
+  return { resources: r, edges: e };
+}
+
+async function makeRegistry(): Promise<ConnectorRegistry> {
+  const { resources, edges } = fixture();
+  const loader = new PluginLoader();
+  // Don't load builtins/filesystem — we plug a single fake connector in
+  // directly so the suite is hermetic and fast.
+  const reg = new ConnectorRegistry(loader);
+  const conn = new FakeTopologyConnector(resources, edges);
+  await conn.connect({ name: "fake-cluster", type: "fake", url: "", enabled: true });
+  // ConnectorRegistry has no public "register a live instance" method,
+  // so we install via the documented addSource path with a fake loader.
+  (loader as unknown as { connectors: Map<string, unknown> }).connectors.set("fake", {
+    name: "fake",
+    source: "builtin",
+    factory: () => conn,
+  });
+  await reg.addSource({ name: "fake-cluster", type: "fake", url: "", enabled: true });
+  return reg;
+}
+
+function parseTool(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe("resolveResource", () => {
+  const { resources } = fixture();
+  it("matches an exact id", () => {
+    const r = resolveResource("k8s:node:n1", resources);
+    assert.ok(!("error" in r));
+    if (!("error" in r)) assert.equal(r.kind, "node");
+  });
+  it("matches a unique exact name", () => {
+    const r = resolveResource("api-aaa", resources);
+    assert.ok(!("error" in r));
+  });
+  it("returns candidates for an ambiguous fuzzy match", () => {
+    // "aaa" doesn't exactly match any name, but fuzzy-matches api-aaa and db-aaa
+    const r = resolveResource("aaa", resources);
+    assert.ok("error" in r);
+    if ("error" in r) {
+      assert.ok((r.candidates?.length ?? 0) >= 2);
+    }
+  });
+  it("returns a clean error for no match", () => {
+    const r = resolveResource("does-not-exist", resources);
+    assert.ok("error" in r);
+  });
+});
+
+describe("get_topology tool", () => {
+  it("returns the full graph by default", async () => {
+    const reg = await makeRegistry();
+    const out = parseTool(await getTopologyHandler(reg, {}));
+    assert.equal(out.sources.length, 1);
+    assert.equal(out.resources.length, fixture().resources.length);
+    assert.equal(out.edges.length, fixture().edges.length);
+    assert.equal(out.truncated, false);
+  });
+
+  it("filters by kind", async () => {
+    const reg = await makeRegistry();
+    const out = parseTool(await getTopologyHandler(reg, { kind: "pod" }));
+    for (const r of out.resources) assert.equal(r.kind, "pod");
+    // edges must reference only the kept resources
+    const ids = new Set<string>(out.resources.map((r: { id: string }) => r.id));
+    for (const e of out.edges) {
+      assert.ok(ids.has(e.from) && ids.has(e.to));
+    }
+  });
+
+  it("filters by scope name or id", async () => {
+    const reg = await makeRegistry();
+    const byName = parseTool(await getTopologyHandler(reg, { scope: "prod" }));
+    const byId = parseTool(await getTopologyHandler(reg, { scope: "k8s:namespace:prod" }));
+    assert.equal(byName.resources.length, byId.resources.length);
+    // staging pod must not appear
+    assert.ok(!byName.resources.some((r: { name: string }) => r.name === "pending-1"));
+  });
+
+  it("respects the limit and reports truncation", async () => {
+    const reg = await makeRegistry();
+    const out = parseTool(await getTopologyHandler(reg, { limit: 3 }));
+    assert.equal(out.resources.length, 3);
+    assert.equal(out.truncated, true);
+    assert.equal(out.total.resources, fixture().resources.length);
+  });
+});
+
+describe("get_blast_radius tool", () => {
+  it("reports shared-host blast radius for a co-located pod", async () => {
+    const reg = await makeRegistry();
+    const out = parseTool(await getBlastRadiusHandler(reg, { resource: "api-aaa" }));
+    assert.equal(out.target.name, "api-aaa");
+    assert.equal(out.hosts.length, 1);
+    const host = out.hosts[0];
+    assert.equal(host.host.name, "n1");
+    // Two ownership roots on n1: deployment/api and deployment/db
+    assert.equal(host.ownershipRoots, 2);
+    const rootNames = new Set(host.coTenants.map((c: { ownershipRootName: string }) => c.ownershipRootName));
+    assert.ok(rootNames.has("api"));
+    assert.ok(rootNames.has("db"));
+    assert.match(out.summary, /blast-radius candidate/i);
+  });
+
+  it("reports no shared-host for a pod alone on its node", async () => {
+    const reg = await makeRegistry();
+    const out = parseTool(await getBlastRadiusHandler(reg, { resource: "api-bbb" }));
+    assert.equal(out.hosts.length, 1);
+    assert.equal(out.hosts[0].host.name, "n2");
+    assert.equal(out.hosts[0].ownershipRoots, 1);
+    assert.match(out.summary, /limited shared-host/i);
+  });
+
+  it("treats a host resource as its own host (incoming RUNS_ON pivot)", async () => {
+    const reg = await makeRegistry();
+    const out = parseTool(await getBlastRadiusHandler(reg, { resource: "k8s:node:n1" }));
+    assert.equal(out.target.kind, "node");
+    assert.equal(out.hosts.length, 1);
+    assert.equal(out.hosts[0].host.id, "k8s:node:n1");
+  });
+
+  it("returns a note when a resource has no RUNS_ON edges", async () => {
+    const reg = await makeRegistry();
+    const out = parseTool(await getBlastRadiusHandler(reg, { resource: "pending-1" }));
+    assert.equal(out.hosts.length, 0);
+    assert.match(out.note, /no RUNS_ON/i);
+  });
+
+  it("surfaces a structured error for unknown resources", async () => {
+    const reg = await makeRegistry();
+    const result = await getBlastRadiusHandler(reg, { resource: "totally-not-here" });
+    assert.equal((result as { isError?: boolean }).isError, true);
+    const out = parseTool(result);
+    assert.match(out.error, /No resource found/);
+  });
+
+  it("uses ownership root, not direct owner, when grouping co-tenants", async () => {
+    // api-aaa is OWNED_BY a ReplicaSet which is OWNED_BY a Deployment.
+    // The blast-radius should bucket api-aaa under the Deployment, not the RS.
+    const reg = await makeRegistry();
+    const out = parseTool(await getBlastRadiusHandler(reg, { resource: "api-aaa" }));
+    const onN1 = out.hosts[0];
+    const apiBucket = onN1.coTenants.find((c: { ownershipRootName: string }) => c.ownershipRootName === "api");
+    assert.ok(apiBucket, "expected an 'api' deployment bucket on n1");
+    assert.equal(apiBucket.ownershipRootKind, "deployment");
+  });
+});

--- a/mcp-server/src/tools/topology.ts
+++ b/mcp-server/src/tools/topology.ts
@@ -1,0 +1,283 @@
+// MCP tools that expose the infrastructure topology graph to agents.
+//
+// Two tools live here:
+//   - `get_topology`     — returns the merged resource/edge graph across
+//                          every topology-capable connector, optionally
+//                          filtered by source/kind/scope. Useful as a
+//                          starting point for any cross-cutting question.
+//   - `get_blast_radius` — given a resource, returns who else is co-tenant
+//                          on the same host(s). The canonical "if this
+//                          host fails, who else fails?" question.
+//
+// Both stay generic — they pivot on the `RUNS_ON` and `OWNED_BY` relations
+// rather than any specific kind. Adding a vCenter/NetBox/AWS topology
+// connector later requires zero changes here.
+
+import type { ConnectorRegistry } from "../connectors/registry.js";
+import { isTopologyProvider } from "../connectors/interface.js";
+import type { Resource, Edge } from "../types.js";
+import { defaultContext, type RequestContext } from "../context.js";
+
+// --- Shared helpers ----------------------------------------------------
+
+interface AggregatedTopology {
+  sources: Array<{ source: string; type: string; revision: number; resources: number; edges: number }>;
+  resources: Resource[];
+  edges: Edge[];
+}
+
+export async function aggregateTopology(registry: ConnectorRegistry): Promise<AggregatedTopology> {
+  const sources: AggregatedTopology["sources"] = [];
+  const resources: Resource[] = [];
+  const edges: Edge[] = [];
+  for (const c of registry.getAll()) {
+    if (!isTopologyProvider(c)) continue;
+    try {
+      const snap = await c.getTopologySnapshot();
+      sources.push({
+        source: snap.source,
+        type: c.type,
+        revision: snap.revision,
+        resources: snap.resources.length,
+        edges: snap.edges.length,
+      });
+      resources.push(...snap.resources);
+      edges.push(...snap.edges);
+    } catch {
+      // A misbehaving connector must not poison the agent's view of the graph.
+    }
+  }
+  return { sources, resources, edges };
+}
+
+/**
+ * Resolve a caller-supplied identifier to a Resource. Accepts:
+ *   - exact canonical id (e.g. "k8s:pod:default/checkout-7f89d")
+ *   - exact resource name (e.g. "checkout-7f89d")
+ *   - case-insensitive substring of name (only used if uniquely matching)
+ *
+ * Stays generic — no knowledge of kind-specific id grammars.
+ */
+export function resolveResource(query: string, resources: Resource[]): Resource | { error: string; candidates?: string[] } {
+  if (!query) return { error: "Missing resource query" };
+  const exactId = resources.find((r) => r.id === query);
+  if (exactId) return exactId;
+  const exactName = resources.filter((r) => r.name === query);
+  if (exactName.length === 1) return exactName[0];
+  if (exactName.length > 1) {
+    return {
+      error: `Name '${query}' is ambiguous across ${exactName.length} resources; pass the full id`,
+      candidates: exactName.map((r) => r.id),
+    };
+  }
+  const q = query.toLowerCase();
+  const fuzzy = resources.filter((r) => r.name.toLowerCase().includes(q) || r.id.toLowerCase().includes(q));
+  if (fuzzy.length === 1) return fuzzy[0];
+  if (fuzzy.length > 1) {
+    return {
+      error: `Query '${query}' matched ${fuzzy.length} resources; pass the full id`,
+      candidates: fuzzy.slice(0, 25).map((r) => r.id),
+    };
+  }
+  return { error: `No resource found matching '${query}'` };
+}
+
+// --- get_topology ------------------------------------------------------
+
+export const getTopologyDefinition = {
+  name: "get_topology" as const,
+  description:
+    "Return the infrastructure topology graph as Resources and Edges. Use this when an agent needs to reason about which workload runs where, who owns whom, or which scope (namespace/project/folder) a resource belongs to.",
+};
+
+export interface GetTopologyArgs {
+  source?: string;
+  kind?: string;
+  scope?: string;
+  limit?: number;
+}
+
+export async function getTopologyHandler(
+  registry: ConnectorRegistry,
+  args: GetTopologyArgs = {},
+  _ctx: RequestContext = defaultContext(),
+) {
+  const agg = await aggregateTopology(registry);
+
+  // Filtering — all optional. Filters compose conjunctively.
+  let resources = agg.resources;
+  let edges = agg.edges;
+
+  if (args.source) {
+    resources = resources.filter((r) => r.source === args.source);
+    edges = edges.filter((e) => e.source === args.source);
+  }
+  if (args.kind) {
+    resources = resources.filter((r) => r.kind === args.kind);
+  }
+  if (args.scope) {
+    // Match either by scope resource id (e.g. "k8s:namespace:default") or by name (e.g. "default").
+    const inScope = new Set<string>();
+    for (const e of agg.edges) {
+      if (e.relation !== "IN_NAMESPACE") continue;
+      const target = agg.resources.find((r) => r.id === e.to);
+      if (!target) continue;
+      if (target.id === args.scope || target.name === args.scope) inScope.add(e.from);
+    }
+    resources = resources.filter((r) => inScope.has(r.id));
+  }
+  // Edges must still reference resources that survived filtering.
+  const keepIds = new Set(resources.map((r) => r.id));
+  edges = edges.filter((e) => keepIds.has(e.from) && keepIds.has(e.to));
+
+  // Soft truncation so an agent can't accidentally pull a 10k-node graph
+  // into context — defaults are generous but capped.
+  const limit = Math.min(Math.max(args.limit ?? 500, 1), 5000);
+  const truncated = resources.length > limit;
+  if (truncated) {
+    resources = resources.slice(0, limit);
+    const keep2 = new Set(resources.map((r) => r.id));
+    edges = edges.filter((e) => keep2.has(e.from) && keep2.has(e.to));
+  }
+
+  const payload = {
+    sources: agg.sources,
+    resources,
+    edges,
+    total: { resources: agg.resources.length, edges: agg.edges.length },
+    truncated,
+  };
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+  };
+}
+
+// --- get_blast_radius --------------------------------------------------
+
+export const getBlastRadiusDefinition = {
+  name: "get_blast_radius" as const,
+  description:
+    "Given a resource, return the impact set if its underlying host(s) fail. Pivots on the generic RUNS_ON relation, so it works for pod→node, vm→hypervisor, container→host alike. Use this for cross-cutting RCA when several services degrade together.",
+};
+
+export interface GetBlastRadiusArgs {
+  resource: string;
+}
+
+interface CoTenant {
+  ownershipRoot: string;       // resource id of terminal OWNED_BY target (or the resource itself)
+  ownershipRootName: string;
+  ownershipRootKind: string;
+  members: Array<{ id: string; name: string; kind: string }>;
+}
+
+interface BlastRadiusForHost {
+  host: { id: string; name: string; kind: string };
+  ownershipRoots: number;      // how many distinct services share this host
+  coTenants: CoTenant[];
+}
+
+export async function getBlastRadiusHandler(
+  registry: ConnectorRegistry,
+  args: GetBlastRadiusArgs,
+  _ctx: RequestContext = defaultContext(),
+) {
+  const agg = await aggregateTopology(registry);
+  const found = resolveResource(args.resource, agg.resources);
+  if ("error" in found) {
+    return {
+      isError: true,
+      content: [{ type: "text" as const, text: JSON.stringify(found, null, 2) }],
+    };
+  }
+
+  // Index edges once.
+  const byId = new Map(agg.resources.map((r) => [r.id, r]));
+  const runsOnOut = new Map<string, string>();          // child → host
+  const runsOnIn = new Map<string, Set<string>>();      // host → children
+  const ownedByOut = new Map<string, string>();         // child → owner
+  for (const e of agg.edges) {
+    if (e.relation === "RUNS_ON") {
+      runsOnOut.set(e.from, e.to);
+      const s = runsOnIn.get(e.to) || new Set<string>();
+      s.add(e.from);
+      runsOnIn.set(e.to, s);
+    } else if (e.relation === "OWNED_BY") {
+      if (!ownedByOut.has(e.from)) ownedByOut.set(e.from, e.to);
+    }
+  }
+
+  function ownershipRoot(id: string): string {
+    let cur = id;
+    for (let i = 0; i < 16; i++) {
+      const next = ownedByOut.get(cur);
+      if (!next || next === cur) return cur;
+      cur = next;
+    }
+    return cur;
+  }
+
+  // Determine which hosts the target depends on. If the resource is itself
+  // a host (incoming RUNS_ON exists), the host is the resource itself.
+  const hosts: string[] = [];
+  if (runsOnIn.has(found.id)) {
+    hosts.push(found.id);
+  } else if (runsOnOut.has(found.id)) {
+    hosts.push(runsOnOut.get(found.id)!);
+  }
+
+  if (hosts.length === 0) {
+    const payload = {
+      target: { id: found.id, name: found.name, kind: found.kind },
+      hosts: [],
+      note: "This resource has no RUNS_ON edges in the current topology — either it is itself a top-level host with no tenants yet, or its connector does not emit RUNS_ON.",
+    };
+    return { content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }] };
+  }
+
+  const perHost: BlastRadiusForHost[] = [];
+  for (const hostId of hosts) {
+    const host = byId.get(hostId);
+    if (!host) continue;
+    const childIds = Array.from(runsOnIn.get(hostId) || []);
+    // Bucket children by their ownership root.
+    const buckets = new Map<string, CoTenant>();
+    for (const cid of childIds) {
+      const child = byId.get(cid);
+      if (!child) continue;
+      const rootId = ownershipRoot(cid);
+      const root = byId.get(rootId);
+      const bucket = buckets.get(rootId) || {
+        ownershipRoot: rootId,
+        ownershipRootName: root ? root.name : rootId,
+        ownershipRootKind: root ? root.kind : "?",
+        members: [],
+      };
+      bucket.members.push({ id: child.id, name: child.name, kind: child.kind });
+      buckets.set(rootId, bucket);
+    }
+    const coTenants = Array.from(buckets.values()).sort((a, b) => b.members.length - a.members.length);
+    perHost.push({
+      host: { id: host.id, name: host.name, kind: host.kind },
+      ownershipRoots: coTenants.length,
+      coTenants,
+    });
+  }
+
+  // Surface a one-line recommendation when ≥2 services share a host —
+  // exactly the "blast radius if it fails" case that justifies this tool.
+  const sharedHosts = perHost.filter((h) => h.ownershipRoots > 1);
+  const summary =
+    sharedHosts.length > 0
+      ? `${sharedHosts.length} of ${perHost.length} host(s) carry ≥2 services — those hosts are blast-radius candidates if they fail.`
+      : `No host carries more than one service besides the target — limited shared-host blast radius.`;
+
+  const payload = {
+    target: { id: found.id, name: found.name, kind: found.kind },
+    hosts: perHost,
+    summary,
+  };
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+  };
+}


### PR DESCRIPTION
## Summary

Lifts the topology graph from \"only visible in the Web UI\" to a first-class MCP surface so the agent can reason about infrastructure the same way it already reasons about metrics and logs.

- **`get_topology`** — returns merged resources + edges from every topology-capable connector. Filters: `source`, `kind`, `scope`, `limit` (default 500, max 5000). Edges trimmed to surviving resources for internal consistency.
- **`get_blast_radius`** — pivots on the generic `RUNS_ON` relation: "if this resource's host(s) fail, who else fails?" Co-tenants are bucketed by *ownership root* (walked via `OWNED_BY` to the terminus). Works for pod→node, vm→hypervisor, container→host without code changes — no K8s-specific chain is hardcoded.

## Why these two

`get_topology` is the "give me the map" primitive — every other topology question can be answered from it, but the filters keep the payload reasonable for an LLM. `get_blast_radius` packages the most useful pre-computed answer: shared-host RCA. This is the question that justifies the topology graph existing at all.

## Live demo

Against the in-compose k3s (with PR #202 + #203):

```
get_blast_radius { resource: "ad314e718676" }
→ target: { kind: "node", name: "ad314e718676" }
  host carries 4 ownership roots:
    omcp-demo-echo (deployment) → 3 pods
    omcp-demo-frontend (deployment) → 2 pods
    coredns (deployment) → 1 pod
    local-path-provisioner (deployment) → 1 pod
  summary: 1 of 1 host(s) carry ≥2 services — blast-radius candidate.
```

## Test plan

- [x] Unit tests in `src/tools/topology.test.ts` — 14 cases against a hand-crafted fixture (ownership chains, shared-host, host-as-target, orphans with no RUNS_ON, ambiguous resolution). All pass.
- [x] `tsc --noEmit` clean.
- [x] Live verified against the running k3s demo (output above).
- [x] Smoke-test workflow updated to assert all 8 tools (was 6).
- [ ] CI on first push of this PR.

## Stacking

Independent of #203 (UI) — the MCP tools call into the connector registry directly, no HTTP endpoint needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)