### PR TITLE
feat(demo): migrate example services into k3s — unified observability story

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,16 @@ This project is fully containerized. **Never run `npm install` on the host machi
 docker compose --profile demo up --build
 ```
 
-All 8 containers start with health checks. Services generate traffic automatically.
+The demo stack brings up:
+- a single-node **k3s** cluster (`rancher/k3s` in a privileged container)
+- the three chaos-able example services (`api-gateway`, `payment-service`, `order-service`) as **Kubernetes Deployments** inside k3s (namespace `omcp-demo`)
+- Prometheus, Loki, Promtail (on the docker-compose side) scraping k3s NodePorts and pod logs
+- the MCP server with the `kubernetes` topology source pre-wired against k3s
+- the autonomous agent
+
+The same Deployments that emit metrics and logs are what shows up in the
+topology graph — that is what lets the agent correlate a metric/log
+anomaly with the underlying host via `get_blast_radius`.
 
 Without `--profile demo`, only `mcp-server` runs — for production deployments where Prometheus/Loki are managed elsewhere.
 
@@ -21,9 +30,12 @@ docker-compose up -d mcp-server
 
 ### View Logs
 ```bash
-docker-compose logs -f agent          # Agent detection loop
-docker-compose logs -f mcp-server     # MCP server
-docker-compose logs -f payment-service # Example service
+docker compose logs -f agent          # Agent detection loop
+docker compose logs -f mcp-server     # MCP server
+
+# Example services run inside k3s now — use kubectl to follow their logs:
+docker exec observability-mcp-k3s-1 \
+  kubectl -n omcp-demo logs -f deployment/payment-service
 ```
 
 ### Run Unit Tests
@@ -43,6 +55,10 @@ curl -X POST http://localhost:8081/chaos/reset
 
 Chaos modes are correlated: error-spike also increases CPU + latency + error logs. Memory-leak generates OOM warnings.
 
+The chaos URLs above are unchanged after the services moved into k3s —
+the compose file maps k3s NodePort 30080/30081/30082 onto host
+8080/8081/8082, so existing scripts and demo videos keep working.
+
 ## Key Endpoints
 
 | Service | URL | Purpose |
@@ -52,9 +68,10 @@ Chaos modes are correlated: error-spike also increases CPU + latency + error log
 | Health API | http://localhost:3000/api/health | Live health data for all services |
 | Prometheus | http://localhost:9090 | Prometheus UI |
 | Loki | http://localhost:3100 | Loki API |
-| API Gateway | http://localhost:8080 | Example service |
-| Payment Service | http://localhost:8081 | Example service (chaos target) |
-| Order Service | http://localhost:8082 | Example service |
+| API Gateway | http://localhost:8080 | Example service (NodePort 30080 in k3s) |
+| Payment Service | http://localhost:8081 | Example service, chaos target (NodePort 30081 in k3s) |
+| Order Service | http://localhost:8082 | Example service (NodePort 30082 in k3s) |
+| k3s (demo only) | https://k3s:6443 (in-network) | Single-node Kubernetes. Hosts the example services as Deployments in namespace `omcp-demo`. Kubeconfig in the `k3s-kubeconfig` named volume; mcp-server reads it via `KUBECONFIG=/k3s-kubeconfig/kubeconfig-internal.yaml`. |
 | Ollama | host.docker.internal:11434 | LLM on Windows host |
 
 ## Project Structure
@@ -74,16 +91,36 @@ Chaos modes are correlated: error-spike also increases CPU + latency + error log
 │   │   ├── config/           # sources.yaml loader (with ${VAR} substitution)
 │   │   ├── util/             # sanitizeForLog, etc.
 │   │   └── ui/index.html     # Single-file Web UI (Dashboard/Sources/Services/Health/Settings)
-│   └── plugins/              # Filesystem connectors: prometheus/, loki/
+│   └── plugins/              # Filesystem connectors: prometheus/, loki/, kubernetes/
 ├── helm/observability-mcp/   # ArtifactHub-grade Helm chart (Deployment/HPA/NetworkPolicy/ServiceMonitor/test/values.schema)
 ├── examples/                 # Demo material — opt-in via `docker compose --profile demo`
 │   ├── agent/                # Optional autonomous detection agent (uses Ollama)
-│   ├── example-services/     # 3 chaos-able microservices
-│   ├── prometheus/           # Demo Prometheus config
+│   ├── example-services/     # 3 chaos-able microservices, source code
+│   ├── kubernetes/           # Demo workload manifests — Deployments + NodePort Services
+│   ├── prometheus/           # Demo Prometheus config (scrapes k3s NodePorts)
 │   ├── loki/                 # Demo Loki config
-│   └── promtail/             # Demo log shipper
+│   └── promtail/             # Demo log shipper (tails k3s pod logs)
 └── docs/                     # configuration, auth-and-tls, plugin-architecture, airgapped-deployment, ...
 ```
