### PR TITLE
docs(topology): canonical kind/relation vocabulary + warn-only validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Without `--profile demo`, only `mcp-server` starts — useful when you already r
 | `get_topology` | topology | Return the merged infrastructure graph (resources + edges) from every topology-capable connector, filterable by source/kind/scope |
 | `get_blast_radius` | topology | Pivot on the universal `RUNS_ON` relation — "if this resource's host fails, who else fails?". Works for pod→node, vm→hypervisor, container→host |
 
-The two topology tools require a topology-capable connector. The bundled [Kubernetes connector](docs/kubernetes.md) is the first; future connectors (vCenter, NetBox, …) plug in via the same `isTopologyProvider` interface.
+The two topology tools require a topology-capable connector. The bundled [Kubernetes connector](docs/kubernetes.md) is the first; future connectors (vCenter, NetBox, …) plug in via the same `isTopologyProvider` interface and emit `kind`/`relation` values from the canonical [topology vocabulary](docs/topology-vocabulary.md).
 
 ## Using with Claude Code
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -16,7 +16,7 @@ Optional connectors (Datadog, Grafana, Elasticsearch, …) are distributed via t
    - `listServices()` — discover services from the backend
    - `getDefaultMetrics()` / `getMetrics()` — return `MetricDefinition[]` in the backend's query language
    - `queryMetrics?()` and/or `queryLogs?()` — implement what the backend supports
