### PR TITLE
feat(benchmark): reproducible RCA A/B harness — topology vs baseline tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,8 @@ flags pass through after a literal `--`.
 - [Troubleshooting](docs/troubleshooting.md) — common pitfalls and fixes
 - [Security](docs/security.md) — automation pipeline, vulnerability reporting, built-in protections
 - [Airgapped deployment](docs/airgapped-deployment.md) — mirroring images, private plugins, GitOps-friendly config
+- [Topology vocabulary](docs/topology-vocabulary.md) — the canonical `kind` / `relation` contract every topology-capable connector emits, plus the warn-only validator
+- [RCA benchmark](docs/benchmark-astronomy-shop.md) — reproducible A/B harness measuring whether `get_topology` + `get_blast_radius` reduce token spend and improve correctness on a fixed RCA prompt
 - [Enterprise access-control gate](docs/enterprise-gate.md) — optional RBAC / catalog / audit behind a signed entitlement token (off by default)
 - [Connector Hub](https://thotischner.github.io/observability-mcp/hub/) — browse versioned, signed connectors (catalog: [`hub/`](hub/README.md))
 - [Use cases](USECASES.md) — five scenarios with the prompts that drive them

--- a/docs/benchmark-astronomy-shop.md
+++ b/docs/benchmark-astronomy-shop.md
@@ -1,0 +1,188 @@
+# Benchmark: does topology context reduce token spend on RCA?
+
+This benchmark measures one question in a controlled way:
+
+> When an LLM has to identify the single root-cause service from a live
+> incident, does giving it `get_topology` + `get_blast_radius` change
+> how many tokens it burns and how often it gets the right answer?
+
+We measure two arms — **baseline** (6 MCP tools: metrics, logs, anomaly
+detection, health, service discovery) and **topology** (same 6 plus
+`get_topology` and `get_blast_radius`). Everything else is identical:
+same prompt, same model, same chaos injection, same chat-loop budget.
+
+The script lives at `scripts/benchmark-rca.mjs`. Both arms run against
+the bundled k3s demo (`docker compose --profile demo up`). Astronomy
+Shop integration is documented separately below as an external overlay
+because shipping a 15-service OTel demo in this repo would dwarf the
+rest of the stack.
+
+> **Honest scope.** This is not a published score-card claim. Numbers
+> below come from one author's WSL2 + Ollama setup. The point of
+> shipping the harness is so anyone can re-run it on their own setup
+> and verify or refute. The methodology, the prompt, the scoring rule,
+> and the demo workload are all in this repo at the SHA below — no
+> proprietary judge model, no hidden prompt tuning.
+
+## Methodology
+
+Per iteration:
+
+1. `POST /chaos/reset` on `payment-service` — clear any prior chaos.
+2. `POST /chaos/error-spike` on `payment-service` — induce a controlled
+   5xx storm. The chaos modes are intentionally correlated (errors also
+   raise CPU and latency and emit error logs) so a competent SRE — or
+   LLM — has multiple signals pointing at the same culprit.
+3. Wait `CHAOS_WINDOW_MS` (default 45 s) so the anomaly is visible to
+   Prometheus / Loki / the topology snapshot.
+4. Send the **fixed RCA prompt** to Ollama:
+
+   > "Production is reporting elevated 5xx errors at the API gateway
+   > over the last few minutes. Your job: identify the single
+   > root-cause service and the failing signal, in two sentences. Use
+   > the available tools."
+
+5. Tool surface depends on `--mode`:
+   - `--mode=baseline` → 6 tools (no topology)
+   - `--mode=topology` → 8 tools (incl. `get_topology`, `get_blast_radius`)
+6. Multi-turn tool calling, up to `MAX_ROUNDS` (default 3). Each tool
+   call goes through MCP `/mcp` Streamable HTTP. Tool results are fed
+   back as `role: "tool"` messages.
+7. When the model produces a final answer (no `tool_calls`), score:
+   - **correctness**: final answer must name `payment-service` AND
+     mention an error / 5xx / error-spike signal.
+   - **tokens**: total `prompt_eval_count + eval_count` summed across
+     every Ollama call in the conversation. Captures per-round context
+     growth, not just the last turn.
+
+### Why crude substring matching for correctness
+
+LLM-as-judge would add another model dependency we'd have to defend.
+Substring matching is hostile to subtle wins — the model might be
+*right* and phrased it differently — but it's transparent, reproducible
+without an API key, and impossible to game by prompt-engineering the
+final answer. Refining the scorer would land as a follow-up.
+
+### Why total tokens, not just prompt tokens
+
+Topology tools are extra context the model has to read on every turn,
+so their cost shows up in `prompt_eval_count` of later rounds. But
+they also (the hypothesis) let the model finish in fewer rounds and
+emit a shorter final answer. The net is what matters, not either side
+in isolation.
+
+## Running it
+
+```bash
+# 1. bring up the demo stack (k3s + Prometheus + Loki + MCP server)
+docker compose --profile demo up -d
+
+# 2. wait for the chaos endpoints to be live
+curl http://localhost:8081/chaos/reset
+
+# 3. make sure Ollama is reachable with the model pulled
+ollama pull llama3.1:8b   # or whatever model you intend to test
+
+# 4. run baseline (no topology)
+node scripts/benchmark-rca.mjs --mode=baseline  --iterations=5 > baseline.json
+
+# 5. run topology
+node scripts/benchmark-rca.mjs --mode=topology  --iterations=5 > topology.json
+```
+
+Defaults assume:
+
+| flag        | default                                    |
+|-------------|--------------------------------------------|
+| `--mcp`     | `http://localhost:3000/mcp`                |
+| `--ollama`  | `http://localhost:11434`                   |
+| `--model`   | `llama3.1:8b`                              |
+| `--chaos`   | `http://localhost:8081`                    |
+| `--target`  | `payment-service`                          |
+| `--window`  | `45000` (ms to wait after chaos trigger)   |
+| `--rounds`  | `3` (max tool-calling rounds)              |
+
+For a head-to-head with the same chaos pattern but a different
+target / model, pass the appropriate flags through.
+
+### Output
+
+The script prints a JSON object per arm with totals and per-iteration
+detail:
+
+```json
+{
+  "mode": "topology",
+  "model": "llama3.1:8b",
+  "iterations": 5,
+  "tools": ["list_sources","list_services","query_metrics","query_logs",
+            "get_service_health","detect_anomalies",
+            "get_topology","get_blast_radius"],
+  "totals": {
+    "tokens": 0,
+    "meanTokensPerIteration": 0,
+    "correctIterations": 0,
+    "accuracy": 0,
+    "meanRounds": 0,
+    "meanDurationMs": 0
+  },
+  "iterations_detail": [...]
+}
+```
+
+Comparing the two arms is a simple `jq` diff:
+
+```bash
+jq '.totals' baseline.json topology.json
+```
+
+## Results
+
+Numbers are populated *only when run with Ollama up*. We deliberately
+do not commit synthetic numbers — the point of the harness is that
+anyone can reproduce a real one. Append your run to this table.
+
+| run date    | model           | iterations | mode      | mean tokens / iter | accuracy | mean rounds | mean duration |
+|-------------|-----------------|------------|-----------|---------------------|----------|-------------|----------------|
+| _example_   | llama3.1:8b     | 5          | baseline  | TBD                 | TBD      | TBD         | TBD            |
+| _example_   | llama3.1:8b     | 5          | topology  | TBD                 | TBD      | TBD         | TBD            |
+
+Open a PR adding a row when you run a head-to-head.
+
+## Why no Astronomy Shop in our compose stack
+
+The OpenTelemetry Demo (Astronomy Shop) is the obvious workload to
+benchmark against: 15 services, real microservice topology, OTel
+instrumentation already wired up. We do **not** bundle it because:
+
+- ~4 GB of images and 15 containers would dwarf our entire demo stack,
+  and most users running this benchmark only need 3 services + chaos
+  to get a comparable A/B.
+- The Astronomy Shop ships its own Prometheus/Grafana/Jaeger; making
+  it cohabit with our k3s-in-compose layout is more compose surgery
+  than the result is worth.
+
+If you want to point this benchmark at Astronomy Shop, use the
+overlay recipe at `examples/benchmark/README.md`. The benchmark script
+itself is backend-agnostic — it talks to MCP, MCP talks to whatever
+Prometheus/Loki/Tempo the operator configured.
+
+## Reproducibility checklist
+
+If you publish numbers, include in your write-up:
+
+- the exact SHA of this repo (so the prompt, the scoring rule, the
+  tool surface, and the chaos pattern are pinned)
+- the Ollama model name + tag
+- iteration count, max rounds, chaos window
+- the full JSON output of both arms
+
+Without those four, a token-saving claim is unverifiable.
+
+## See also
+
+- `docs/topology-vocabulary.md` — the contract the topology tools
+  operate on. Affects what `get_topology` returns and which edges
+  `get_blast_radius` walks.
+- `docs/kubernetes.md` — what the bundled kubernetes connector emits.
+- `examples/benchmark/README.md` — Astronomy Shop overlay recipe.

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -1,0 +1,71 @@
+# Benchmark overlay — pointing the harness at the OpenTelemetry Demo
+
+The benchmark script at `scripts/benchmark-rca.mjs` (see
+`docs/benchmark-astronomy-shop.md` for the methodology) is
+backend-agnostic: it asks MCP, MCP asks whichever
+Prometheus/Loki/Tempo the operator has wired up. So pointing the same
+harness at the OpenTelemetry Demo ("Astronomy Shop") is a matter of
+running their stack alongside ours and re-pointing our MCP sources.
+
+This file is a recipe, not an integrated profile, because the OTel
+Demo is ~15 services / ~4 GB of images — too heavy to belong in this
+repo's compose stack.
+
+## Recipe
+
+```bash
+# 1. Pull and start Astronomy Shop in a separate compose project
+git clone --depth=1 https://github.com/open-telemetry/opentelemetry-demo /tmp/otel-demo
+cd /tmp/otel-demo
+docker compose up -d
+
+# 2. Verify their Prometheus + Grafana are up
+curl http://localhost:9090/api/v1/status/runtimeinfo   # Astronomy Shop's Prometheus
+curl http://localhost:8080                              # the demo frontend
+
+# 3. Point this repo's MCP server at their backends instead of ours
+#    Use the Web UI at http://localhost:3000 → Sources, or edit
+#    mcp-server/config/sources.yaml:
+#
+#    sources:
+#      - name: prom-otel-demo
+#        type: prometheus
+#        url: http://host.docker.internal:9090
+#      - name: tempo-otel-demo
+#        type: tempo
+#        url: http://host.docker.internal:3200
+#
+# 4. Trigger a real incident pattern in the Astronomy Shop. They
+#    expose a feature flags page at http://localhost:8080/feature
+#    — enable e.g. `paymentServiceFailure` or `cartServiceFailure`
+#    for a controlled error spike.
+
+# 5. Run the benchmark, pointing chaos at the feature-flag toggle
+#    instead of our /chaos/error-spike endpoint:
+cd <this repo>
+node scripts/benchmark-rca.mjs \
+  --mode=baseline \
+  --target=paymentservice \
+  --chaos=http://localhost:8080/api/feature \
+  --iterations=5
+```
+
+The `--target` flag changes which service name the correctness scorer
+looks for. The chaos trigger URL is currently hard-coded to
+`POST <chaos>/chaos/error-spike`; if you want to drive feature flags
+instead, that's a one-line patch in `chaosTrigger()`. We deliberately
+have not generalised it because the OTel Demo chaos surface is wholly
+different from our `/chaos/*` endpoints — coupling them would obscure
+which workload produced which numbers.
+
+## Caveats
+
+- Port `8080` collides between Astronomy Shop's frontend and our
+  api-gateway NodePort. Stop our demo (`docker compose stop`) first
+  or remap.
+- Astronomy Shop's Prometheus runs on its own scrape interval; allow
+  a longer `--window` (e.g. 90 000) so the topology snapshot has
+  caught the failure.
+- Astronomy Shop ships Jaeger, not Tempo, by default. The Tempo
+  connector won't have data — switch their `tracing-backend` flag to
+  Tempo or skip the `CALLS`-edge half of the topology test.

--- a/scripts/benchmark-rca.mjs
+++ b/scripts/benchmark-rca.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+// Controlled A/B benchmark: does giving the LLM access to topology tools
+// (get_topology + get_blast_radius) reduce token spend and improve
+// correctness on a basic root-cause-analysis prompt?
+//
+// Methodology
+// -----------
+// For each iteration:
+//   1. POST /chaos/reset                       — clear prior state
+//   2. POST /chaos/error-spike on payment-service
+//   3. Wait CHAOS_WINDOW_MS so the anomaly is visible to MCP
+//   4. Send a fixed RCA prompt to Ollama with the MCP tool surface:
+//        --mode=baseline  → 6 tools (no topology)
+//        --mode=topology  → 8 tools (incl. get_topology, get_blast_radius)
+//   5. Multi-turn tool calling: up to MAX_ROUNDS rounds, each tool call
+//      goes through MCP /mcp Streamable HTTP, results are fed back.
+//   6. When the LLM produces a final answer (no tool_calls), score:
+//        - correctness: did the final answer name "payment-service"
+//          AND mention an error-rate / 5xx / error-spike signal?
+//        - tokens: sum of prompt_eval_count + eval_count across every
+//          Ollama call in the conversation.
+//
+// We measure TOTAL tokens across the whole conversation, not just the
+// final turn — that captures the per-round context growth honestly. Some
+// tool results are large; if topology shrinks how many other tools the
+// agent has to call, that shows up here.
+//
+// Correctness scoring is intentionally crude (substring match). LLM
+// judges add another model dependency we'd have to defend; for a public
+// number we'd rather over-disclose the rule than hide it behind a
+// rubric. See docs/benchmark-astronomy-shop.md.
+
+import { setTimeout as sleep } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+// When this file is imported (e.g. by the unit test), skip the IIFE so
+// the pure helpers can be exercised without spinning up MCP / Ollama.
+const IS_MAIN = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+
+const args = parseArgs(process.argv.slice(2));
+const MODE = args.mode || "baseline";
+const ITERATIONS = +(args.iterations || 3);
+const MCP_URL = args.mcp || "http://localhost:3000/mcp";
+const OLLAMA_URL = args.ollama || "http://localhost:11434";
+const MODEL = args.model || "llama3.1:8b";
+const CHAOS_BASE = args.chaos || "http://localhost:8081";
+const CHAOS_TARGET_SERVICE = args.target || "payment-service";
+const CHAOS_WINDOW_MS = +(args.window || 45_000);
+const MAX_ROUNDS = +(args.rounds || 3);
+const TOPOLOGY_TOOLS = new Set(["get_topology", "get_blast_radius"]);
+
+const RCA_PROMPT = `Production is reporting elevated 5xx errors at the API gateway over the
+last few minutes. Your job: identify the single root-cause service and
+the failing signal, in two sentences. Use the available tools.`;
+
+if (!["baseline", "topology"].includes(MODE)) {
+  die(`--mode must be "baseline" or "topology" (got ${MODE})`);
+}
+
+// Module-level state used by the MCP helpers below. Declared up here so
+// the top-level await IIFE can call into them without tripping TDZ.
+let _sessionId = null;
+
+if (IS_MAIN) (async () => {
+  const tools = await mcpToolsList();
+  const filtered = MODE === "topology" ? tools : tools.filter((t) => !TOPOLOGY_TOOLS.has(t.name));
+  log(`mode=${MODE} model=${MODEL} iterations=${ITERATIONS} tools=${filtered.length} (${filtered.map((t) => t.name).join(",")})`);
+
+  const results = [];
+  for (let i = 1; i <= ITERATIONS; i++) {
+    log(`--- iteration ${i}/${ITERATIONS} ---`);
+    await chaosReset();
+    await chaosTrigger("error-spike");
+    log(`waiting ${CHAOS_WINDOW_MS}ms for anomaly to manifest...`);
+    await sleep(CHAOS_WINDOW_MS);
+    const r = await runOne(filtered);
+    log(`  tokens=${r.tokens} rounds=${r.rounds} correct=${r.correct} duration=${r.durationMs}ms`);
+    results.push(r);
+    await chaosReset();
+  }
+
+  const totalTokens = results.reduce((s, r) => s + r.tokens, 0);
+  const correct = results.filter((r) => r.correct).length;
+  const avgRounds = results.reduce((s, r) => s + r.rounds, 0) / results.length;
+  const avgDuration = results.reduce((s, r) => s + r.durationMs, 0) / results.length;
+  const out = {
+    mode: MODE,
+    model: MODEL,
+    iterations: ITERATIONS,
+    tools: filtered.map((t) => t.name),
+    totals: {
+      tokens: totalTokens,
+      meanTokensPerIteration: Math.round(totalTokens / results.length),
+      correctIterations: correct,
+      accuracy: correct / results.length,
+      meanRounds: +avgRounds.toFixed(2),
+      meanDurationMs: Math.round(avgDuration),
+    },
+    iterations_detail: results,
+  };
+  console.log(JSON.stringify(out, null, 2));
+})().catch((e) => die(e.stack || String(e)));
+
+async function runOne(toolDefs) {
+  const ollamaTools = toolDefs.map((t) => ({
+    type: "function",
+    function: {
+      name: t.name,
+      description: t.description || "",
+      parameters: t.inputSchema || { type: "object", properties: {} },
+    },
+  }));
+  const messages = [
+    { role: "system", content: "You are an SRE diagnosing a live production incident. Be terse and use tools before guessing." },
+    { role: "user", content: RCA_PROMPT },
+  ];
+  const started = Date.now();
+  let totalTokens = 0;
+  let rounds = 0;
+  let finalContent = "";
+  for (let r = 0; r < MAX_ROUNDS + 1; r++) {
+    const resp = await ollamaChat(messages, ollamaTools);
+    if (!resp) break;
+    totalTokens += (resp.prompt_eval_count || 0) + (resp.eval_count || 0);
+    const msg = resp.message || {};
+    if (!msg.tool_calls || msg.tool_calls.length === 0) {
+      finalContent = String(msg.content || "");
+      break;
+    }
+    rounds += 1;
+    messages.push(msg);
+    for (const tc of msg.tool_calls) {
+      const name = tc.function?.name;
+      const argObj = tc.function?.arguments || {};
+      let content;
+      try {
+        const tr = await mcpToolCall(name, argObj);
+        content = (tr.content?.[0]?.text) || JSON.stringify(tr);
+      } catch (e) {
+        content = JSON.stringify({ error: String(e) });
+      }
+      messages.push({ role: "tool", content, tool_name: name });
+    }
+    if (r === MAX_ROUNDS - 1) {
+      // Final round must produce an answer, not more tools.
+      ollamaTools.length = 0;
+    }
+  }
+  return {
+    tokens: totalTokens,
+    rounds,
+    correct: scoreCorrectness(finalContent),
+    durationMs: Date.now() - started,
+    finalAnswer: finalContent.slice(0, 600),
+  };
+}
+
+function scoreCorrectness(text) {
+  const t = (text || "").toLowerCase();
+  const namedTarget = t.includes(CHAOS_TARGET_SERVICE.toLowerCase());
+  const namedSignal = /(error[ -]?spike|error rate|5xx|errors?\b|http 5)/i.test(t);
+  return namedTarget && namedSignal;
+}
+
+async function ollamaChat(messages, tools) {
+  const body = { model: MODEL, messages, stream: false };
+  if (tools.length > 0) body.tools = tools;
+  let res;
+  try {
+    res = await fetch(`${OLLAMA_URL}/api/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (e) {
+    log(`ollama unreachable at ${OLLAMA_URL}: ${e.message || e}`);
+    return null;
+  }
+  if (!res.ok) {
+    log(`ollama error ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    return null;
+  }
+  return res.json();
+}
+
+// --- MCP Streamable HTTP — session-per-iteration --------------------------
+
+async function mcpEnsureSession() {
+  if (_sessionId) return _sessionId;
+  const res = await fetch(MCP_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "benchmark-rca", version: "0.1.0" },
+      },
+    }),
+  });
+  _sessionId = res.headers.get("mcp-session-id");
+  await res.text();
+  if (!_sessionId) die("MCP initialize returned no session id");
+  await fetch(MCP_URL, {
+    method: "POST",
+    headers: mcpHeaders(),
+    body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized", params: {} }),
+  });
+  return _sessionId;
+}
+
+function mcpHeaders() {
+  return {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+    "mcp-session-id": _sessionId,
+  };
+}
+
+async function mcpToolsList() {
+  await mcpEnsureSession();
+  const res = await fetch(MCP_URL, {
+    method: "POST",
+    headers: mcpHeaders(),
+    body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }),
+  });
+  const body = await res.text();
+  return parseSseJson(body)?.result?.tools || [];
+}
+
+async function mcpToolCall(name, argObj) {
+  await mcpEnsureSession();
+  const res = await fetch(MCP_URL, {
+    method: "POST",
+    headers: mcpHeaders(),
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: Math.floor(Math.random() * 1e9),
+      method: "tools/call",
+      params: { name, arguments: argObj },
+    }),
+  });
+  const body = await res.text();
+  const parsed = parseSseJson(body);
+  if (parsed?.error) throw new Error(`MCP error: ${parsed.error.message}`);
+  return parsed?.result || {};
+}
+
+function parseSseJson(raw) {
+  // MCP Streamable HTTP responses arrive either as plain JSON or as a
+  // single SSE event prefixed `data: `. Handle both forms.
+  const text = String(raw || "").trim();
+  if (!text) return null;
+  for (const line of text.split(/\r?\n/)) {
+    const s = line.startsWith("data: ") ? line.slice(6) : line;
+    try { return JSON.parse(s); } catch { /* try next */ }
+  }
+  return null;
+}
+
+// --- Chaos helpers --------------------------------------------------------
+
+async function chaosReset() {
+  try { await fetch(`${CHAOS_BASE}/chaos/reset`, { method: "POST" }); }
+  catch { /* tolerate */ }
+}
+async function chaosTrigger(name) {
+  const res = await fetch(`${CHAOS_BASE}/chaos/${name}`, { method: "POST" });
+  if (!res.ok) die(`chaos trigger ${name} failed: HTTP ${res.status}`);
+}
+
+// --- utilities ------------------------------------------------------------
+
+function parseArgs(argv) {
+  const out = {};
+  for (const a of argv) {
+    if (!a.startsWith("--")) continue;
+    const [k, ...rest] = a.slice(2).split("=");
+    out[k] = rest.length ? rest.join("=") : "true";
+  }
+  return out;
+}
+function log(...m) { console.error(...m); }
+function die(m) { console.error(m); process.exit(1); }
+
+export { parseArgs, parseSseJson, scoreCorrectness };

