### PR TITLE
feat(tempo): derive CALLS service-graph edges from sampled traces (1.1.0)

### DIFF
--- a/connectors/tempo/index.js
+++ b/connectors/tempo/index.js
@@ -66,14 +66,34 @@ const DEFAULT_METRICS = [
 // Accepted aliases → all resolve to the trace-duration series.
 const LATENCY_ALIASES = new Set(["latency", "latency_p99", "duration", "response_time"]);
 
+// Topology cache TTL — Tempo trace data lags real-world calls by tens of
+// seconds anyway, so refreshing more often just burns Tempo API quota.
+const TOPOLOGY_TTL_MS = 30_000;
+// How many recent traces we sample per refresh. Larger = better edge
+// coverage but more /api/traces round-trips. 50 is a defensible compromise
+// for demos and CI; operators can override via source config.
+const DEFAULT_TRACE_SAMPLE = 50;
+// Inferred trace-derived edges carry lower confidence than authoritative
+// k8s ownerReferences edges (1.0). Documented in topology-vocabulary.md.
+const CALLS_CONFIDENCE = 0.7;
+
 export class TempoConnector {
   constructor() {
     this.name = "tempo";
     this.type = "tempo";
+    // Honest reporting: we now emit both — metrics (trace-derived latency)
+    // AND topology (service graph from trace spans). The connector
+    // surface in interface.ts inspects the topology methods, not this
+    // string; `signalType` stays informational.
     this.signalType = "metrics";
     this._metrics = DEFAULT_METRICS;
     this._base = "";
     this._token = "";
+    this._traceSample = DEFAULT_TRACE_SAMPLE;
+    // Memoized topology snapshot — built lazily, refreshed on demand.
+    this._topology = { snap: null, expiresAt: 0, revision: 0 };
+    this._watchers = new Set();
+    this._watchTimer = null;
   }
 
   async connect(config) {
@@ -84,10 +104,18 @@ export class TempoConnector {
     if (Array.isArray(config && config.metrics) && config.metrics.length > 0) {
       this._metrics = config.metrics;
     }
+    const sample = config && Number(config.traceSample);
+    if (Number.isFinite(sample) && sample > 0) {
+      this._traceSample = Math.min(Math.floor(sample), 500);
+    }
   }
 
   async disconnect() {
-    /* stateless */
+    if (this._watchTimer) {
+      clearInterval(this._watchTimer);
+      this._watchTimer = null;
+    }
+    this._watchers.clear();
   }
 
   _headers() {
@@ -169,6 +197,199 @@ export class TempoConnector {
       resolvedSeries: q,
     };
   }
+
+  // --- Topology capability ---
+  //
+  // Tempo does not expose a service-graph endpoint directly — what it
+  // exposes is the raw trace store. We derive the service graph the same
+  // way Grafana's "Service Graph" tab does client-side: sample N recent
+  // traces, walk the span tree, and for every parent → child span pair
+  // where the resource.service.name differs, emit one CALLS edge. Edges
+  // are de-duplicated across the sample so a chatty path does not produce
+  // N copies.
+  //
+  // This is a sampled, eventually-consistent view — confidence < 1.0 on
+  // every edge. See docs/topology-vocabulary.md for the meaning of CALLS
+  // and the confidence convention.
+
+  async _buildTopology() {
+    const services = await this.listServices();
+    const resources = services.map((s) => ({
+      id: serviceId(s.name),
+      kind: "service",
+      name: s.name,
+      source: this.name,
+      labels: {},
+      attributes: {},
+    }));
+    const edgeMap = new Map();
+    let traceIds;
+    try {
+      traceIds = await this._sampleTraceIds();
+    } catch {
+      traceIds = [];
+    }
+    for (const id of traceIds) {
+      let trace;
+      try {
+        trace = await this._fetchTrace(id);
+      } catch {
+        continue;
+      }
+      for (const [from, to] of callPairs(trace)) {
+        if (!from || !to || from === to) continue;
+        const key = `${from}|${to}`;
+        if (edgeMap.has(key)) continue;
+        edgeMap.set(key, {
+          from: serviceId(from),
+          to: serviceId(to),
+          relation: "CALLS",
+          source: this.name,
+          confidence: CALLS_CONFIDENCE,
+        });
+      }
+    }
+    // Make sure every endpoint of an edge appears as a resource — a service
+    // discovered only via a trace span (never returned by listServices)
+    // would otherwise produce a dangling edge that get_topology strips.
+    const have = new Set(resources.map((r) => r.id));
+    for (const e of edgeMap.values()) {
+      for (const id of [e.from, e.to]) {
+        if (have.has(id)) continue;
+        have.add(id);
+        const name = id.replace(/^tempo:service:/, "");
+        resources.push({ id, kind: "service", name, source: this.name, labels: {}, attributes: {} });
+      }
+    }
+    this._topology.revision += 1;
+    return {
+      source: this.name,
+      resources,
+      edges: [...edgeMap.values()],
+      revision: this._topology.revision,
+    };
+  }
+
+  async _refreshIfStale() {
+    const now = Date.now();
+    if (this._topology.snap && now < this._topology.expiresAt) return this._topology.snap;
+    const snap = await this._buildTopology();
+    this._topology.snap = snap;
+    this._topology.expiresAt = now + TOPOLOGY_TTL_MS;
+    return snap;
+  }
+
+  async _sampleTraceIds() {
+    const u = new URL(`${this._base}/api/search`);
+    u.searchParams.set("q", "{}");
+    u.searchParams.set("limit", String(this._traceSample));
+    const res = await fetch(u, { headers: this._headers() });
+    if (!res.ok) return [];
+    const body = await res.json();
+    const traces = (body && body.traces) || [];
+    return traces.map((t) => t && (t.traceID || t.traceId)).filter(Boolean);
+  }
+
+  async _fetchTrace(id) {
+    const res = await fetch(`${this._base}/api/traces/${encodeURIComponent(id)}`, {
+      headers: this._headers(),
+    });
+    if (!res.ok) return null;
+    return res.json();
+  }
+
+  async listResources() {
+    return (await this._refreshIfStale()).resources;
+  }
+
+  async listEdges() {
+    return (await this._refreshIfStale()).edges;
+  }
+
+  async getTopologySnapshot() {
+    return this._refreshIfStale();
+  }
+
+  watchTopology(listener) {
+    this._watchers.add(listener);
+    // Initial resync so subscribers see the current state without racing
+    // the next poll tick — same contract as the k8s connector.
+    queueMicrotask(async () => {
+      try {
+        const snap = await this._refreshIfStale();
+        listener({ type: "resync", snapshot: snap });
+      } catch { /* swallow */ }
+    });
+    if (!this._watchTimer) {
+      this._watchTimer = setInterval(async () => {
+        let snap;
+        try { snap = await this._buildTopology(); } catch { return; }
+        this._topology.snap = snap;
+        this._topology.expiresAt = Date.now() + TOPOLOGY_TTL_MS;
+        for (const l of this._watchers) {
+          try { l({ type: "resync", snapshot: snap }); } catch { /* skip */ }
+        }
+      }, TOPOLOGY_TTL_MS);
+      // Don't keep the event loop alive just for this poller.
+      if (this._watchTimer && typeof this._watchTimer.unref === "function") {
+        this._watchTimer.unref();
+      }
+    }
+    return () => {
+      this._watchers.delete(listener);
+      if (this._watchers.size === 0 && this._watchTimer) {
+        clearInterval(this._watchTimer);
+        this._watchTimer = null;
+      }
+    };
+  }
+}
+
+function serviceId(name) {
+  return `tempo:service:${name}`;
+}
+
+// Walk an OTLP-JSON trace and return [parentService, childService] pairs
+// for every cross-service span edge. Handles both Tempo response shapes:
+// `{batches:[...]}` (newer) and `{trace:{batches:[...]}}` (older wrapper).
+function callPairs(trace) {
+  const batches = (trace && (trace.batches || (trace.trace && trace.trace.batches))) || [];
+  // Build spanId → serviceName once across all batches.
+  const svcOf = new Map();
+  const spans = [];
+  for (const b of batches) {
+    const svc = serviceNameOf(b && b.resource);
+    if (!svc) continue;
+    const scopes = (b && b.scopeSpans) || (b && b.instrumentationLibrarySpans) || [];
+    for (const sc of scopes) {
+      for (const s of sc.spans || []) {
+        if (!s || !s.spanId) continue;
+        svcOf.set(s.spanId, svc);
+        spans.push(s);
+      }
+    }
+  }
+  const pairs = [];
+  for (const s of spans) {
+    const child = svcOf.get(s.spanId);
+    const parentId = s.parentSpanId || s.parentSpanID;
+    if (!parentId) continue;
+    const parent = svcOf.get(parentId);
+    if (!parent || !child || parent === child) continue;
+    pairs.push([parent, child]);
+  }
+  return pairs;
+}
+
+function serviceNameOf(resource) {
+  const attrs = (resource && resource.attributes) || [];
+  for (const a of attrs) {
+    if (!a || a.key !== "service.name") continue;
+    const v = a.value;
+    if (!v) continue;
+    return v.stringValue || (typeof v === "string" ? v : null);
+  }
+  return null;
 }
 
 export default function create() {

--- a/connectors/tempo/index.test.mjs
+++ b/connectors/tempo/index.test.mjs
@@ -86,6 +86,98 @@ test("queryMetrics maps trace durations → seconds, sorted by start time", asyn
   assert.equal(r.summary.min, 0.1);
 });
 
+test("topology — derives CALLS edges from cross-service parent/child spans, dedupes", async () => {
+  const c = create();
+  await c.connect({ url: "http://tempo", traceSample: 2 });
+  const batch = (svc, spans) => ({
+    resource: { attributes: [{ key: "service.name", value: { stringValue: svc } }] },
+    scopeSpans: [{ spans }],
+  });
+  // Same shape, different traces — should produce one CALLS edge frontend→checkout,
+  // not two. Plus a same-service intra-call that must NOT become an edge.
+  const traceOne = {
+    batches: [
+      batch("frontend", [{ spanId: "s1", parentSpanId: "" }]),
+      batch("checkout", [{ spanId: "s2", parentSpanId: "s1" }, { spanId: "s3", parentSpanId: "s2" }]),
+    ],
+  };
+  const traceTwo = {
+    trace: { // older wrapper shape — must still parse
+      batches: [
+        batch("frontend", [{ spanId: "x1", parentSpanId: "" }]),
+        batch("checkout", [{ spanId: "x2", parentSpanId: "x1" }]),
+      ],
+    },
+  };
+  globalThis.fetch = mockFetch([
+    ["/api/v2/search/tag/resource.service.name/values", () =>
+      ok({ tagValues: ["frontend", "checkout"] })],
+    ["/api/search", () => ok({ traces: [{ traceID: "T1" }, { traceID: "T2" }] })],
+    ["/api/traces/T1", () => ok(traceOne)],
+    ["/api/traces/T2", () => ok(traceTwo)],
+  ]);
+  const snap = await c.getTopologySnapshot();
+  assert.equal(snap.source, "tempo");
+  assert.equal(snap.resources.length, 2);
+  assert.deepEqual(snap.resources.map((r) => r.kind).sort(), ["service", "service"]);
+  assert.deepEqual(snap.edges.length, 1);
+  const e = snap.edges[0];
+  assert.equal(e.from, "tempo:service:frontend");
+  assert.equal(e.to, "tempo:service:checkout");
+  assert.equal(e.relation, "CALLS");
+  assert.equal(e.source, "tempo");
+  assert.ok(e.confidence > 0 && e.confidence < 1, "inferred edges carry sub-1.0 confidence");
+});
+
+test("topology — second snapshot call within TTL is served from cache (no extra HTTP)", async () => {
+  const c = create();
+  await c.connect({ url: "http://tempo" });
+  let traceQueries = 0;
+  globalThis.fetch = mockFetch([
+    ["/api/v2/search/tag", () => ok({ tagValues: ["a"] })],
+    ["/api/search", () => { traceQueries += 1; return ok({ traces: [] }); }],
+  ]);
+  await c.getTopologySnapshot();
+  await c.getTopologySnapshot();
+  assert.equal(traceQueries, 1, "second call should hit cache, not Tempo");
+});
+
+test("topology — adds resources for services seen only via spans", async () => {
+  const c = create();
+  await c.connect({ url: "http://tempo" });
+  const b = (svc, spans) => ({
+    resource: { attributes: [{ key: "service.name", value: { stringValue: svc } }] },
+    scopeSpans: [{ spans }],
+  });
+  globalThis.fetch = mockFetch([
+    // listServices only knows "a"; the trace also references "b" — connector
+    // must promote "b" to a Resource so the CALLS edge is not dangling.
+    ["/api/v2/search/tag", () => ok({ tagValues: ["a"] })],
+    ["/api/search", () => ok({ traces: [{ traceID: "t" }] })],
+    ["/api/traces/t", () => ok({ batches: [
+      b("a", [{ spanId: "p", parentSpanId: "" }]),
+      b("b", [{ spanId: "c", parentSpanId: "p" }]),
+    ] })],
+  ]);
+  const snap = await c.getTopologySnapshot();
+  assert.deepEqual(snap.resources.map((r) => r.name).sort(), ["a", "b"]);
+  assert.equal(snap.edges.length, 1);
+  assert.equal(snap.edges[0].to, "tempo:service:b");
+});
+
+test("topology — listResources / listEdges defer to the same snapshot", async () => {
+  const c = create();
+  await c.connect({ url: "http://tempo" });
+  globalThis.fetch = mockFetch([
+    ["/api/v2/search/tag", () => ok({ tagValues: ["s1", "s2"] })],
+    ["/api/search", () => ok({ traces: [] })],
+  ]);
+  const r = await c.listResources();
+  const e = await c.listEdges();
+  assert.equal(r.length, 2);
+  assert.deepEqual(e, []);
+});
+
 test("queryMetrics rejects unknown metrics, drops NaN samples", async () => {
   const c = create();
   await c.connect({ url: "http://tempo" });

--- a/connectors/tempo/manifest.json
+++ b/connectors/tempo/manifest.json
@@ -17,5 +17,6 @@
   },
   "compat": {
     "serverVersion": ">=1.7.0"
-  }
+  },
+  "integrity": "sha256-p43JS48KOAU5wrfvNuCeTsYYO5ArpR3xwvMf+LEQQLw="
 }

--- a/connectors/tempo/manifest.json
+++ b/connectors/tempo/manifest.json
@@ -2,17 +2,20 @@
   "schemaVersion": 1,
   "name": "tempo",
   "displayName": "Grafana Tempo",
-  "version": "1.0.0",
-  "description": "Grafana Tempo connector — OTLP-native tracing backend. Surfaces trace-derived service latency (per-trace duration) via the Tempo TraceQL search API and discovers services from the resource.service.name tag. Optional Bearer auth.",
-  "signalTypes": ["metrics"],
+  "version": "1.1.0",
+  "description": "Grafana Tempo connector — OTLP-native tracing backend. Surfaces trace-derived service latency (per-trace duration) via the TraceQL search API, discovers services from the resource.service.name tag, and derives a service-graph (CALLS edges) by sampling recent traces and walking cross-service parent/child spans. Optional Bearer auth.",
+  "signalTypes": ["metrics", "topology"],
   "homepage": "https://github.com/ThoTischner/observability-mcp",
   "license": "MIT",
   "capabilities": {
     "queryMetrics": true,
-    "listServices": true
+    "listServices": true,
+    "listResources": true,
+    "listEdges": true,
+    "getTopologySnapshot": true,
+    "watchTopology": true
   },
   "compat": {
-    "serverVersion": ">=1.4.0"
-  },
-  "integrity": "sha256-Wpg5LcyUCuGxzM8OPGdVn/4/LmpP4iWrvbsCEp8kMdQ="
+    "serverVersion": ">=1.7.0"
+  }
 }

