### PR TITLE
feat(rbac): role-based access control on the management plane

### DIFF
--- a/mcp-server/src/auth/middleware.ts
+++ b/mcp-server/src/auth/middleware.ts
@@ -12,7 +12,7 @@
  * are no-ops and every existing handler behaves exactly as before.
  */
 
-import type { NextFunction, Request, Response } from "express";
+import type { NextFunction, Request, RequestHandler, Response } from "express";
 
 import { readCookie, verifySession, type SessionPayload, type SessionConfig } from "./session.js";
 
@@ -37,24 +37,24 @@ export interface AuthedRequest extends Request {
  * valid; otherwise leaves it undefined. Always calls `next()`. Mount this
  * globally so every handler can read the identity.
  */
-export function buildSessionAttacher(runtime: AuthRuntime) {
+export function buildSessionAttacher(runtime: AuthRuntime): RequestHandler {
   const sessionCfg = runtime.session;
   // In anonymous mode the secret is meaningless — verifySession would
   // throw on an empty secret — so install a true no-op middleware and
   // skip every per-request branch.
   if (runtime.mode === "anonymous" || !sessionCfg) {
-    return function noopAttacher(_req: AuthedRequest, _res: Response, next: NextFunction): void {
+    return function noopAttacher(_req: Request, _res: Response, next: NextFunction): void {
       next();
     };
   }
-  return function sessionAttacher(req: AuthedRequest, _res: Response, next: NextFunction): void {
+  return function sessionAttacher(req: Request, _res: Response, next: NextFunction): void {
     // verifySession is a pure parse + HMAC verify. It safely returns
     // null on empty / null / malformed input, so call it unconditionally
     // and let the result speak for itself — no attacker-controlled
     // branch decides whether the check runs.
     const raw = readCookie(req.headers.cookie || "");
     const payload = verifySession(raw, sessionCfg);
-    if (payload) req.session = payload;
+    if (payload) (req as AuthedRequest).session = payload;
     next();
   };
 }
@@ -65,13 +65,13 @@ export function buildSessionAttacher(runtime: AuthRuntime) {
  * route or router, NOT globally — paths the operator wants public
  * (login, /api/me, /api/info, /healthz, ...) simply don't register it.
  */
-export function buildRequireSession(runtime: AuthRuntime) {
-  return function requireSession(req: AuthedRequest, res: Response, next: NextFunction): void {
+export function buildRequireSession(runtime: AuthRuntime): RequestHandler {
+  return function requireSession(req: Request, res: Response, next: NextFunction): void {
     if (runtime.mode === "anonymous" || !runtime.session) {
       next();
       return;
     }
-    if (req.session) {
+    if ((req as AuthedRequest).session) {
       next();
       return;
     }

--- a/mcp-server/src/auth/rbac.test.ts
+++ b/mcp-server/src/auth/rbac.test.ts
@@ -1,0 +1,131 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  hasPermission,
+  buildRequirePermission,
+  listGrantedPermissions,
+  DEFAULT_POLICY,
+  type Permission,
+} from "./rbac.js";
+import type { AuthedRequest, AuthRuntime } from "./middleware.js";
+
+function mkReq(roles?: string[]) {
+  return {
+    session: roles
+      ? { sub: "u", name: "u", roles, iat: 0, exp: Date.now() / 1000 + 60 }
+      : undefined,
+  } as AuthedRequest;
+}
+function mkRes() {
+  let statusCode = 0;
+  let body: unknown = null;
+  return {
+    status(c: number) { statusCode = c; return this; },
+    json(b: unknown) { body = b; return this; },
+    get statusCode() { return statusCode; },
+    get body() { return body; },
+  } as unknown as import("express").Response & { statusCode: number; body: unknown };
+}
+
+test("DEFAULT_POLICY — viewer reads but cannot write", () => {
+  assert.equal(hasPermission(["viewer"], "sources", "read"), true);
+  assert.equal(hasPermission(["viewer"], "sources", "write"), false);
+  assert.equal(hasPermission(["viewer"], "sources", "delete"), false);
+});
+
+test("DEFAULT_POLICY — operator writes sources + settings but never deletes", () => {
+  assert.equal(hasPermission(["operator"], "sources", "write"), true);
+  assert.equal(hasPermission(["operator"], "settings", "write"), true);
+  assert.equal(hasPermission(["operator"], "sources", "delete"), false);
+});
+
+test("DEFAULT_POLICY — admin can do everything across every resource", () => {
+  for (const resource of ["sources", "services", "health", "topology", "settings", "connectors", "audit", "users"] as const) {
+    for (const action of ["read", "write", "delete"] as const) {
+      assert.equal(hasPermission(["admin"], resource, action), true, `admin should ${action} ${resource}`);
+    }
+  }
+});
+
+test("hasPermission — empty / missing roles grant nothing", () => {
+  assert.equal(hasPermission(undefined, "sources", "read"), false);
+  assert.equal(hasPermission([], "sources", "read"), false);
+  assert.equal(hasPermission(["unknown-role"], "sources", "read"), false);
+});
+
+test("hasPermission — union of roles is honoured", () => {
+  // A user assigned both viewer and operator gets the operator superset.
+  assert.equal(hasPermission(["viewer", "operator"], "sources", "write"), true);
+});
+
+test("hasPermission — custom policy overrides built-in", () => {
+  const custom: Record<string, Permission[]> = {
+    "incident-commander": [{ resource: "sources", action: "delete" }],
+  };
+  assert.equal(hasPermission(["incident-commander"], "sources", "delete", custom), true);
+  // Built-in admin is NOT in the custom policy → loses its grants.
+  assert.equal(hasPermission(["admin"], "sources", "delete", custom), false);
+});
+
+test("buildRequirePermission — anonymous always allows", () => {
+  const mw = buildRequirePermission({ mode: "anonymous" } as AuthRuntime, "sources", "write");
+  const res = mkRes() as ReturnType<typeof mkRes>;
+  let called = false;
+  mw(mkReq(), res as unknown as import("express").Response, () => { called = true; });
+  assert.equal(called, true);
+  assert.equal(res.statusCode, 0);
+});
+
+test("buildRequirePermission — denies viewer on write", () => {
+  const runtime = { mode: "basic", session: { secret: "x".repeat(48) } } as AuthRuntime;
+  const mw = buildRequirePermission(runtime, "sources", "write");
+  const res = mkRes() as ReturnType<typeof mkRes>;
+  let called = false;
+  mw(mkReq(["viewer"]), res as unknown as import("express").Response, () => { called = true; });
+  assert.equal(called, false);
+  assert.equal(res.statusCode, 403);
+  const body = res.body as Record<string, unknown>;
+  assert.equal(body.code, "OMCP_PERMISSION_DENIED");
+});
+
+test("buildRequirePermission — allows operator on write", () => {
+  const runtime = { mode: "basic", session: { secret: "x".repeat(48) } } as AuthRuntime;
+  const mw = buildRequirePermission(runtime, "sources", "write");
+  const res = mkRes() as ReturnType<typeof mkRes>;
+  let called = false;
+  mw(mkReq(["operator"]), res as unknown as import("express").Response, () => { called = true; });
+  assert.equal(called, true);
+  assert.equal(res.statusCode, 0);
+});
+
+test("buildRequirePermission — denies missing session in basic mode", () => {
+  const runtime = { mode: "basic", session: { secret: "x".repeat(48) } } as AuthRuntime;
+  const mw = buildRequirePermission(runtime, "sources", "read");
+  const res = mkRes() as ReturnType<typeof mkRes>;
+  let called = false;
+  mw(mkReq(), res as unknown as import("express").Response, () => { called = true; });
+  assert.equal(called, false);
+  assert.equal(res.statusCode, 403);
+});
+
+test("listGrantedPermissions — deduplicates across overlapping roles", () => {
+  const p = listGrantedPermissions(["viewer", "operator"]);
+  const keys = p.map((g) => `${g.resource}:${g.action}`);
+  assert.equal(new Set(keys).size, keys.length, "expected no duplicates");
+  // sanity: includes both a viewer-only read and an operator-only write
+  assert.ok(p.some((g) => g.resource === "sources" && g.action === "read"));
+  assert.ok(p.some((g) => g.resource === "sources" && g.action === "write"));
+});
+
+test("listGrantedPermissions — admin lists every (resource, action) once", () => {
+  const p = listGrantedPermissions(["admin"]);
+  // 8 resources * 3 actions = 24 unique entries
+  assert.equal(p.length, 24);
+});
+
+test("DEFAULT_POLICY shape — has the three built-in roles", () => {
+  assert.ok(DEFAULT_POLICY.viewer);
+  assert.ok(DEFAULT_POLICY.operator);
+  assert.ok(DEFAULT_POLICY.admin);
+});

--- a/mcp-server/src/auth/rbac.ts
+++ b/mcp-server/src/auth/rbac.ts
@@ -1,0 +1,143 @@
+/**
+ * Role-based access control for the management plane.
+ *
+ * Roles are simple string identifiers (`viewer`, `operator`, `admin` ship
+ * built-in but the resolver is open-set — a deployment may add any number
+ * of custom roles via OIDC group claims, the local users file, or future
+ * RBAC config).
+ *
+ * Permissions are encoded as `<resource>:<action>` pairs. The permission
+ * table maps each pair to the set of roles that are granted it. A role
+ * with no entries in the table grants nothing.
+ *
+ * Anonymous mode bypasses RBAC entirely — there is no identity to check.
+ * Basic mode runs every mutating /api/* request through `requirePermission`
+ * middleware (mounted in index.ts alongside `requireSession`).
+ */
+
+import type { NextFunction, Response } from "express";
+
+import type { AuthedRequest, AuthRuntime } from "./middleware.js";
+
+export type Action = "read" | "write" | "delete";
+export type Resource =
+  | "sources"
+  | "services"
+  | "health"
+  | "topology"
+  | "settings"
+  | "connectors"
+  | "audit"
+  | "users";
+
+export interface Permission {
+  resource: Resource;
+  action: Action;
+}
+
+/** Built-in default policy. Operators can replace this via OMCP_RBAC_POLICY in a follow-up. */
+export const DEFAULT_POLICY: Record<string, Permission[]> = {
+  viewer: [
+    { resource: "sources", action: "read" },
+    { resource: "services", action: "read" },
+    { resource: "health", action: "read" },
+    { resource: "topology", action: "read" },
+    { resource: "settings", action: "read" },
+    { resource: "connectors", action: "read" },
+    { resource: "audit", action: "read" },
+  ],
+  operator: [
+    // Inherits viewer's read set + write on operational resources.
+    { resource: "sources", action: "read" },
+    { resource: "sources", action: "write" },
+    { resource: "services", action: "read" },
+    { resource: "health", action: "read" },
+    { resource: "health", action: "write" },
+    { resource: "topology", action: "read" },
+    { resource: "settings", action: "read" },
+    { resource: "settings", action: "write" },
+    { resource: "connectors", action: "read" },
+    { resource: "audit", action: "read" },
+  ],
+  admin: [
+    // Full surface — readable + writable + deletable.
+    ...(["sources", "services", "health", "topology", "settings", "connectors", "audit", "users"] as Resource[])
+      .flatMap((r) =>
+        (["read", "write", "delete"] as Action[]).map<Permission>((a) => ({ resource: r, action: a })),
+      ),
+  ],
+};
+
+/** Resolve whether the given role set grants the requested permission. */
+export function hasPermission(
+  roles: string[] | undefined,
+  resource: Resource,
+  action: Action,
+  policy: Record<string, Permission[]> = DEFAULT_POLICY,
+): boolean {
+  if (!roles || roles.length === 0) return false;
+  for (const role of roles) {
+    const grants = policy[role];
+    if (!grants) continue;
+    for (const g of grants) {
+      if (g.resource === resource && g.action === action) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Express middleware factory. Returns a no-op in anonymous mode, otherwise
+ * gates the route on the named permission. Assumes `req.session` has been
+ * attached upstream by `buildSessionAttacher` and any auth requirement has
+ * already been enforced by `buildRequireSession` — so reaching this point
+ * with no session means anonymous mode is active.
+ */
+export function buildRequirePermission(
+  runtime: AuthRuntime,
+  resource: Resource,
+  action: Action,
+  policy: Record<string, Permission[]> = DEFAULT_POLICY,
+) {
+  if (runtime.mode === "anonymous") {
+    return function rbacNoop(_req: AuthedRequest, _res: Response, next: NextFunction): void {
+      next();
+    };
+  }
+  return function rbacGate(req: AuthedRequest, res: Response, next: NextFunction): void {
+    const roles = req.session?.roles;
+    if (hasPermission(roles, resource, action, policy)) {
+      next();
+      return;
+    }
+    res.status(403).json({
+      error: "permission denied",
+      code: "OMCP_PERMISSION_DENIED",
+      required: { resource, action },
+      have: roles ?? [],
+    });
+  };
+}
+
+/** Convenience snapshot for `/api/me` — list every permission the
+ * given role set unlocks. Used by the UI to hide write controls the
+ * current user can't trigger anyway. */
+export function listGrantedPermissions(
+  roles: string[] | undefined,
+  policy: Record<string, Permission[]> = DEFAULT_POLICY,
+): Permission[] {
+  if (!roles || roles.length === 0) return [];
+  const seen = new Set<string>();
+  const out: Permission[] = [];
+  for (const role of roles) {
+    const grants = policy[role];
+    if (!grants) continue;
+    for (const g of grants) {
+      const key = `${g.resource}:${g.action}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(g);
+    }
+  }
+  return out;
+}

--- a/mcp-server/src/auth/rbac.ts
+++ b/mcp-server/src/auth/rbac.ts
@@ -15,7 +15,7 @@
  * middleware (mounted in index.ts alongside `requireSession`).
  */
 
-import type { NextFunction, Response } from "express";
+import type { NextFunction, Request, RequestHandler, Response } from "express";
 
 import type { AuthedRequest, AuthRuntime } from "./middleware.js";
 
@@ -98,14 +98,14 @@ export function buildRequirePermission(
   resource: Resource,
   action: Action,
   policy: Record<string, Permission[]> = DEFAULT_POLICY,
-) {
+): RequestHandler {
   if (runtime.mode === "anonymous") {
-    return function rbacNoop(_req: AuthedRequest, _res: Response, next: NextFunction): void {
+    return function rbacNoop(_req: Request, _res: Response, next: NextFunction): void {
       next();
     };
   }
-  return function rbacGate(req: AuthedRequest, res: Response, next: NextFunction): void {
-    const roles = req.session?.roles;
+  return function rbacGate(req: Request, res: Response, next: NextFunction): void {
+    const roles = (req as AuthedRequest).session?.roles;
     if (hasPermission(roles, resource, action, policy)) {
       next();
       return;

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -950,7 +950,7 @@ async function main() {
 
   // Update an existing source
   app.put("/api/sources/:name", need("sources","write"), async (req, res) => {
-    const oldName = req.params.name;
+    const oldName = String(req.params.name);
     const { name, type, url, enabled, auth, tls } = req.body;
     const existing = registry.getSourceConfigs().find((s) => s.name === oldName);
     if (!existing) {
@@ -977,7 +977,7 @@ async function main() {
 
   // Delete a source
   app.delete("/api/sources/:name", need("sources","delete"), async (req, res) => {
-    const name = req.params.name;
+    const name = String(req.params.name);
     const existing = registry.getSourceConfigs().find((s) => s.name === name);
     if (!existing) {
       res.status(404).json({ error: `Source "${name}" not found` });
@@ -1010,7 +1010,7 @@ async function main() {
 
   // Toggle source enabled/disabled
   app.patch("/api/sources/:name/toggle", need("sources","write"), async (req, res) => {
-    const name = req.params.name;
+    const name = String(req.params.name);
     const existing = registry.getSourceConfigs().find((s) => s.name === name);
     if (!existing) {
       res.status(404).json({ error: `Source "${name}" not found` });
@@ -1139,9 +1139,9 @@ async function main() {
 
   // Get metrics for a source (active metrics or defaults)
   app.get("/api/sources/:name/metrics", (req, res) => {
-    const connector = registry.getByName(req.params.name);
+    const connector = registry.getByName(String(req.params.name));
     if (!connector) {
-      res.status(404).json({ error: `Source "${req.params.name}" not found` });
+      res.status(404).json({ error: `Source "${String(req.params.name)}" not found` });
       return;
     }
     res.json({
@@ -1152,7 +1152,7 @@ async function main() {
 
   // Update metrics for a source
   app.put("/api/sources/:name/metrics", need("sources","write"), async (req, res) => {
-    const name = req.params.name;
+    const name = String(req.params.name);
     const sourceIdx = config.sources.findIndex((s) => s.name === name);
     if (sourceIdx === -1) {
       res.status(404).json({ error: `Source "${name}" not found` });
@@ -1167,7 +1167,7 @@ async function main() {
 
   // Reset a source's metrics to connector defaults
   app.delete("/api/sources/:name/metrics", need("sources","write"), async (req, res) => {
-    const name = req.params.name;
+    const name = String(req.params.name);
     const sourceIdx = config.sources.findIndex((s) => s.name === name);
     if (sourceIdx === -1) {
       res.status(404).json({ error: `Source "${name}" not found` });

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -46,6 +46,12 @@ import {
   type AuthRuntime,
   type AuthedRequest,
 } from "./auth/middleware.js";
+import {
+  buildRequirePermission,
+  listGrantedPermissions,
+  type Resource,
+  type Action,
+} from "./auth/rbac.js";
 import { getPluginLoader } from "./connectors/loader.js";
 import {
   resolveHubCatalogUrl,
@@ -539,6 +545,8 @@ async function main() {
   // there is no string-match-based "is this public?" branch anywhere.
   app.use(buildSessionAttacher(authRuntime));
   const requireSession = buildRequireSession(authRuntime);
+  const need = (resource: Resource, action: Action) =>
+    buildRequirePermission(authRuntime, resource, action);
   // Protected route prefixes. /api/me, /api/auth/*, /api/info,
   // /api/openapi.json deliberately don't appear here — they stay public.
   for (const prefix of [
@@ -671,6 +679,7 @@ async function main() {
       authenticated: true,
       mode: authRuntime.mode,
       user: { sub: sess.sub, name: sess.name, roles: sess.roles ?? [] },
+      permissions: listGrantedPermissions(sess.roles),
       exp: sess.exp,
     });
   });
@@ -811,7 +820,7 @@ async function main() {
   // Only catalog tarballUrls are fetched (no arbitrary URL in the body)
   // to avoid SSRF. The connector persists to PLUGINS_DIR (back it with
   // a PVC on k8s so it survives restarts).
-  app.post("/api/connectors/install", installRateLimit, async (req, res) => {
+  app.post("/api/connectors/install", installRateLimit, need("connectors","write"), async (req, res) => {
     if (process.env.ENABLE_UI_INSTALL !== "true") {
       return res.status(403).json({
         error: "UI install is disabled. Set ENABLE_UI_INSTALL=true and PLUGIN_TRUST_ROOT to enable it.",
@@ -878,6 +887,7 @@ async function main() {
   app.post(
     "/api/connectors/upload",
     installRateLimit,
+    need("connectors", "write"),
     express.raw({ type: "application/octet-stream", limit: "50mb" }),
     async (req, res) => {
       if (process.env.ENABLE_UI_INSTALL !== "true") {
@@ -919,7 +929,7 @@ async function main() {
   );
 
   // Add a new source
-  app.post("/api/sources", installRateLimit, async (req, res) => {
+  app.post("/api/sources", installRateLimit, need("sources","write"), async (req, res) => {
     const { name, type, url, enabled, auth, tls } = req.body;
     if (!name || !type || !url) {
       res.status(400).json({ error: "name, type, and url are required" });
@@ -939,7 +949,7 @@ async function main() {
   });
 
   // Update an existing source
-  app.put("/api/sources/:name", async (req, res) => {
+  app.put("/api/sources/:name", need("sources","write"), async (req, res) => {
     const oldName = req.params.name;
     const { name, type, url, enabled, auth, tls } = req.body;
     const existing = registry.getSourceConfigs().find((s) => s.name === oldName);
@@ -966,7 +976,7 @@ async function main() {
   });
 
   // Delete a source
-  app.delete("/api/sources/:name", async (req, res) => {
+  app.delete("/api/sources/:name", need("sources","delete"), async (req, res) => {
     const name = req.params.name;
     const existing = registry.getSourceConfigs().find((s) => s.name === name);
     if (!existing) {
@@ -979,7 +989,7 @@ async function main() {
   });
 
   // Test a source connection (without saving)
-  app.post("/api/sources/test", installRateLimit, async (req, res) => {
+  app.post("/api/sources/test", installRateLimit, need("sources","write"), async (req, res) => {
     const { name, type, url, enabled, auth, tls } = req.body;
     if (!type || !url) {
       res.status(400).json({ error: "type and url are required" });
@@ -999,7 +1009,7 @@ async function main() {
   });
 
   // Toggle source enabled/disabled
-  app.patch("/api/sources/:name/toggle", async (req, res) => {
+  app.patch("/api/sources/:name/toggle", need("sources","write"), async (req, res) => {
     const name = req.params.name;
     const existing = registry.getSourceConfigs().find((s) => s.name === name);
     if (!existing) {
@@ -1098,7 +1108,7 @@ async function main() {
   });
 
   // Update general settings
-  app.put("/api/settings", (req, res) => {
+  app.put("/api/settings", need("settings","write"), (req, res) => {
     config = { ...config, settings: { ...config.settings, ...req.body } };
     saveConfig(config);
     res.json({ ok: true, settings: config.settings });
@@ -1118,7 +1128,7 @@ async function main() {
     res.json(config.healthThresholds);
   });
 
-  app.put("/api/health-thresholds", (req, res) => {
+  app.put("/api/health-thresholds", need("health","write"), (req, res) => {
     config = { ...config, healthThresholds: { ...config.healthThresholds, ...req.body } };
     applyConfigToRuntime(config, registry);
     saveConfig(config);
@@ -1141,7 +1151,7 @@ async function main() {
   });
 
   // Update metrics for a source
-  app.put("/api/sources/:name/metrics", async (req, res) => {
+  app.put("/api/sources/:name/metrics", need("sources","write"), async (req, res) => {
     const name = req.params.name;
     const sourceIdx = config.sources.findIndex((s) => s.name === name);
     if (sourceIdx === -1) {
@@ -1156,7 +1166,7 @@ async function main() {
   });
 
   // Reset a source's metrics to connector defaults
-  app.delete("/api/sources/:name/metrics", async (req, res) => {
+  app.delete("/api/sources/:name/metrics", need("sources","write"), async (req, res) => {
     const name = req.params.name;
     const sourceIdx = config.sources.findIndex((s) => s.name === name);
     if (sourceIdx === -1) {

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -1333,7 +1333,7 @@
         </div>
       </div>
       <div style="display:grid; grid-template-columns: 1fr 1fr; gap: 16px;">
-        <div class="card"><div class="card-header"><h2>Sources</h2><button class="btn btn-primary btn-sm" onclick="showPage('sources');openAddModal()">+ Add Source</button></div><div id="dash-sources"><div class="empty">Loading...</div></div></div>
+        <div class="card"><div class="card-header"><h2>Sources</h2><button class="btn btn-primary btn-sm" data-rbac="sources:write" onclick="showPage('sources');openAddModal()">+ Add Source</button></div><div id="dash-sources"><div class="empty">Loading...</div></div></div>
         <div class="card"><div class="card-header"><h2>Services</h2></div><div id="dash-services"><div class="empty">Loading...</div></div></div>
       </div>
       <div style="display:grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 16px;">
@@ -1355,7 +1355,7 @@
           <div class="breadcrumb">Console / Observability / <b>Sources</b></div>
           <h1>Data Sources</h1>
         </div>
-        <div class="ph-actions"><button class="btn btn-primary btn-sm" onclick="openAddModal()">+ Add Source</button></div>
+        <div class="ph-actions"><button class="btn btn-primary btn-sm" data-rbac="sources:write" onclick="openAddModal()">+ Add Source</button></div>
       </div>
       <div class="card">
         <div class="card-header"><h2>All sources</h2></div>
@@ -1408,7 +1408,7 @@
           <p class="empty" style="margin:0 0 12px">Install a signed connector <code>.tgz</code> directly — handy for air-gapped environments. The bundle is always verified against the configured trust root before it is loaded.</p>
           <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
             <input type="file" id="conn-upload-file" accept=".tgz,.tar.gz,application/octet-stream">
-            <button class="btn btn-primary btn-sm" onclick="uploadConnector(this)">Upload &amp; install</button>
+            <button class="btn btn-primary btn-sm" data-rbac="connectors:write" onclick="uploadConnector(this)">Upload &amp; install</button>
           </div>
         </div>
       </div>
@@ -1525,8 +1525,8 @@
             </div>
           </div>
           <div style="display:flex; gap:8px; justify-content:flex-end;">
-            <button class="btn btn-ghost btn-sm" onclick="resetSettings()">Reset to Defaults</button>
-            <button class="btn btn-primary btn-sm" id="btn-save-settings" onclick="saveSettings()" disabled>Save Settings</button>
+            <button class="btn btn-ghost btn-sm" data-rbac="settings:write" onclick="resetSettings()">Reset to Defaults</button>
+            <button class="btn btn-primary btn-sm" id="btn-save-settings" data-rbac="settings:write" onclick="saveSettings()" disabled>Save Settings</button>
           </div>
         </div>
 
@@ -1581,8 +1581,8 @@
             <div class="form-group"><label>Degraded above score</label><input type="number" id="ht-bound-degraded" min="0" max="100"></div>
           </div>
           <div style="display:flex; gap:8px; justify-content:flex-end;">
-            <button class="btn btn-ghost btn-sm" onclick="resetHealth()">Reset to Defaults</button>
-            <button class="btn btn-primary btn-sm" id="btn-save-health" onclick="saveHealth()" disabled>Save Thresholds</button>
+            <button class="btn btn-ghost btn-sm" data-rbac="health:write" onclick="resetHealth()">Reset to Defaults</button>
+            <button class="btn btn-primary btn-sm" id="btn-save-health" data-rbac="health:write" onclick="saveHealth()" disabled>Save Thresholds</button>
           </div>
         </div>
 
@@ -1969,18 +1969,41 @@ async function omcpLogout() {
   // Reload the page so any cached in-memory state is dropped.
   location.reload();
 }
+// Identity + granted permissions snapshot, refreshed after sign-in /
+// out. Other code calls omcpCan('sources','write') to decide whether
+// to render write controls. Anonymous mode → window.__omcpMe.permissions
+// is undefined and omcpCan() returns true (no RBAC enforced).
+window.__omcpMe = { authenticated: false, mode: 'anonymous', permissions: null };
+function omcpCan(resource, action) {
+  const me = window.__omcpMe;
+  if (!me || me.mode === 'anonymous') return true;
+  if (!Array.isArray(me.permissions)) return false;
+  return me.permissions.some(p => p.resource === resource && p.action === action);
+}
+function omcpApplyRbacToDom() {
+  // Hide elements marked with data-rbac="resource:action" when the
+  // current user lacks that permission. Idempotent — safe to call on
+  // every render.
+  document.querySelectorAll('[data-rbac]').forEach(el => {
+    const [r, a] = (el.getAttribute('data-rbac') || '').split(':');
+    if (!r || !a) return;
+    el.style.display = omcpCan(r, a) ? '' : 'none';
+  });
+}
 async function omcpSyncIdentity() {
   const badge = document.getElementById('user-badge');
   try {
     const r = await _omcpRawFetch('/api/me');
     if (!r.ok) { if (badge) badge.style.display = 'none'; return; }
     const me = await r.json();
+    window.__omcpMe = me;
     if (me.authenticated && badge) {
       badge.querySelector('.user-name').textContent = me.user.name;
       badge.style.display = '';
     } else if (badge) {
       badge.style.display = 'none';
     }
+    omcpApplyRbacToDom();
   } catch (e) { if (badge) badge.style.display = 'none'; }
 }
 window.addEventListener('DOMContentLoaded', omcpSyncIdentity);


### PR DESCRIPTION
## Summary
Adds the policy resolver, the per-route gate, and the UI hooks that hide write controls users can't trigger anyway. **Anonymous mode is unchanged** — RBAC checks only run in basic mode.

### Backend
- \`mcp-server/src/auth/rbac.ts\` — \`Action\` / \`Resource\` types, \`DEFAULT_POLICY\` (viewer reads-only, operator reads + writes on operational resources, admin 8×3 full surface), \`hasPermission\`, \`buildRequirePermission\`, \`listGrantedPermissions\`.
- \`need(resource, action)\` helper in \`index.ts\` wires the gate onto **11 mutating routes** — sources CRUD + test + toggle + metrics, settings, health-thresholds, connectors install + upload.
- \`/api/me\` now returns the user's permissions for client-side use.
- \`/api/enterprise/*\` intentionally untouched (separate trust model via signed entitlement).

### UI
- \`window.__omcpMe\` snapshot, \`omcpCan(r, a)\` helper.
- \`omcpApplyRbacToDom()\` hides every \`[data-rbac=\"r:a\"]\` element the user lacks the permission for. Idempotent; runs after every identity sync.
- 7 top-level write controls annotated (Add Source ×2, Save / Reset Settings, Save / Reset Thresholds, Upload connector). Per-row source action buttons stay visible — server is the authoritative gate.

## Test plan
- [x] 13 new rbac.test.ts unit tests covering policy shape, role union, custom-policy override, anonymous bypass, allow/deny/missing-session paths, dedup
- [x] Pre-push review-agent caught a missed route (\`/api/connectors/upload\`); fixed
- [x] tsc clean (local docker unavailable; relying on CI)
- [ ] CI: unit + integration + ui-smoke + CodeQL green

🤖 Generated with [Claude Code](https://claude.com/claude-code)