+
+## Demo data flow
+
+```
+docker-compose                                  k3s (in a privileged container)
+──────────────                                  ────────────────────────────────
+image-loader  ─builds & ctr-imports─────────►   containerd ──► example-service:demo
+                                                                 ▼
+prometheus  ◄──scrape via NodePort──── k3s ──── Deployments: api-gateway, payment-service, order-service
+                                       │           (namespace omcp-demo, Pods 1× each)
+loki  ◄────── push ──── promtail ◄───  │
+                                       └─────── /var/log/pods (named volume) ──► promtail
+mcp-server (kubernetes source) ─watch───┘
+```
+
+The chaos endpoints stay reachable on the host (`localhost:8080/8081/8082`)
+because compose maps NodePort 30080/30081/30082 from the k3s container.
+The agent never observes the move: it talks to MCP over stdio/HTTP and
+the tool layer abstracts the underlying transport.
 
 ## Adding a New Connector
 

--- a/README.md
+++ b/README.md
@@ -117,15 +117,16 @@ graph TB
     end
 
     subgraph Connectors ["Pluggable Connectors"]
-        Prom["Prometheus<br/><small>PromQL</small>"]
-        Loki["Loki<br/><small>LogQL</small>"]
+        Prom["Prometheus<br/><small>PromQL — metrics</small>"]
+        Loki["Loki<br/><small>LogQL — logs</small>"]
+        K8s["Kubernetes<br/><small>watch — topology</small>"]
         Next["Your Backend<br/><small>Any query language</small>"]
     end
 
     Agent <-->|"MCP<br/>Streamable HTTP"| Tools
     Tools --- Analysis
     Tools --- UI
-    MCP --> Prom & Loki & Next
+    MCP --> Prom & Loki & K8s & Next
 
     style MCP fill:#1a1a2e,stroke:#58a6ff,color:#fff
     style Connectors fill:#0d1117,stroke:#3fb950,color:#fff
@@ -237,7 +238,9 @@ cd observability-mcp
 docker compose --profile demo up --build
 ```
 
-Boots 8 containers with health checks: 3 example microservices, Prometheus, Loki, Promtail, the MCP server, and the agent. Open `http://localhost:3000`.
+Boots a single-node **k3s** cluster, builds the three example services and runs them as Kubernetes Deployments inside k3s, plus Prometheus, Loki, Promtail, the MCP server and the agent on the docker-compose side. Open `http://localhost:3000`.
+
+The same Deployments that Prometheus scrapes and Loki receives logs from are also what the topology graph shows — so the agent can correlate a metric/log anomaly with its underlying host using `get_blast_radius`. Chaos endpoints stay on `localhost:8080/8081/8082` (mapped to the k3s NodePorts) so existing scripts and demo videos keep working unchanged.
 
 Without `--profile demo`, only `mcp-server` starts — useful when you already run Prometheus/Loki elsewhere and just want to expose them via MCP.
 
