### PR TITLE
chore(dist): wider npm keywords, funding link, release verification docs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,3 +66,55 @@ The server is built with the following defaults:
 
 If you operate the server on the public internet, set `MCP_AUTH_TOKEN` and
 front it with a reverse proxy that terminates TLS.
+
+## Verifying releases
+
+Every release artifact ships with build attestations so operators can verify
+it came from this repository's CI before installing it.
+
+### npm package — provenance attestation
+
+```bash
+# Verify the package was built by the published GitHub Actions workflow
+npm view @thotischner/observability-mcp dist-tags
+npm audit signatures @thotischner/observability-mcp
+```
+
+Provenance is also visible on the
+[npm package page](https://www.npmjs.com/package/@thotischner/observability-mcp)
+under the "Provenance" tab.
+
+### Container image — GHCR + scanned
+
+```bash
+# Pull and inspect the source-commit label
+docker pull ghcr.io/thotischner/observability-mcp:latest
+docker image inspect ghcr.io/thotischner/observability-mcp:latest \
+  --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}'
+```
+
+CI scans every image with Trivy before publishing; high-severity CVEs block
+the release.
+
+### Helm chart — GPG-signed
+
+The Helm chart is GPG-signed; the public key is committed at
+[`docs/helm-signing.pub.asc`](docs/helm-signing.pub.asc) and the fingerprint
+is advertised on ArtifactHub via the `artifacthub.io/signKey` annotation.
+
+```bash
+# Add the signing key to your keyring
+curl -sS https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc \
+  | gpg --import
+
+# Verify the .tgz + .prov pair before installing
+helm verify ./observability-mcp-<version>.tgz
+```
+
+### MCP tool surface — `tools/list` is the contract
+
+The server only advertises tools it actually implements. The integration
+smoke test asserts the exact set of advertised tools on every PR (see
+[`.github/workflows/integration.yml`](.github/workflows/integration.yml)).
+If `tools/list` claims a tool, calling it does what the docs say. If a tool
+name is missing from `tools/list`, it does not exist in that build.

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -28,6 +28,10 @@
         "openapi-types": "^12.1.3",
         "tsx": "^4.22.0",
         "typescript": "^6.0.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ThoTischner"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -15,12 +15,29 @@
   },
   "keywords": [
     "mcp",
+    "model-context-protocol",
     "observability",
     "prometheus",
     "loki",
-    "model-context-protocol",
-    "anomaly-detection"
+    "kubernetes",
+    "tempo",
+    "topology",
+    "blast-radius",
+    "anomaly-detection",
+    "incident-response",
+    "root-cause-analysis",
+    "sre",
+    "platform-engineering",
+    "agent",
+    "ai-agent",
+    "llm-tools",
+    "claude",
+    "ollama"
   ],
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/ThoTischner"
+  },
   "bin": {
     "observability-mcp": "./dist/index.js",
     "omcp": "./dist/cli/index.js"


### PR DESCRIPTION
## Summary
Two small but high-leverage launch-prep changes for the npm + ArtifactHub surfaces.

**mcp-server/package.json**
- Expand keywords from 6 → 19. Adds search-relevant terms a new visitor is most likely to type: \`topology\`, \`kubernetes\`, \`tempo\`, \`blast-radius\`, \`incident-response\`, \`root-cause-analysis\`, \`sre\`, \`platform-engineering\`, \`agent\`, \`ai-agent\`, \`llm-tools\`, \`claude\`, \`ollama\`.
- Add a \`funding\` field pointing at \`github.com/sponsors/ThoTischner\`.

**SECURITY.md — new \"Verifying releases\" section**
Copy-pasteable commands so operators can verify supply-chain claims rather than trust them:
- \`npm audit signatures\` for the npm provenance attestation (CI already emits via \`--provenance\`).
- \`docker image inspect … org.opencontainers.image.revision\` to tie an image back to a source commit; Trivy gate documented.
- \`gpg --import\` of the existing chart-signing key (URL matches Chart.yaml \`artifacthub.io/signKey\`) + \`helm verify\` against the .tgz/.prov pair.
- A paragraph re-stating that \`tools/list\` is the authoritative MCP contract and the integration smoke test asserts the exact set on every PR.

## Test plan
- [x] 82 unit tests pass
- [x] Pre-push review-agent: Quality + Sensitive-data PASS
- [x] package.json still parses as JSON
- [x] All new keywords map to features that actually exist (kubernetes connector, tempo bridge, anomaly detection, …)
- [x] SECURITY.md commands cross-checked: npm/helm/gpg verbs exist, signing-key URL matches Chart.yaml
- [ ] CI: standard workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)