-   - `listResources?()` / `listEdges?()` / `getTopologySnapshot?()` / `watchTopology?()` — implement these if your backend models infrastructure topology (Kubernetes pods on nodes, VMs on hypervisors, …). The `isTopologyProvider()` guard in `interface.ts` is the contract the new MCP tools (`get_topology`, `get_blast_radius`) and the Web UI Topology page consume.
+   - `listResources?()` / `listEdges?()` / `getTopologySnapshot?()` / `watchTopology?()` — implement these if your backend models infrastructure topology (Kubernetes pods on nodes, VMs on hypervisors, …). The `isTopologyProvider()` guard in `interface.ts` is the contract the new MCP tools (`get_topology`, `get_blast_radius`) and the Web UI Topology page consume. Emit `kind` and `relation` values from the canonical [topology vocabulary](topology-vocabulary.md) so cross-connector reasoning works; the validator in `topology-vocabulary.ts` warns on drift.
 3. Register a factory in `mcp-server/src/connectors/registry.ts`:
    ```ts
    connectorFactories[type] = () => new MyConnector();

--- a/docs/topology-vocabulary.md
+++ b/docs/topology-vocabulary.md
@@ -1,0 +1,64 @@
+# Topology vocabulary
+
+The connector-agnostic infrastructure graph in this project is built from two primitives:
+
+```ts
+interface Resource { id; kind; name; source; labels; attributes? }
+interface Edge     { from; to; relation; source; confidence }
+```
+
+`kind` and `relation` are free-form strings at the type level — but the MCP tools (`get_topology`, `get_blast_radius`), the UI graph view, and any cross-connector reasoning all depend on connectors agreeing on what each value *means*. This document is that agreement.
+
+The vocabulary is intentionally tiny: only values that are emitted by a shipped connector OR are reserved as the agreed name for a near-term connector. Extending it is a documentation change here plus an entry in `KINDS` / `RELATIONS` in `mcp-server/src/connectors/topology-vocabulary.ts`. The same module exports `validateResource`, `validateEdge`, and `validateSnapshot` which are wired into the kubernetes connector and emit a one-shot `console.warn` per distinct offender. Validation is warn-only by design — a connector that emits an unknown value still works, but the drift gets caught in CI before it spreads.
+
+## Conventions
+
+- `kind` is **lowercase singular**, ASCII (`pod`, not `Pods` or `pod_v1`).
+- `relation` is **UPPER_SNAKE_CASE** verb phrase, read *from → to* (`pod RUNS_ON node`).
+- `id` is the connector's canonical id for the resource and is opaque to consumers. It MUST be globally unique within the snapshot a single connector returns. Two connectors observing the same resource will currently report two ids; identity reconciliation across connectors is an open gap (see `docs/connectors.md`).
+- `source` on both `Resource` and `Edge` is the connector's source name (e.g. `k8s-prod`) so the UI can colour-band by origin and `get_topology` can filter by source.
+- `confidence` on an `Edge` is `[0, 1]`. Edges derived from authoritative APIs (k8s `ownerReferences`, `node.name`) use `1.0`. Inferred edges (e.g. service-to-service from trace spans) should use a lower number.
+
+## Canonical `kind` values
+
+| `kind` | Meaning | Used by | Notes |
+|---|---|---|---|
+| `pod` | Single running workload instance | kubernetes | One container or a tightly coupled group, in the K8s sense. |
+| `node` | Host that runs pods | kubernetes | A Kubernetes worker node. Equivalent to `host` in non-k8s setups. |
+| `deployment` | Versioned rollout managing replicas | kubernetes | The "ownership root" the agent reports as the affected workload. |
+| `replicaset` | Mid-tier owner between `deployment` and `pod` | kubernetes | Surfaced so the ownership walk is faithful; rarely interesting on its own. |
+| `namespace` | Logical scope grouping resources | kubernetes | Used by the UI scope filter; mapped onto AWS accounts / vCenter folders / NetBox sites for non-k8s connectors. |
+| `service` | Long-lived addressable workload | reserved | For service-discovery-driven connectors (e.g. a future Consul or DNS-SD source). Distinct from a `deployment` because a service can be backed by anything. |
+| `container` | Sub-pod runtime unit | reserved | Only needed once a connector cares about per-container telemetry independently. |
+| `vm` | Virtual machine | reserved | vCenter/Proxmox/EC2 connectors. |
+| `host` | Physical or virtual host outside k8s | reserved | Symmetric to `node` for non-k8s connectors. |
+| `hypervisor` | Host that runs VMs | reserved | vCenter ESXi hosts, Proxmox nodes. |
+| `cluster` | Logical container of nodes/hosts | reserved | For multi-cluster federation. |
+
+Reserved values do not have to be emitted today, but a future connector adding them does not need a fresh round of bikeshedding.
+
+## Canonical `relation` values
+
+All relations are read **from → to**.
+
+| `relation` | Semantics | Used by | Example |
+|---|---|---|---|
+| `RUNS_ON` | The `from` is physically hosted by the `to`. Co-tenancy via this relation is the basis of `get_blast_radius`. | kubernetes | `pod → node`, future `vm → hypervisor`, future `container → host`. |
+| `OWNED_BY` | The `from` is managed by the `to`. Walking `OWNED_BY` to its terminus yields the *ownership root* — the deployable thing the operator cares about. | kubernetes | `pod → replicaset → deployment`. |
+| `IN_NAMESPACE` | The `from` is scoped by the `to` for organisational purposes. Rendered as a background band in the UI graph rather than an edge to avoid collapse. | kubernetes | `pod → namespace`, future `vm → folder`, future `host → aws-account`. |
+| `CALLS` | The `from` issues requests to the `to`. Edge weight (via `confidence`) reflects how strong the signal is. | reserved (tempo) | `service → service` derived from trace spans. |
+| `CONTAINS` | The `from` is composed of the `to`. Use sparingly — `OWNED_BY` is usually the right tool. | reserved | `pod → container`, `vm → disk`. |
+| `DEPENDS_ON` | Declared logical dependency, not inferred from traffic. | reserved | Catalog or manifest-derived. |
+
+## Extending the vocabulary
+
+1. Pick a name that fits the conventions above. Check the reserved list before inventing.
+2. Add it to `KINDS` or `RELATIONS` in `mcp-server/src/connectors/topology-vocabulary.ts`.
+3. Add a row in the appropriate table above with **what it means**, **who emits it**, and **an example**.
+4. Add a test in `topology-vocabulary.test.ts` if the new value has interesting semantics worth pinning.
+
+The validator runs in every topology-emitting connector and treats anything not in `KINDS` / `RELATIONS` as a warning — so a missed step here will surface as a one-shot `console.warn` per offending value the next time the snapshot is rendered.
+
+## Versioning
+
+The vocabulary follows the same release cadence as the server (`mcp-server/package.json` version). Adding a value is a *minor* bump. Renaming or removing a value is a *major* bump because connectors and downstream agents may have hard-coded it.

--- a/mcp-server/src/connectors/kubernetes.ts
+++ b/mcp-server/src/connectors/kubernetes.ts
@@ -28,6 +28,7 @@ import {
   type KubeReplicaSet,
   type KubeNamespace,
 } from "./kubernetes-graph.js";
+import { validateSnapshot } from "./topology-vocabulary.js";
 
 // Minimal informer abstraction so the connector is unit-testable without
 // a live cluster. The real implementation in createInformerFactory wraps
@@ -77,6 +78,7 @@ export class KubernetesConnector implements ObservabilityConnector {
 
   name = "";
   private store!: TopologyStore;
+  private warnedVocab = new Set<string>();
   private factory?: InformerFactory;
   private informers: Informer<unknown>[] = [];
   private providerOverride?: InformerFactoryProvider;
@@ -205,14 +207,19 @@ export class KubernetesConnector implements ObservabilityConnector {
     return this.store?.listEdges() ?? [];
   }
   async getTopologySnapshot(): Promise<TopologySnapshot> {
-    return (
-      this.store?.snapshot() ?? {
-        source: this.name,
-        resources: [],
-        edges: [],
-        revision: 0,
-      }
-    );
+    const snap = this.store?.snapshot() ?? {
+      source: this.name,
+      resources: [],
+      edges: [],
+      revision: 0,
+    };
+    for (const w of validateSnapshot(snap.resources, snap.edges)) {
+      const key = `${w.kind}:${w.value}`;
+      if (this.warnedVocab.has(key)) continue;
+      this.warnedVocab.add(key);
+      console.warn("topology vocabulary warning (source=%s): %s", this.name, w.message);
+    }
+    return snap;
   }
   watchTopology(listener: TopologyChangeListener): () => void {
     if (!this.store) return () => {};

--- a/mcp-server/src/connectors/topology-vocabulary.test.ts
+++ b/mcp-server/src/connectors/topology-vocabulary.test.ts
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  KINDS,
+  RELATIONS,
+  isKnownKind,
+  isKnownRelation,
+  validateResource,
+  validateEdge,
+  validateSnapshot,
+} from "./topology-vocabulary.js";
+
+test("vocabulary — KINDS and RELATIONS contain what the kubernetes connector emits today", () => {
+  for (const k of ["pod", "node", "deployment", "replicaset", "namespace"]) {
+    assert.equal(isKnownKind(k), true, `kind "${k}" must be in the canonical vocabulary`);
+  }
+  for (const r of ["RUNS_ON", "OWNED_BY", "IN_NAMESPACE"]) {
+    assert.equal(isKnownRelation(r), true, `relation "${r}" must be in the canonical vocabulary`);
+  }
+});
+
+test("vocabulary — CALLS is reserved for the upcoming trace connector", () => {
+  assert.equal(isKnownRelation("CALLS"), true);
+});
+
+test("validateResource — canonical kinds produce no warnings", () => {
+  for (const k of KINDS) {
+    assert.deepEqual(validateResource({ kind: k }), []);
+  }
+});
+
+test("validateResource — unknown kind warns", () => {
+  const w = validateResource({ kind: "frobnicator" });
+  assert.equal(w.length, 1);
+  assert.equal(w[0].kind, "unknown_resource_kind");
+  assert.equal(w[0].value, "frobnicator");
+});
+
+test("validateResource — uppercase kind triggers a case-mismatch hint", () => {
+  const w = validateResource({ kind: "Pod" });
+  assert.equal(w.length, 1);
+  assert.equal(w[0].kind, "case_mismatch");
+  assert.match(w[0].message, /lowercase "pod"/);
+});
+
+test("validateEdge — canonical relations produce no warnings", () => {
+  for (const r of RELATIONS) {
+    assert.deepEqual(validateEdge({ relation: r }), []);
+  }
+});
+
+test("validateEdge — unknown relation warns", () => {
+  const w = validateEdge({ relation: "FROBNICATES" });
+  assert.equal(w.length, 1);
+  assert.equal(w[0].kind, "unknown_relation");
+});
+
+test("validateEdge — lowercase relation triggers a case-mismatch hint", () => {
+  const w = validateEdge({ relation: "runs_on" });
+  assert.equal(w.length, 1);
+  assert.equal(w[0].kind, "case_mismatch");
+  assert.match(w[0].message, /UPPER_SNAKE "RUNS_ON"/);
+});
+
+test("validateSnapshot — de-duplicates repeated offenders", () => {
+  const warnings = validateSnapshot(
+    [
+      { kind: "frobnicator" },
+      { kind: "frobnicator" },
+      { kind: "pod" },
+    ],
+    [
+      { relation: "FROBNICATES" },
+      { relation: "FROBNICATES" },
+      { relation: "RUNS_ON" },
+    ],
+  );
+  assert.equal(warnings.length, 2, `expected one warning per distinct offender, got ${warnings.length}`);
+});
+
+test("validateSnapshot — a fully canonical snapshot is silent", () => {
+  const warnings = validateSnapshot(
+    [{ kind: "pod" }, { kind: "node" }, { kind: "deployment" }],
+    [{ relation: "RUNS_ON" }, { relation: "OWNED_BY" }, { relation: "IN_NAMESPACE" }],
+  );
+  assert.deepEqual(warnings, []);
+});

--- a/mcp-server/src/connectors/topology-vocabulary.ts
+++ b/mcp-server/src/connectors/topology-vocabulary.ts
@@ -1,0 +1,141 @@
+/**
+ * Canonical vocabulary for the connector-agnostic topology graph.
+ *
+ * The set is intentionally small: only values that are emitted by a shipped
+ * connector OR are reserved as the agreed name for a near-term connector.
+ * Adding a value is a documentation change in docs/topology-vocabulary.md
+ * plus an entry in the const arrays below; never invent a value at the call
+ * site without that paper trail.
+ *
+ * Validation is warn-only by design — a connector that emits an unknown
+ * value still works, but the warning shows up in logs and unit tests so
+ * vocabulary drift gets caught before it spreads.
+ */
+
+import type { Edge, Resource } from "../types.js";
+
+export const KINDS = [
+  "pod",
+  "node",
+  "deployment",
+  "replicaset",
+  "namespace",
+  "service",
+  "container",
+  "vm",
+  "host",
+  "hypervisor",
+  "cluster",
+] as const;
+
+export type Kind = (typeof KINDS)[number];
+
+export const RELATIONS = [
+  "RUNS_ON",
+  "OWNED_BY",
+  "IN_NAMESPACE",
+  "CALLS",
+  "CONTAINS",
+  "DEPENDS_ON",
+] as const;
+
+export type Relation = (typeof RELATIONS)[number];
+
+const KIND_SET = new Set<string>(KINDS);
+const RELATION_SET = new Set<string>(RELATIONS);
+
+export function isKnownKind(k: string): k is Kind {
+  return KIND_SET.has(k);
+}
+
+export function isKnownRelation(r: string): r is Relation {
+  return RELATION_SET.has(r);
+}
+
+export interface VocabularyWarning {
+  kind: "unknown_resource_kind" | "unknown_relation" | "case_mismatch";
+  message: string;
+  value: string;
+}
+
+/**
+ * Lint a single resource. Returns warnings for unknown or miscased `kind`
+ * values; an empty array means the resource passes the vocabulary.
+ */
+export function validateResource(r: Pick<Resource, "kind">): VocabularyWarning[] {
+  const out: VocabularyWarning[] = [];
+  if (!isKnownKind(r.kind)) {
+    const lower = r.kind.toLowerCase();
+    if (isKnownKind(lower)) {
+      out.push({
+        kind: "case_mismatch",
+        value: r.kind,
+        message: `resource kind "${r.kind}" should be lowercase "${lower}" — see docs/topology-vocabulary.md`,
+      });
+    } else {
+      out.push({
+        kind: "unknown_resource_kind",
+        value: r.kind,
+        message: `resource kind "${r.kind}" is not in the canonical vocabulary; either rename or extend docs/topology-vocabulary.md + KINDS`,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Lint a single edge. Returns warnings for unknown or miscased `relation`
+ * values; an empty array means the edge passes the vocabulary.
+ */
+export function validateEdge(e: Pick<Edge, "relation">): VocabularyWarning[] {
+  const out: VocabularyWarning[] = [];
+  if (!isKnownRelation(e.relation)) {
+    const upper = e.relation.toUpperCase();
+    if (isKnownRelation(upper)) {
+      out.push({
+        kind: "case_mismatch",
+        value: e.relation,
+        message: `relation "${e.relation}" should be UPPER_SNAKE "${upper}" — see docs/topology-vocabulary.md`,
+      });
+    } else {
+      out.push({
+        kind: "unknown_relation",
+        value: e.relation,
+        message: `relation "${e.relation}" is not in the canonical vocabulary; either rename or extend docs/topology-vocabulary.md + RELATIONS`,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Convenience: lint a full snapshot. Returns the de-duplicated set of
+ * warnings (one per distinct value) so a noisy connector does not flood
+ * the log on each tick.
+ */
+export function validateSnapshot(
+  resources: Pick<Resource, "kind">[],
+  edges: Pick<Edge, "relation">[],
+): VocabularyWarning[] {
+  const seen = new Set<string>();
+  const out: VocabularyWarning[] = [];
+  for (const r of resources) {
+    for (const w of validateResource(r)) {
+      const key = `r:${w.kind}:${w.value}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        out.push(w);
+      }
+    }
+  }
+  for (const e of edges) {
+    for (const w of validateEdge(e)) {
+      const key = `e:${w.kind}:${w.value}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        out.push(w);
+      }
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
- Pin the connector-agnostic graph contract (`kind` / `relation`) so future topology connectors do not silently drift the surface that `get_topology`, `get_blast_radius`, and the UI consume.
- New `docs/topology-vocabulary.md` enumerates every canonical value with semantics, examples, who emits it, and reserved-for-future entries (`service`, `vm`, `host`, `hypervisor`, …; `CALLS`, `CONTAINS`, `DEPENDS_ON`).
- New `mcp-server/src/connectors/topology-vocabulary.ts` exports `KINDS`, `RELATIONS`, plus warn-only validators. Wired into the kubernetes connector's `getTopologySnapshot`: one `console.warn` per distinct offender per connector lifetime, never blocks.
- `README.md` and `docs/connectors.md` link the vocabulary doc from the topology surface area sections.

## Test plan
- [x] `node:20-alpine` docker run: `npx tsx --test src/connectors/topology-vocabulary.test.ts` — **10/10 pass**
- [x] full suite delta vs `origin/main` is zero (4 pre-existing prom-connection failures are present on both branches)
- [x] `npm run build` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)