--- a/connectors/tempo/package.json
+++ b/connectors/tempo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@observability-mcp/connector-tempo",
-  "version": "1.0.0",
-  "description": "Grafana Tempo connector for observability-mcp — trace-derived service latency via the Tempo TraceQL search API.",
+  "version": "1.1.0",
+  "description": "Grafana Tempo connector for observability-mcp — trace-derived service latency + service-graph (CALLS) topology via the Tempo TraceQL search API.",
   "type": "module",
   "main": "./index.js",
   "license": "MIT",

--- a/hub/catalog/index.json
+++ b/hub/catalog/index.json
@@ -127,14 +127,21 @@
     {
       "name": "tempo",
       "displayName": "Grafana Tempo",
-      "description": "Grafana Tempo connector — OTLP-native tracing backend. Surfaces trace-derived service latency via the Tempo TraceQL search API, feeding the same anomaly/health path as a Prometheus latency metric.",
+      "description": "Grafana Tempo connector — OTLP-native tracing backend. Surfaces trace-derived service latency via the TraceQL search API and derives a service-graph (CALLS edges) by walking cross-service parent/child spans across a recent-trace sample.",
       "tier": "official",
       "builtin": false,
       "signalTypes": [
-        "metrics"
+        "metrics",
+        "topology"
       ],
-      "latest": "1.0.0",
+      "latest": "1.1.0",
       "versions": [
+        {
+          "version": "1.1.0",
+          "releasedAt": "2026-05-24",
+          "serverCompat": ">=1.7.0",
+          "changelog": "Adds topology capability: derives CALLS edges between services from a sampled batch of recent Tempo traces (default 50). Snapshots memoized for 30s. Sample size configurable via source config (`traceSample`)."
+        },
         {
           "version": "1.0.0",
           "releasedAt": "2026-05-18",

--- a/hub/catalog/index.json
+++ b/hub/catalog/index.json
@@ -140,6 +140,7 @@
           "version": "1.1.0",
           "releasedAt": "2026-05-24",
           "serverCompat": ">=1.7.0",
+          "integrity": "sha256-p43JS48KOAU5wrfvNuCeTsYYO5ArpR3xwvMf+LEQQLw=",
           "changelog": "Adds topology capability: derives CALLS edges between services from a sampled batch of recent Tempo traces (default 50). Snapshots memoized for 30s. Sample size configurable via source config (`traceSample`)."
         },
         {

--- a/hub/catalog/tempo.json
+++ b/hub/catalog/tempo.json
@@ -12,6 +12,7 @@
       "version": "1.1.0",
       "releasedAt": "2026-05-24",
       "serverCompat": ">=1.7.0",
+      "integrity": "sha256-p43JS48KOAU5wrfvNuCeTsYYO5ArpR3xwvMf+LEQQLw=",
       "changelog": "Adds topology capability: derives CALLS edges between services from a sampled batch of recent Tempo traces (default 50). Snapshots memoized for 30s. Sample size configurable via source config (`traceSample`)."
     },
     {

--- a/hub/catalog/tempo.json
+++ b/hub/catalog/tempo.json
@@ -2,12 +2,18 @@
   "catalogVersion": 1,
   "name": "tempo",
   "displayName": "Grafana Tempo",
-  "description": "Grafana Tempo connector — OTLP-native tracing backend. Surfaces trace-derived service latency via the Tempo TraceQL search API, feeding the same anomaly/health path as a Prometheus latency metric.",
+  "description": "Grafana Tempo connector — OTLP-native tracing backend. Surfaces trace-derived service latency via the TraceQL search API and derives a service-graph (CALLS edges) by walking cross-service parent/child spans across a recent-trace sample.",
   "vendor": "observability-mcp",
   "homepage": "https://github.com/ThoTischner/observability-mcp",
   "tier": "official",
-  "signalTypes": ["metrics"],
+  "signalTypes": ["metrics", "topology"],
   "versions": [
+    {
+      "version": "1.1.0",
+      "releasedAt": "2026-05-24",
+      "serverCompat": ">=1.7.0",
+      "changelog": "Adds topology capability: derives CALLS edges between services from a sampled batch of recent Tempo traces (default 50). Snapshots memoized for 30s. Sample size configurable via source config (`traceSample`)."
+    },
     {
       "version": "1.0.0",
       "releasedAt": "2026-05-18",


### PR DESCRIPTION
## Summary
- Tempo connector now implements the topology capability: samples recent traces, walks span trees, emits one `CALLS` edge per distinct cross-service parent→child pair.
- Closes the biggest competitive gap from the recent peer audit — until now every topology source we ship emits only vertical edges (`RUNS_ON`, `OWNED_BY`); Smartscape / Datadog Service Map / New Relic all have the horizontal call graph from APM.
- Inferred edges carry `confidence=0.7` (vs `1.0` for authoritative k8s ownership) per the convention pinned in `docs/topology-vocabulary.md`.
- Manifest bumped to **1.1.0**, `signalTypes: ["metrics", "topology"]`, `serverCompat: ">=1.7.0"`. Hub catalog entry adds the 1.1.0 row.

## Notes
- Snapshots memoized for 30s; trace sample size defaults to 50, configurable via the source's `traceSample` option.
- Handles both Tempo trace response shapes (`{batches:...}` and older `{trace:{batches:...}}`).
- `watchTopology` polls on the same 30s cadence and `unref`s the timer.
- Old `integrity` hash removed from the source manifest — the publish flow re-stamps it for the new tarball.

## Test plan
- [x] `node --test connectors/tempo/index.test.mjs` — **11/11 pass** (4 new topology tests + 7 pre-existing)
- [x] `node hub/build-catalog.mjs && node --test hub/build-catalog.test.mjs` — **6/6** incl. index-in-sync check
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)