@@ -375,7 +378,7 @@ flags pass through after a literal `--`.
 | Web UI | http://localhost:3000 |
 | Health API | http://localhost:3000/api/health |
 
-In the docker-compose demo: Prometheus on `:9090`, Loki on `:3100`, services on `:8080–:8082`.
+In the docker-compose demo: Prometheus on `:9090`, Loki on `:3100`. The three example services run as Kubernetes Deployments inside the in-compose k3s and are reachable on the host via the NodePort mapping `:8080–:8082` — same URLs as before the k8s migration, so existing chaos commands keep working.
 
 **Transports:** Streamable HTTP by default (`/mcp`). For stdio-based clients/catalogs (Claude Desktop, Glama's `mcp-proxy`, etc.) run with `--stdio` (or `MCP_TRANSPORT=stdio`) — one MCP server over stdin/stdout, all logs on stderr so the protocol stream stays clean.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,69 +4,126 @@ services:
   # `docker compose up mcp-server` gives a bare server you can point at
   # your own Prometheus/Loki via the Web UI or env vars.
   # ------------------------------------------------------------
-  # DEMO PROFILE — `docker compose --profile demo up` adds the example
-  # microservices, Prometheus, Loki, Promtail, and the autonomous agent
-  # so you can see chaos detection end-to-end without external infra.
+  # DEMO PROFILE — `docker compose --profile demo up` adds:
+  #   * a single-node k3s cluster
+  #   * the three chaos-able example services as Kubernetes Deployments
+  #     inside that cluster
+  #   * Prometheus + Loki + Promtail (running on the docker-compose side)
+  #     scraping the cluster's NodePorts and pod logs
+  #   * the autonomous agent
+  #
+  # The example services live in k3s on purpose: it is the same demo
+  # workload that emits metrics and logs and that shows up in the
+  # topology graph — that is what lets the agent correlate a metric or
+  # log anomaly with its underlying host via `get_blast_radius`.
   # ============================================================
 
-  # --- Example Microservices (demo) ---
-  api-gateway:
+  # --- k3s (demo) ---
+  # Single-node Kubernetes for the topology connector + workloads.
+  # NodePorts 30080/30081/30082 (the example services) are mapped to
+  # the host as 8080/8081/8082 so the documented chaos URLs
+  # (`curl localhost:8081/chaos/error-spike`) keep working unchanged
+  # after the move from compose to k8s.
+  k3s:
     profiles: ["demo"]
-    build:
-      context: ./examples/example-services
+    image: rancher/k3s:v1.31.3-k3s1
+    command:
+      - server
+      - --tls-san=k3s
+      - --disable=traefik
+      - --disable=metrics-server
+      - --disable=servicelb
+    privileged: true
+    tmpfs:
+      - /run
+      - /var/run
     environment:
-      - SERVICE_NAME=api-gateway
-      - PORT=8080
+      - K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml
+      - K3S_KUBECONFIG_MODE=666
+    volumes:
+      - k3s-server:/var/lib/rancher/k3s
+      - k3s-kubeconfig:/output
+      # Pod logs are written to /var/log/pods inside the k3s container.
+      # We expose them as a named volume so the promtail container can
+      # tail them from outside k3s.
+      - k3s-pod-logs:/var/log/pods
     ports:
-      - "8080:8080"
-    labels:
-      logging: "promtail"
+      - "8080:30080"
+      - "8081:30081"
+      - "8082:30082"
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
-      interval: 10s
-      timeout: 3s
-      retries: 3
+      test: ["CMD-SHELL", "kubectl get --raw=/healthz | grep -q ok"]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+      start_period: 30s
     restart: unless-stopped
     networks:
       - observability
 
-  payment-service:
+  # --- image-loader (demo) ---
+  # One-shot. Builds the `example-service:demo` image from the source in
+  # examples/example-services, then pipes the OCI tarball into k3s'
+  # embedded containerd (k8s.io namespace) via `ctr images import`.
+  # This avoids needing a local image registry — the kubelet finds the
+  # image in containerd directly. Manifests pin `imagePullPolicy: Never`
+  # so the demo stays airgap-clean (no Docker-Hub round-trip).
+  image-loader:
     profiles: ["demo"]
-    build:
-      context: ./examples/example-services
-    environment:
-      - SERVICE_NAME=payment-service
-      - PORT=8081
-    ports:
-      - "8081:8081"
-    labels:
-      logging: "promtail"
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8081/health"]
-      interval: 10s
-      timeout: 3s
-      retries: 3
-    restart: unless-stopped
+    image: docker:27-cli
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        echo "building example-service:demo ..."
+        docker build -t example-service:demo /src/example-services
+        echo "waiting for the k3s sibling container ..."
+        until k3s_id=$$(docker ps -q --filter "label=com.docker.compose.service=k3s") && [ -n "$$k3s_id" ]; do sleep 2; done
+        echo "k3s container: $$k3s_id"
+        until docker exec "$$k3s_id" kubectl get --raw=/healthz 2>/dev/null | grep -q ok; do sleep 2; done
+        echo "importing example-service:demo into k3s containerd (namespace k8s.io) ..."
+        docker save example-service:demo | docker exec -i "$$k3s_id" ctr -a /run/k3s/containerd/containerd.sock -n k8s.io images import -
+        echo "image-loader done"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./examples:/src:ro
+    depends_on:
+      k3s:
+        condition: service_healthy
     networks:
       - observability
 
-  order-service:
+  # k3s-init: rewrite kubeconfig for in-network use (k3s' default points
+  # at 127.0.0.1), then apply the demo workload and wait for rollouts.
+  # Splits cleanly from image-loader so the dependency graph is obvious:
+  # image must be in containerd before kubectl-apply runs.
+  k3s-init:
     profiles: ["demo"]
-    build:
-      context: ./examples/example-services
-    environment:
-      - SERVICE_NAME=order-service
-      - PORT=8082
-    ports:
-      - "8082:8082"
-    labels:
-      logging: "promtail"
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8082/health"]
-      interval: 10s
-      timeout: 3s
-      retries: 3
-    restart: unless-stopped
+    image: rancher/k3s:v1.31.3-k3s1
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        until [ -f /output/kubeconfig.yaml ]; do sleep 1; done
+        sed 's|https://127.0.0.1:6443|https://k3s:6443|g' /output/kubeconfig.yaml > /output/kubeconfig-internal.yaml
+        export KUBECONFIG=/output/kubeconfig-internal.yaml
+        until kubectl get nodes 2>/dev/null | grep -qE '\sReady\s'; do
+          echo "waiting for node Ready..."
+          sleep 2
+        done
+        kubectl apply -f /workload/workload.yaml
+        for d in api-gateway payment-service order-service; do
+          kubectl -n omcp-demo rollout status deployment/$$d --timeout=180s
+        done
+        echo "k3s demo workload ready"
+    volumes:
+      - k3s-kubeconfig:/output
+      - ./examples/kubernetes:/workload:ro
+    depends_on:
+      k3s:
+        condition: service_healthy
+      image-loader:
+        condition: service_completed_successfully
     networks:
       - observability
 
@@ -87,12 +144,8 @@ services:
     networks:
       - observability
     depends_on:
-      api-gateway:
-        condition: service_healthy
-      payment-service:
-        condition: service_healthy
-      order-service:
-        condition: service_healthy
+      k3s-init:
+        condition: service_completed_successfully
 
   loki:
     profiles: ["demo"]
@@ -113,12 +166,16 @@ services:
     networks:
       - observability
 
+  # Promtail tails the k3s pod log directory (shared via the k3s-pod-logs
+  # named volume). Container/namespace/pod labels are extracted from the
+  # file path by the pipeline in examples/promtail/promtail-config.yml —
+  # no docker socket needed.
   promtail:
     profiles: ["demo"]
     image: grafana/promtail:3.1.0
     volumes:
       - ./examples/promtail/promtail-config.yml:/etc/promtail/config.yml:ro
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - k3s-pod-logs:/var/log/pods:ro
     command: -config.file=/etc/promtail/config.yml
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:9080/ready"]
@@ -131,6 +188,8 @@ services:
     depends_on:
       loki:
         condition: service_healthy
+      k3s-init:
+        condition: service_completed_successfully
 
   # --- MCP Server ---
   mcp-server:
@@ -141,6 +200,12 @@ services:
     environment:
       - PROMETHEUS_URL=http://prometheus:9090
       - LOKI_URL=http://loki:3100
+      # The kubernetes source in config/sources.yaml reads this. In a
+      # non-demo run the file is absent and the source reports "down"
+      # without blocking startup.
+      - KUBECONFIG=/k3s-kubeconfig/kubeconfig-internal.yaml
+    volumes:
+      - k3s-kubeconfig:/k3s-kubeconfig:ro
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/api/sources"]
       interval: 10s
@@ -149,9 +214,14 @@ services:
     restart: unless-stopped
     networks:
       - observability
-    # No depends_on prometheus/loki — they live in the demo profile and
-    # mcp-server must be able to start standalone (pointing at external
-    # backends or with sources added later via the Web UI).
+    # depends_on entries here all belong to the demo profile. When demo
+    # is not active, compose silently drops them — mcp-server still
+    # starts standalone (pointing at external backends or with sources
+    # added later via the Web UI).
+    depends_on:
+      k3s-init:
+        condition: service_completed_successfully
+        required: false
 
   # --- AI Agent (demo) ---
   agent:
@@ -174,6 +244,9 @@ services:
 
 volumes:
   loki-data:
+  k3s-server:
+  k3s-kubeconfig:
+  k3s-pod-logs:
 
 networks:
   observability:

--- a/examples/kubernetes/workload.yaml
+++ b/examples/kubernetes/workload.yaml
@@ -1,0 +1,202 @@
+---
+# Demo workload applied to the in-compose k3s by the k3s-init container.
+#
+# All three chaos-able example services live here as real Kubernetes
+# Deployments + NodePort Services. Prometheus and Loki (running in
+# docker-compose) scrape them via the NodePort exposed on the `k3s`
+# service hostname, so the *same* services that emit metrics/logs now
+# appear in the topology graph — exactly the cross-source story the
+# observability-mcp demo is meant to tell.
+#
+# Image: `example-service:demo` is built once by the `image-loader`
+# compose service, saved to /image-cache/example-service.tar, and
+# imported into k3s by k3s-init via `ctr images import`. With
+# imagePullPolicy: Never the kubelet never tries to fetch it from a
+# remote registry — keeps the demo airgap-clean.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: omcp-demo
+  labels:
+    app.kubernetes.io/part-of: observability-mcp-demo
+---
+# ---------------- api-gateway ----------------
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+  namespace: omcp-demo
+  labels:
+    app: api-gateway
+    tier: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-gateway
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+        tier: frontend
+    spec:
+      containers:
+        - name: app
+          image: example-service:demo
+          imagePullPolicy: Never
+          env:
+            - name: SERVICE_NAME
+              value: api-gateway
+            - name: PORT
+              value: "8080"
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 20m
+              memory: 32Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-gateway
+  namespace: omcp-demo
+  labels:
+    app: api-gateway
+spec:
+  type: NodePort
+  selector:
+    app: api-gateway
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      nodePort: 30080
+---
+# ---------------- payment-service ----------------
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-service
+  namespace: omcp-demo
+  labels:
+    app: payment-service
+    tier: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: payment-service
+  template:
+    metadata:
+      labels:
+        app: payment-service
+        tier: backend
+    spec:
+      containers:
+        - name: app
+          image: example-service:demo
+          imagePullPolicy: Never
+          env:
+            - name: SERVICE_NAME
+              value: payment-service
+            - name: PORT
+              value: "8081"
+          ports:
+            - name: http
+              containerPort: 8081
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 20m
+              memory: 32Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-service
+  namespace: omcp-demo
+  labels:
+    app: payment-service
+spec:
+  type: NodePort
+  selector:
+    app: payment-service
+  ports:
+    - name: http
+      port: 8081
+      targetPort: 8081
+      nodePort: 30081
+---
+# ---------------- order-service ----------------
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: order-service
+  namespace: omcp-demo
+  labels:
+    app: order-service
+    tier: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: order-service
+  template:
+    metadata:
+      labels:
+        app: order-service
+        tier: backend
+    spec:
+      containers:
+        - name: app
+          image: example-service:demo
+          imagePullPolicy: Never
+          env:
+            - name: SERVICE_NAME
+              value: order-service
+            - name: PORT
+              value: "8082"
+          ports:
+            - name: http
+              containerPort: 8082
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8082
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 20m
+              memory: 32Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: order-service
+  namespace: omcp-demo
+  labels:
+    app: order-service
+spec:
+  type: NodePort
+  selector:
+    app: order-service
+  ports:
+    - name: http
+      port: 8082
+      targetPort: 8082
+      nodePort: 30082

--- a/examples/prometheus/prometheus.yml
+++ b/examples/prometheus/prometheus.yml
@@ -2,21 +2,29 @@ global:
   scrape_interval: 5s
   evaluation_interval: 5s
 
+# The three example services run inside the in-compose k3s. We scrape
+# them via NodePort on the `k3s` service hostname (resolvable inside the
+# observability docker network). The job/service labels stay identical
+# to the application's emitted job= label so /api/health,
+# get_service_health and detect_anomalies code paths are unchanged —
+# only the underlying transport moved from compose containers to k8s
+# pods. See examples/kubernetes/workload.yaml.
+
 scrape_configs:
   - job_name: "api-gateway"
     static_configs:
-      - targets: ["api-gateway:8080"]
+      - targets: ["k3s:30080"]
         labels:
           service: "api-gateway"
 
   - job_name: "payment-service"
     static_configs:
-      - targets: ["payment-service:8081"]
+      - targets: ["k3s:30081"]
         labels:
           service: "payment-service"
 
   - job_name: "order-service"
     static_configs:
-      - targets: ["order-service:8082"]
+      - targets: ["k3s:30082"]
         labels:
           service: "order-service"

--- a/examples/promtail/promtail-config.yml
+++ b/examples/promtail/promtail-config.yml
@@ -8,21 +8,38 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# k3s writes pod logs to /var/log/pods/<namespace>_<pod>_<uid>/<container>/<n>.log
+# The compose file mounts the k3s container's /var/log/pods as a shared
+# volume into promtail. We file-tail those logs and extract namespace /
+# pod / container as labels from the path, then apply a JSON pipeline so
+# the application's `level` and `service` fields still surface as Loki
+# labels the same way the previous docker-shipped streams did.
 scrape_configs:
-  - job_name: docker
-    docker_sd_configs:
-      - host: unix:///var/run/docker.sock
-        refresh_interval: 5s
-        filters:
-          - name: label
-            values: ["logging=promtail"]
-    relabel_configs:
-      - source_labels: ["__meta_docker_container_name"]
-        regex: "/(.*)"
-        target_label: "container"
-      - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
-        target_label: "service"
+  - job_name: k3s-pods
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: k3s-pods
+          __path__: /var/log/pods/*/*/*.log
     pipeline_stages:
+      # k3s (and any CRI runtime) writes pod logs in the CRI format:
+      #   <RFC3339Nano> <stdout|stderr> <P|F> <message>
+      # Strip the prefix so the downstream JSON stage sees the
+      # application payload directly. `cri` also surfaces the
+      # stream/flag as labels for free.
+      - cri: {}
+      # Path looks like: /var/log/pods/omcp-demo_payment-service-7fd_<uid>/app/0.log
+      - regex:
+          source: filename
+          expression: '^/var/log/pods/(?P<namespace>[^_]+)_(?P<pod>[^_]+)_[^/]+/(?P<container>[^/]+)/[0-9]+\.log$'
+      - labels:
+          namespace:
+          pod:
+          container:
+      # The example services emit a `service` field; surface it as a
+      # label so existing service-keyed queries (`{service="…"}`) work
+      # exactly like with the previous docker_sd setup.
       - json:
           expressions:
             level: level

--- a/mcp-server/config/sources.yaml
+++ b/mcp-server/config/sources.yaml
@@ -24,6 +24,16 @@ sources:
     url: http://loki:3100
     enabled: true
 
+  # Kubernetes topology source. Reads $KUBECONFIG which the compose file
+  # points at the in-network kubeconfig written by the k3s-init
+  # container. In a non-demo run the file is absent and the connector
+  # reports "down" cleanly. url/auth are unused — the connector reads
+  # server + credentials from kubeconfig.
+  - name: kubernetes
+    type: kubernetes
+    url: ""
+    enabled: true
+
 settings:
   checkIntervalMs: 30000
   defaultSensitivity: medium


### PR DESCRIPTION
## Summary

The three chaos-able example services (`api-gateway`, `payment-service`, `order-service`) move from being docker-compose containers to **Kubernetes Deployments** running inside the in-compose k3s. They are the same services Prometheus scrapes and Loki ingests, so the topology graph and the metric/log signals now describe the **same** workload — that is the precondition for honest cross-source RCA (e.g. `get_blast_radius` on a pod, then see which other Deployments share the host).

## Test plan

- [x] `docker compose --profile demo up --build` — all 6 services healthy on first boot
- [x] `/api/sources` reports prometheus, loki, kubernetes all `up`
- [x] Prometheus scraping all three services via `k3s:30080-2` (job/service labels unchanged)
- [x] Loki receives logs with full labels (`service`, `level`, `namespace`, `pod`, `container`, `stream`) — CRI prefix stripped, JSON payload parsed
- [x] Chaos endpoint `curl localhost:8081/chaos/error-spike` still works (NodePort 30081 mapped to host 8081)
- [x] `/api/health` produces health scores for all three services
- [x] Topology snapshot lists the same three names as Deployments
- [ ] CI smoke test on first push of this PR

## What changed at a glance

- `image-loader` compose service builds `example-service:demo` and pipes it into k3s' containerd via `docker exec ... ctr -n k8s.io images import -`. No local registry needed.
- New manifests `examples/kubernetes/workload.yaml` — namespace `omcp-demo`, 3 Deployments + 3 NodePort Services, `imagePullPolicy: Never`.
- `examples/prometheus/prometheus.yml` — static targets point at the k3s service hostname + NodePorts. Job labels identical to the prior compose-name targets.
- `examples/promtail/promtail-config.yml` — drops docker-socket SD; file-tails `/var/log/pods/*/*/*.log` via a shared `k3s-pod-logs` named volume. Adds a `cri:` stage to strip the CRI log prefix before JSON parsing.
- `mcp-server/config/sources.yaml` — adds the `kubernetes` source (enabled by default; gracefully reports "down" in non-demo runs).
- `docker-compose.yml` — removes the three service blocks, adds k3s NodePort mappings on the `k3s` service, adds the shared log volume.
- Docs (`README.md`, `CLAUDE.md`) — rewritten quickstart, key-endpoints table, repo layout, architecture mermaid, demo dataflow diagram. Chaos URLs unchanged.

## Subsumes #202

This PR includes everything #202 was setting up (k3s service, kubernetes source, workload manifest) but with the real demo services instead of placeholder echo pods. When this lands, #202 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)