--- a/scripts/benchmark-rca.test.mjs
+++ b/scripts/benchmark-rca.test.mjs
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { parseArgs, parseSseJson, scoreCorrectness } from "./benchmark-rca.mjs";
+
+test("parseArgs — kv with = and bare flags", () => {
+  const a = parseArgs(["--mode=topology", "--iterations=5", "--verbose"]);
+  assert.equal(a.mode, "topology");
+  assert.equal(a.iterations, "5");
+  assert.equal(a.verbose, "true");
+});
+
+test("parseArgs — ignores positional args", () => {
+  const a = parseArgs(["foo", "--mode=baseline", "bar"]);
+  assert.deepEqual(Object.keys(a).sort(), ["mode"]);
+});
+
+test("parseSseJson — handles plain JSON", () => {
+  const r = parseSseJson('{"jsonrpc":"2.0","id":1,"result":{"ok":true}}');
+  assert.equal(r.result.ok, true);
+});
+
+test("parseSseJson — handles SSE-framed JSON", () => {
+  const r = parseSseJson('event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{"x":42}}\n\n');
+  assert.equal(r.result.x, 42);
+});
+
+test("parseSseJson — null on garbage", () => {
+  assert.equal(parseSseJson(""), null);
+  assert.equal(parseSseJson("not json"), null);
+});
+
+test("scoreCorrectness — true when the target service AND an error signal are named", () => {
+  assert.equal(
+    scoreCorrectness("Root cause: payment-service is throwing 5xx errors after the deploy."),
+    true,
+  );
+  assert.equal(
+    scoreCorrectness("Payment-service shows an error spike of 41% over the last 5 minutes."),
+    true,
+  );
+});
+
+test("scoreCorrectness — false when the target service is missing", () => {
+  assert.equal(
+    scoreCorrectness("The order-service is throwing 5xx errors."),
+    false,
+  );
+});
+
+test("scoreCorrectness — false when no error signal is mentioned", () => {
+  assert.equal(
+    scoreCorrectness("payment-service has elevated CPU usage."),
+    false,
+  );
+});
+
+test("scoreCorrectness — handles empty / null answers", () => {
+  assert.equal(scoreCorrectness(""), false);
+  assert.equal(scoreCorrectness(null), false);
+  assert.equal(scoreCorrectness(undefined), false);
+});


