### PR TITLE
docs(readme): lead with the benchmark result + inline MCP config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,50 @@ question instead of juggling N vendor servers and their query languages.*
 
 ---
 
+## Why it matters — measured, not asserted
+
+On a real Kubernetes-platform-team question ("which other pods share a node with
+`payment-service` so we know what else falls over if that node goes down?"), the same
+local model produces wildly different answers depending on the tools you hand it:
+
+| Tools available to the agent (llama3.1:8b, n=10) | Cross-namespace blast-radius accuracy |
+|---|:---:|
+| Generic metric + log + service tools | **0 / 10** &nbsp;— hallucinates the wrong entity type (`prometheus`, `loki`, `kubernetes`) |
+| Same model + `get_topology` + `get_blast_radius` | **10 / 10** &nbsp;— exact correct co-tenant list, every iteration |
+
+Raw JSON for both arms, plus three more scenarios (single-service RCA, in-namespace
+blast radius, scenarios where topology does *not* help), live in
+[docs/benchmark-astronomy-shop.md](docs/benchmark-astronomy-shop.md). The harness is in
+[`scripts/benchmark-rca.mjs`](scripts/benchmark-rca.mjs); re-run with `make benchmark-up && make benchmark-run`.
+
+We don't claim universal speedup — the doc spells out exactly where the topology tools
+help (graph-shaped questions) and where they don't (pure single-metric drill-downs).
+
+---
+
 ## Try it in 10 seconds
 
 ```bash
 npx @thotischner/observability-mcp
 # then open http://localhost:3000
+```
+
+Wire it into Claude Code with one CLI call:
+
+```bash
+claude mcp add observability --transport http http://localhost:3000/mcp
+```
+
+…or commit it to your repo as `.mcp.json` (works the same in Claude Desktop / Cursor):
+
+```json
+{
+  "mcpServers": {
+    "observability": {
+      "transport": { "type": "http", "url": "http://localhost:3000/mcp" }
+    }
+  }
+}
 ```
 
 The server starts with **zero sources**. Add Prometheus/Loki via the Web UI or `PROMETHEUS_URL` / `LOKI_URL` env vars.
@@ -384,7 +423,7 @@ flags pass through after a literal `--`.
 - [Airgapped deployment](docs/airgapped-deployment.md) — mirroring images, private plugins, GitOps-friendly config
 - [Topology vocabulary](docs/topology-vocabulary.md) — the canonical `kind` / `relation` contract every topology-capable connector emits, plus the warn-only validator
 - [RCA benchmark](docs/benchmark-astronomy-shop.md) — reproducible A/B harness; on a cross-namespace blast-radius question (llama3.1:8b, n=10) the baseline tool set scores 0/10 and hallucinates the wrong entity type, the same model with topology tools scores 10/10 deterministically — see the three-scenarios table for the full honest picture
-- [Enterprise access-control gate](docs/enterprise-gate.md) — optional RBAC / catalog / audit behind a signed entitlement token (off by default)
+- [Governance access-control gate](docs/enterprise-gate.md) — optional RBAC / catalog / audit behind a signed entitlement token (off by default)
 - [Connector Hub](https://thotischner.github.io/observability-mcp/hub/) — browse versioned, signed connectors (catalog: [`hub/`](hub/README.md))
 - [Use cases](USECASES.md) — five scenarios with the prompts that drive them
 


### PR DESCRIPTION
## Summary
Reframes the README hero so the value proposition lands above the fold instead of being buried behind 200+ lines of feature bullets.

**New \"Why it matters — measured, not asserted\" section** right after the demo gif:
- Headline grounded in a real platform-team problem (cross-node blast radius).
- Comparison table: same llama3.1:8b, **0/10 with generic tools vs 10/10 with topology tools** (n=10).
- Honest caveat sentence — topology helps graph-shaped questions, not single-metric drill-downs.
- Links to harness + full three-scenarios doc.

**\"Try it in 10 seconds\" inlined**: one-liner CLI + \`.mcp.json\` snippet so a fresh visitor can go from \"interesting\" to \"wired into my agent\" in one scroll.

**One small naming cleanup**: docs link \"Enterprise access-control gate\" → \"Governance access-control gate\" to respect the neutral-naming convention. Underlying file docs/enterprise-gate.md is unchanged (file rename = separate, bigger PR).

## Test plan
- [x] Pre-push review-agent: Quality + Sensitive-data PASS
- [x] Headline claim cross-checked against docs/benchmark-astronomy-shop.md line 190
- [x] \`.mcp.json\` snippet identical to existing \"Using with Claude Code\" section
- [x] No other \"Enterprise … gate\" link occurrences in the README
- [ ] CI: markdown unchanged surface → standard workflows should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)