### PR TITLE
docs: sync docs with the topology / Kubernetes connector stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ the compose file maps k3s NodePort 30080/30081/30082 onto host
 | Service | URL | Purpose |
 |---------|-----|---------|
 | MCP Server | http://localhost:3000/mcp | MCP Streamable HTTP endpoint |
-| Web UI | http://localhost:3000 | Management UI (5 pages) |
+| Web UI | http://localhost:3000 | Management UI (Dashboard / Sources / Services / Health / Topology / Settings) |
 | Health API | http://localhost:3000/api/health | Live health data for all services |
 | Prometheus | http://localhost:9090 | Prometheus UI |
 | Loki | http://localhost:3100 | Loki API |

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ graph TB
     Agent["AI Agent<br/><small>Claude, Ollama, etc.</small>"]
 
     subgraph MCP ["observability-mcp :3000"]
-        Tools["6 MCP Tools"]
+        Tools["8 MCP Tools"]
         Analysis["Analysis Engine<br/><small>Robust stats, Health Scoring, Correlation</small>"]
         UI["Web UI"]
     end
@@ -254,6 +254,10 @@ Without `--profile demo`, only `mcp-server` starts — useful when you already r
 | `query_logs` | logs | Query logs with error/warning counts and top patterns |
 | `get_service_health` | unified | Health score combining metrics + logs (0–100) |
 | `detect_anomalies` | unified | Cross-signal anomaly detection with robust (median/MAD + trend) analysis |
+| `get_topology` | topology | Return the merged infrastructure graph (resources + edges) from every topology-capable connector, filterable by source/kind/scope |
+| `get_blast_radius` | topology | Pivot on the universal `RUNS_ON` relation — "if this resource's host fails, who else fails?". Works for pod→node, vm→hypervisor, container→host |
+
+The two topology tools require a topology-capable connector. The bundled [Kubernetes connector](docs/kubernetes.md) is the first; future connectors (vCenter, NetBox, …) plug in via the same `isTopologyProvider` interface.
 
 ## Using with Claude Code
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -40,6 +40,6 @@ If Ollama is unavailable, the agent falls back to raw anomaly JSON output withou
 1. Sync settings from the MCP server (`checkIntervalMs`, `defaultSensitivity`).
 2. Call `list_services` to discover what to monitor.
 3. Call `detect_anomalies` per service with the configured sensitivity.
-4. For each anomaly: ask the LLM to root-cause it, with up to three rounds of tool calls (`query_metrics`, `query_logs`, `get_service_health`).
+4. For each anomaly: ask the LLM to root-cause it, with up to three rounds of tool calls. The current toolbelt is `query_metrics`, `query_logs`, `get_service_health` for digging into a single service, plus `get_topology` and `get_blast_radius` ([docs/kubernetes.md](kubernetes.md)) for cross-cutting questions like "do these two anomalous services share a host?". The LLM picks composition order.
 5. Output the incident analysis with severity classification (P1–P4).
 6. Deduplicate within a 5-minute TTL so the same incident isn't reported repeatedly.

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -2,7 +2,7 @@
 
 Each backend is a connector that owns its native query language. The MCP tool layer stays backend-agnostic.
 