### PR DESCRIPTION
## Summary
- Closes the last open item from the strategic four-point list — proves the topology-via-MCP thesis is **measurable**, even if we don't have published numbers yet.
- `scripts/benchmark-rca.mjs` runs a fixed RCA prompt twice (baseline vs topology tool sets) against the bundled k3s demo with chaos injection, captures total tokens + correctness + rounds.
- `docs/benchmark-astronomy-shop.md` is the methodology: explains the prompt, the scoring rule (transparent substring match, not LLM-as-judge), the default flags, the reproducibility checklist. **Results table is deliberately empty** — we don't commit synthetic numbers.
- `examples/benchmark/README.md` documents the Astronomy Shop external overlay recipe (we don't bundle the 15-service stack — honest about why).

## Notes
- End-to-end smoke-tested inside the compose network: MCP handshake OK, tool enumeration shows 6 vs 8 correctly, chaos trigger fires, harness exits cleanly with `ollama unreachable` when no LLM is up.
- Unit tests cover the pure helpers (`parseArgs`, `parseSseJson`, `scoreCorrectness`).
- Harness exports the helpers + uses a `IS_MAIN` guard so the IIFE only fires when run directly, not on import for tests.

## Test plan
- [x] `node --test scripts/benchmark-rca.test.mjs` — **9/9 pass**
- [x] live smoke inside compose net: MCP handshake + tool list + chaos trigger work; ollama unreachable handled gracefully
- [ ] CI green
- [ ] (post-merge, manual) reproduce numbers with Ollama up and append a row to the doc's results table

🤖 Generated with [Claude Code](https://claude.com/claude-code)