### PR TITLE
docs(make): connect-claude-code / connect-cursor / doctor targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build up demo down logs test lint smoke clean release-dryrun benchmark-up benchmark-down benchmark-run benchmark-deps
+.PHONY: help build up demo down logs test lint smoke ui-smoke clean release-dryrun benchmark-up benchmark-down benchmark-run benchmark-deps connect-claude-code connect-cursor doctor
 
 # Print every target with its leading-comment description.
 help: ## Show this help
@@ -26,6 +26,61 @@ down: ## Stop everything and remove volumes
 
 logs: ## Tail mcp-server logs
 	docker compose logs -f mcp-server
+
+##@ Connect from your agent
+
+# Host + port the running mcp-server is reachable at. Override with
+#   OMCP_HOST=mcp.internal OMCP_PORT=4444 make connect-claude-code
+# if you've remapped the compose service or are running it behind a proxy.
+OMCP_HOST ?= localhost
+OMCP_PORT ?= 3000
+
+connect-claude-code: ## Print the .mcp.json snippet for Claude Code / Claude Desktop
+	@echo "# Paste into the 'mcpServers' object of your Claude config"
+	@echo "# (Claude Code: claude mcp add observability --transport http http://$(OMCP_HOST):$(OMCP_PORT)/mcp)"
+	@echo "# (Claude Desktop: ~/.config/Claude/claude_desktop_config.json on Linux,"
+	@echo "#  ~/Library/Application Support/Claude/claude_desktop_config.json on macOS)"
+	@echo ""
+	@echo '{'
+	@echo '  "mcpServers": {'
+	@echo '    "observability": {'
+	@echo '      "transport": { "type": "http", "url": "http://$(OMCP_HOST):$(OMCP_PORT)/mcp" }'
+	@echo '    }'
+	@echo '  }'
+	@echo '}'
+
+connect-cursor: ## Print the MCP config snippet for Cursor
+	@echo "# Drop into ~/.cursor/mcp.json (create the file if it doesn't exist)"
+	@echo ""
+	@echo '{'
+	@echo '  "mcpServers": {'
+	@echo '    "observability": {'
+	@echo '      "url": "http://$(OMCP_HOST):$(OMCP_PORT)/mcp"'
+	@echo '    }'
+	@echo '  }'
+	@echo '}'
+
+doctor: ## Quick health check — is the mcp-server reachable on $$OMCP_HOST:$$OMCP_PORT?
+	@printf "Probing http://$(OMCP_HOST):$(OMCP_PORT)/healthz ... "
+	@if curl -fsS --max-time 3 "http://$(OMCP_HOST):$(OMCP_PORT)/healthz" >/dev/null; then \
+	  echo "ok"; \
+	else \
+	  echo "FAIL — is the stack up? Try: make demo"; exit 1; \
+	fi
+	@printf "Probing MCP handshake on /mcp ... "
+	@if curl -fsS --max-time 5 -X POST "http://$(OMCP_HOST):$(OMCP_PORT)/mcp" \
+	  -H "Content-Type: application/json" \
+	  -H "Accept: application/json, text/event-stream" \
+	  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"omcp-doctor","version":"1.0"}}}' \
+	  | grep -q '"serverInfo"'; then \
+	  echo "ok"; \
+	else \
+	  echo "FAIL — server is up but MCP handshake did not return serverInfo"; exit 1; \
+	fi
+	@echo
+	@echo "All good. Wire your agent up with:"
+	@echo "  make connect-claude-code   # Claude Code / Claude Desktop"
+	@echo "  make connect-cursor        # Cursor"
 
 ##@ Verification
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ claude mcp add observability --transport http http://localhost:3000/mcp
 
 The server starts with **zero sources**. Add Prometheus/Loki via the Web UI or `PROMETHEUS_URL` / `LOKI_URL` env vars.
 
+> If you'd rather have the snippets above printed by a Make target — including
+> custom-host / custom-port substitution — use `make connect-claude-code` or
+> `make connect-cursor`. `make doctor` round-trips a real MCP handshake against
+> a running server and tells you what to fix if it can't.
+
 Want the full chaos-engineering demo (Prometheus + Loki + 3 example services + the autonomous agent)? Clone and run:
 
 ```bash


### PR DESCRIPTION
## Summary
Three new onboarding-focused Makefile recipes in a fresh \`##@ Connect from your agent\` help section:

- **\`make connect-claude-code\`** — prints a ready-to-paste \`.mcp.json\` for Claude Code / Claude Desktop, with the OS-specific config file paths in comments and the one-liner CLI form as a reminder.
- **\`make connect-cursor\`** — Cursor variant (flat \`url\` shape).
- **\`make doctor\`** — round-trips a real MCP handshake (\`/healthz\` → initialize JSON-RPC → assert \`serverInfo\` returns). Exits non-zero on failure so scripts/CI can rely on it.

All three honour \`OMCP_HOST\` and \`OMCP_PORT\` overrides:
\`\`\`bash
OMCP_HOST=mcp.internal OMCP_PORT=4444 make connect-claude-code
\`\`\`

README gets a one-paragraph blockquote pointing at the new targets, positioned right after the existing inline snippets so it complements rather than duplicates.

\`.PHONY\` updated to include the three new targets plus the previously-missing \`ui-smoke\`.

## Test plan
- [x] 82 unit tests pass
- [x] Pre-push review-agent: Quality + Sensitive-data PASS
- [x] Local \`make connect-claude-code\` and \`make connect-cursor\` produce valid JSON (verified via python3 -m json.tool)
- [x] \`OMCP_HOST=… OMCP_PORT=… make connect-*\` substitution verified
- [x] \`make doctor\` exits non-zero against an unreachable host
- [ ] CI: standard workflows should pass; new make targets are not in the CI critical path

🤖 Generated with [Claude Code](https://claude.com/claude-code)