-Currently shipped: **Prometheus** (PromQL) and **Loki** (LogQL). Adding a new one means implementing one interface.
+Currently shipped: **Prometheus** (PromQL, metrics), **Loki** (LogQL, logs), and **Kubernetes** (watch-based, topology). Adding a new one means implementing one interface — see the [Kubernetes connector reference](kubernetes.md) for an example of a connector that emits a `Resource`/`Edge` graph instead of metrics or logs.
 
 Optional connectors (Datadog, Grafana, Elasticsearch, …) are distributed via the [Connector Hub](https://thotischner.github.io/observability-mcp/hub/) and can be added to a running server without a rebuild — via the Web UI's **Connectors** page (browse the hub, install, or upload a signed `.tgz`), the `omcp plugin install` CLI, or the Helm bundle image. The runtime install paths are fail-closed and off by default; see [`docs/plugin-architecture.md`](plugin-architecture.md#the-connector-hub) for the API, guardrails (`ENABLE_UI_INSTALL` + trust root), and Kubernetes persistence.
 
@@ -16,6 +16,7 @@ Optional connectors (Datadog, Grafana, Elasticsearch, …) are distributed via t
    - `listServices()` — discover services from the backend
    - `getDefaultMetrics()` / `getMetrics()` — return `MetricDefinition[]` in the backend's query language
    - `queryMetrics?()` and/or `queryLogs?()` — implement what the backend supports
+   - `listResources?()` / `listEdges?()` / `getTopologySnapshot?()` / `watchTopology?()` — implement these if your backend models infrastructure topology (Kubernetes pods on nodes, VMs on hypervisors, …). The `isTopologyProvider()` guard in `interface.ts` is the contract the new MCP tools (`get_topology`, `get_blast_radius`) and the Web UI Topology page consume.
 3. Register a factory in `mcp-server/src/connectors/registry.ts`:
    ```ts
    connectorFactories[type] = () => new MyConnector();

--- a/docs/enterprise-gate.md
+++ b/docs/enterprise-gate.md
@@ -1,8 +1,8 @@
 # Enterprise access-control gate
 
 The MCP server has an **optional** seam that enforces role-based access
-control, a product catalog, and an audit log in front of the six MCP
-tools. It is **off by default** and changes nothing unless an operator
+control, a product catalog, and an audit log in front of every MCP
+tool. It is **off by default** and changes nothing unless an operator
 explicitly opts in.
 
 The seam itself (`mcp-server/src/enterprise-gate.ts`) is Apache-2.0 and

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -1,0 +1,132 @@
+# Kubernetes connector
+
+A watch-based **topology** connector. Unlike Prometheus (metrics) or
+Loki (logs), Kubernetes does not emit time-series — it describes
+infrastructure shape: which pod runs on which node, which deployment
+owns which pods, what namespace something lives in. The connector
+exposes that shape as a generic `Resource` / `Edge` graph the rest of
+the server can reason about without knowing any Kubernetes specifics.
+
+> The model is intentionally generic — `kind` and `relation` are open
+> strings, not TypeScript unions. A future vCenter / NetBox / NetApp
+> connector emits `Resource`s and `Edge`s of its own kinds and
+> relations; the same UI page, the same `get_topology` and
+> `get_blast_radius` MCP tools, and the same correlator code consume
+> them. See [`docs/connectors.md`](connectors.md) for the contract.
+
+## What it discovers
+
+The connector starts an [@kubernetes/client-node](https://github.com/kubernetes-client/javascript)
+Informer per kind and keeps an in-memory store synchronised with the
+cluster. No polling — the watch stream is the source of truth and the
+store applies add/update/delete events as they arrive.
+
+Resources emitted (`kind` value in the graph):
+
+| Kind | Where it comes from | Cluster-scoped? |
+|------|---------------------|-----------------|
+| `node` | `/api/v1/nodes` | yes |
+| `namespace` | `/api/v1/namespaces` | yes |
+| `pod` | `/api/v1/pods` (all namespaces) | no |
+| `deployment` | `/apis/apps/v1/deployments` | no |
+| `replicaset` | `/apis/apps/v1/replicasets` | no |
+
+Edges (`relation` value):
+
+| Relation | Edge | Meaning |
+|----------|------|---------|
+| `RUNS_ON` | `pod → node` | Where the kubelet scheduled this pod. Universal "blast radius" pivot — `get_blast_radius` uses this relation across every topology connector. |
+| `OWNED_BY` | `pod → replicaset`, `replicaset → deployment` | Built from each object's `metadata.ownerReferences`. Walked transitively by the tools/UI to find the ownership root (e.g. a Pod's terminal owner is its Deployment). |
+| `IN_NAMESPACE` | `pod → namespace`, `deployment → namespace`, `replicaset → namespace` | Membership in a scope. Drawn as a tinted background band in the UI graph, not as an edge, to avoid star-shaped clutter. |
+
+Canonical IDs follow `k8s:<kind>:<namespace>/<name>` for namespaced
+kinds and `k8s:<kind>:<name>` for cluster-scoped ones. Pod names are
+ephemeral by design (pods are cattle, not pets) — the K8s
+`metadata.uid` is preserved in `attributes.uid` for future
+cross-source entity resolution.
+
+## Configuration
+
+```yaml
+sources:
+  - name: my-cluster
+    type: kubernetes
+    enabled: true
+    url: ""        # ignored — credentials come from kubeconfig
+```
+
+Authentication is picked up from:
+
+1. `$KUBECONFIG`, if set and the file exists — the supported path for
+   the in-compose demo (mcp-server reads
+   `/k3s-kubeconfig/kubeconfig-internal.yaml` from a named volume).
+2. `~/.kube/config`, otherwise.
+3. In-cluster ServiceAccount when the well-known env vars
+   `KUBERNETES_SERVICE_HOST` + `KUBERNETES_SERVICE_PORT` are present —
+   the path the Helm chart uses by default.
+
+The connector explicitly detects in-cluster via those env vars rather
+than via `kc.loadFromCluster()`'s try/catch, because in
+`@kubernetes/client-node` v1.x `loadFromCluster()` no longer throws
+when files/env are missing — it silently returns
+`https://undefined:undefined`. See `src/connectors/kubernetes-client.ts`.
+
+## Permissions
+
+In-cluster, the connector needs read-only access to the kinds it
+watches. The minimum RBAC for a `kubernetes-source` ServiceAccount:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: omcp-topology-reader
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "namespaces", "pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "list", "watch"]
+```
+
+## What you can ask through MCP
+
+Once the connector is connected and the watch has caught up, two MCP
+tools are available to agents (in addition to the existing
+metric/log tools):
+
+- `get_topology` — return the merged resource/edge graph, optionally
+  filtered by `source`, `kind`, or `scope` (e.g. namespace name or
+  id). Hard cap of 5000 resources to keep agent context bounded.
+- `get_blast_radius` — pivot on `RUNS_ON`: given any resource id, name
+  or unique substring, return the host(s) it depends on and every
+  other ownership-root running there. The canonical "if this host
+  dies, who else fails?" question. If the target is itself a host
+  (has incoming `RUNS_ON`), its tenants are reported.
+
+The Web UI surfaces the same data under **Observability → Topology**
+with three sub-tabs (Summary, Blast radius, layered graph).
+
+## Live demo
+
+`docker compose --profile demo up` brings up a single-node k3s and
+applies a workload that puts the three chaos-able example services
+(`api-gateway`, `payment-service`, `order-service`) into the
+`omcp-demo` namespace. Prometheus and Loki scrape those same
+Deployments — that is what lets an agent correlate a metric or log
+anomaly with its underlying host. See
+[`docs/configuration.md`](configuration.md) and
+[`CLAUDE.md`](../CLAUDE.md) for the demo plumbing.
+
+## Caveats
+
+- **Single-node single-cluster only, today.** Multi-cluster federation
+  is a future increment — adding a second `kubernetes` source today
+  works mechanically but the connector does no cross-cluster entity
+  resolution yet.
+- **No metrics or logs.** This connector intentionally does not
+  implement `queryMetrics` / `queryLogs`. Pair it with Prometheus +
+  Loki for the full picture.
+- **Pod IDs are ephemeral.** A pod recreate produces a new id. Stable
+  identity sits at the Deployment level.

--- a/docs/presentation.html
+++ b/docs/presentation.html
@@ -304,7 +304,7 @@ flowchart TB
 
     subgraph MCP ["observability-mcp :3000"]
         direction TB
-        Tools["6 MCP Tools"]
+        Tools["8 MCP Tools"]
         Analysis["Analysis Engine"]
         UI["Web UI"]
     end
@@ -330,10 +330,10 @@ flowchart TB
       </div>
     </section>
 
-    <!-- ===== SLIDE 7: THE 6 TOOLS ===== -->
+    <!-- ===== SLIDE 7: THE 8 TOOLS ===== -->
     <section>
       <span class="tag">Surface area</span>
-      <h2>6 tools. One contract.</h2>
+      <h2>8 tools. One contract.</h2>
       <table style="margin-top:24px;width:100%;">
         <thead>
           <tr><th>Tool</th><th>Signal</th><th>What it does</th></tr>
@@ -345,6 +345,8 @@ flowchart TB
           <tr><td><code>query_logs</code></td><td>logs</td><td>Log entries with error counts and top patterns</td></tr>
           <tr><td><code>get_service_health</code></td><td>unified</td><td>0–100 score combining metrics &amp; logs</td></tr>
           <tr><td><code>detect_anomalies</code></td><td>unified</td><td>Cross-signal anomalies via z-score analysis</td></tr>
+          <tr><td><code>get_topology</code></td><td>topology</td><td>Merged infrastructure graph (resources + edges) across topology connectors</td></tr>
+          <tr><td><code>get_blast_radius</code></td><td>topology</td><td>"If this host dies, who else fails?" — pivots on the generic RUNS_ON relation</td></tr>
         </tbody>
       </table>
       <p style="margin-top:24px;font-size:0.7em;" class="muted">
@@ -512,8 +514,8 @@ docker-compose up</code></pre>
         <div>
           <h3>Shipped</h3>
           <ul style="font-size:0.75em;">
-            <li>Prometheus + Loki connectors</li>
-            <li>Web UI (5 pages, real-time)</li>
+            <li>Prometheus + Loki + Kubernetes (topology) connectors</li>
+            <li>Web UI (6 pages, real-time — incl. Topology graph)</li>
             <li>prom-client + node_exporter adaptive defaults</li>
             <li>Per-instance <code>groupBy</code> breakdown</li>
             <li>Grafana Cloud / Mimir / managed Loki support</li>


### PR DESCRIPTION
## Summary

Pure docs PR. Brings every place the docs lagged behind the topology features in #200, #203, #204, #205 back in line.

- New `docs/kubernetes.md` — reference for the kubernetes connector (mirrors the structure of `prometheus.md` / `loki.md`).
- `README.md` MCP Tools table now includes `get_topology` and `get_blast_radius`; architecture mermaid says "8 MCP Tools".
- `docs/connectors.md` lists the kubernetes connector and documents the optional topology methods on `ObservabilityConnector`.
- `docs/agent.md` mentions the new tools in the agent loop step that describes available tool calls.
- `docs/presentation.html` headline + tool table + shipped-features list updated.
- `docs/enterprise-gate.md` drops the hardcoded "six MCP tools" wording.
- `CLAUDE.md` key-endpoints table names the six UI pages explicitly instead of saying "5 pages".

## Why a separate PR

Easier to review than mixing with the feature PRs that already merged. No code changes; CI should pass trivially.

## Test plan

- [x] No code touched, `tsc --noEmit` not affected.
- [ ] CI green on first push.
- [ ] Skim of every changed file for unintended changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)