### PR TITLE
feat(audit): tamper-evident management-plane audit log

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,7 +52,7 @@ jobs:
         run: npm ci
       - name: Run tests
         working-directory: ./mcp-server
-        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/connectors/verify.test.ts src/connectors/hub.test.ts src/connectors/install.test.ts src/cli/*.test.ts
+        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/audit/*.test.ts src/connectors/verify.test.ts src/connectors/hub.test.ts src/connectors/install.test.ts src/cli/*.test.ts
       - name: Connector hub catalog (validate + in-sync)
         run: |
           node hub/build-catalog.mjs --check

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ doctor: ## Quick health check — is the mcp-server reachable on $$OMCP_HOST:$$O
 test: ## Run mcp-server unit tests in Docker
 	docker run --rm -w /app -v "$(PWD)/mcp-server:/app" node:20-alpine \
 	  sh -c "npm install --silent --no-audit --no-fund && \
-	         npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts"
+	         npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/audit/*.test.ts"
 
 lint: ## helm lint + tsc --noEmit
 	docker run --rm -v "$(PWD)/helm:/apps" alpine/helm:3.16.2 lint /apps/observability-mcp

--- a/mcp-server/src/audit/log.test.ts
+++ b/mcp-server/src/audit/log.test.ts
@@ -1,0 +1,129 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { AuditLog, verifyChain, chainHash, type AuditEntry } from "./log.js";
+
+function sample(seq: number, prevHash: string): AuditEntry {
+  const base = {
+    ts: `2026-05-28T00:00:${String(seq).padStart(2, "0")}Z`,
+    seq,
+    prevHash,
+    actor: { sub: "alice" },
+    resource: "sources",
+    action: "write",
+    method: "POST",
+    path: "/api/sources",
+    status: 200,
+  };
+  const hash = chainHash(base);
+  return { ...base, hash };
+}
+
+test("AuditLog in-memory — record + list", async () => {
+  const log = new AuditLog();
+  await log.record({
+    actor: { sub: "alice", name: "Alice" },
+    resource: "sources",
+    action: "write",
+    method: "POST",
+    path: "/api/sources",
+    status: 200,
+  });
+  await log.record({
+    actor: { sub: "bob" },
+    resource: "settings",
+    action: "write",
+    method: "PUT",
+    path: "/api/settings",
+    status: 200,
+  });
+  const entries = log.list();
+  assert.equal(entries.length, 2);
+  // Most recent first.
+  assert.equal(entries[0].actor.sub, "bob");
+  assert.equal(entries[1].actor.sub, "alice");
+  // Chain is intact: prevHash of entry 2 equals hash of entry 1
+  // (entries[1] is the FIRST chronologically here).
+  assert.equal(entries[0].prevHash, entries[1].hash);
+});
+
+test("AuditLog — list filters by actor + action + window", async () => {
+  const log = new AuditLog();
+  await log.record({ actor: { sub: "alice" }, resource: "sources", action: "write", method: "POST", path: "/api/sources", status: 200 });
+  await log.record({ actor: { sub: "bob" },   resource: "sources", action: "delete", method: "DELETE", path: "/api/sources/x", status: 200 });
+  await log.record({ actor: { sub: "alice" }, resource: "settings", action: "write", method: "PUT", path: "/api/settings", status: 200 });
+
+  assert.equal(log.list({ actor: "alice" }).length, 2);
+  assert.equal(log.list({ action: "delete" }).length, 1);
+  assert.equal(log.list({ actor: "bob", action: "delete" }).length, 1);
+  // Empty window → nothing
+  assert.equal(log.list({ from: "2099-01-01", to: "2099-12-31" }).length, 0);
+});
+
+test("AuditLog — in-memory ring honours cap", async () => {
+  const log = new AuditLog({ inMemoryCap: 3 });
+  for (let i = 0; i < 10; i++) {
+    await log.record({ actor: { sub: `u${i}` }, resource: "sources", action: "write", method: "POST", path: "/api/sources", status: 200 });
+  }
+  const entries = log.list({ limit: 100 });
+  assert.equal(entries.length, 3);
+  // Only the three most recent should survive.
+  assert.deepEqual(entries.map((e) => e.actor.sub), ["u9", "u8", "u7"]);
+});
+
+test("AuditLog — file mode persists and bootstraps", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "omcp-audit-"));
+  const file = join(dir, "audit.jsonl");
+  try {
+    const log1 = new AuditLog({ file });
+    await log1.bootstrap();
+    await log1.record({ actor: { sub: "alice" }, resource: "sources", action: "write", method: "POST", path: "/api/sources", status: 200 });
+    await log1.record({ actor: { sub: "alice" }, resource: "sources", action: "write", method: "POST", path: "/api/sources", status: 200 });
+    // Allow the write queue to flush.
+    await new Promise((r) => setTimeout(r, 30));
+
+    const raw = await readFile(file, "utf8");
+    const lines = raw.trim().split("\n");
+    assert.equal(lines.length, 2);
+
+    // Restart: bootstrap should pick up seq + lastHash.
+    const log2 = new AuditLog({ file });
+    await log2.bootstrap();
+    assert.equal(log2.nextSeq, 3, "expected nextSeq to resume at 3 after replay");
+    const next = await log2.record({ actor: { sub: "alice" }, resource: "sources", action: "write", method: "POST", path: "/api/sources", status: 200 });
+    assert.equal(next.seq, 3);
+    // prevHash chain continued from the replayed tip.
+    const firstChain = JSON.parse(lines[0]) as AuditEntry;
+    const secondChain = JSON.parse(lines[1]) as AuditEntry;
+    assert.equal(secondChain.prevHash, firstChain.hash);
+    assert.equal(next.prevHash, secondChain.hash);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("verifyChain — accepts a clean chain", () => {
+  const e1 = sample(1, "0".repeat(64));
+  const e2 = sample(2, e1.hash);
+  const r = verifyChain([e1, e2]);
+  assert.deepEqual(r, { ok: true });
+});
+
+test("verifyChain — rejects a flipped prevHash", () => {
+  const e1 = sample(1, "0".repeat(64));
+  const e2 = { ...sample(2, e1.hash), prevHash: "deadbeef".repeat(8) };
+  const r = verifyChain([e1, e2]);
+  assert.equal(r.ok, false);
+  if (!r.ok) assert.equal(r.brokenAt, 1);
+});
+
+test("verifyChain — rejects an entry whose hash doesn't match its content", () => {
+  const e1 = sample(1, "0".repeat(64));
+  // Tamper with `actor` AFTER hashing.
+  const e1Tampered = { ...e1, actor: { sub: "mallory" } };
+  const r = verifyChain([e1Tampered]);
+  assert.equal(r.ok, false);
+});

--- a/mcp-server/src/audit/log.ts
+++ b/mcp-server/src/audit/log.ts
@@ -1,0 +1,176 @@
+/**
+ * Append-only audit log for the management plane.
+ *
+ * Distinct from the enterprise-gate audit (`enterprise/audit/`) which
+ * records every gated MCP tool call. This one records every mutating
+ * `/api/*` request (sources/settings/health-thresholds/connectors)
+ * so an operator can answer "who changed what, when".
+ *
+ * On-disk format is JSONL with one entry per line. Each line includes
+ * `prevHash` and `hash` (SHA-256 over the canonical JSON of the entry
+ * without the hash field itself, plus the previous hash) — a
+ * tamper-evident chain that `scripts/verify-audit.mjs` can walk.
+ *
+ * In-memory mode (no `OMCP_MGMT_AUDIT_FILE`) keeps the last
+ * `inMemoryCap` entries in a ring buffer so the UI's audit tab still
+ * shows something even without persistence configured. This is the
+ * default in the demo / single-user case.
+ */
+
+import { createHash } from "node:crypto";
+import { appendFile, readFile } from "node:fs/promises";
+
+export interface AuditEntry {
+  /** RFC-3339 UTC timestamp. */
+  ts: string;
+  /** Monotonically-increasing per-process sequence number. */
+  seq: number;
+  /** Identity that triggered the change. "anonymous" when auth is off. */
+  actor: { sub: string; name?: string };
+  /** Logical resource + action, mirrors the RBAC vocabulary. */
+  resource: string;
+  action: string;
+  /** Full request method + path for easy reading in the UI. */
+  method: string;
+  path: string;
+  /** HTTP status code emitted by the gated handler. */
+  status: number;
+  /** Source IP, best-effort (honours X-Forwarded-For when trust-proxy is set). */
+  ip?: string;
+  /** Optional resource identifier extracted from the path (`:name` param). */
+  target?: string;
+  /** Tamper-evident chain. */
+  prevHash: string;
+  hash: string;
+}
+
+export interface AuditLogConfig {
+  /** Absolute path to a JSONL file. When undefined, the log lives in
+   * memory only. */
+  file?: string;
+  /** How many recent entries to keep in memory regardless of file mode. */
+  inMemoryCap?: number;
+}
+
+export const DEFAULT_IN_MEMORY_CAP = 500;
+const GENESIS_HASH = "0".repeat(64);
+
+export class AuditLog {
+  private readonly cap: number;
+  private readonly file: string | undefined;
+  private ring: AuditEntry[] = [];
+  private lastHash: string = GENESIS_HASH;
+  private seq = 0;
+  private writeQueue: Promise<void> = Promise.resolve();
+  private bootstrapped: Promise<void> | null = null;
+
+  constructor(cfg: AuditLogConfig = {}) {
+    this.cap = cfg.inMemoryCap ?? DEFAULT_IN_MEMORY_CAP;
+    this.file = cfg.file;
+  }
+
+  /**
+   * If a file is configured, replay it to recover seq + lastHash so a
+   * server restart picks up the chain exactly where it left off.
+   * Safe to call multiple times — bootstraps once and caches.
+   */
+  async bootstrap(): Promise<void> {
+    if (!this.file) return;
+    if (this.bootstrapped) return this.bootstrapped;
+    this.bootstrapped = (async () => {
+      let raw: string;
+      try {
+        raw = await readFile(this.file!, "utf8");
+      } catch {
+        return; // first run, fine
+      }
+      for (const line of raw.split("\n")) {
+        const t = line.trim();
+        if (!t) continue;
+        try {
+          const entry = JSON.parse(t) as AuditEntry;
+          if (typeof entry.seq === "number") this.seq = Math.max(this.seq, entry.seq);
+          if (typeof entry.hash === "string") this.lastHash = entry.hash;
+          if (this.ring.length === this.cap) this.ring.shift();
+          this.ring.push(entry);
+        } catch {
+          // skip malformed line — don't fail boot on a single corrupt entry
+        }
+      }
+    })();
+    return this.bootstrapped;
+  }
+
+  /**
+   * Record an event. Returns the canonical entry (with chain fields)
+   * once enqueued; persistence to disk completes asynchronously.
+   */
+  async record(input: Omit<AuditEntry, "ts" | "seq" | "prevHash" | "hash">): Promise<AuditEntry> {
+    if (this.bootstrapped) await this.bootstrapped;
+    this.seq += 1;
+    const ts = new Date().toISOString();
+    const base = { ts, seq: this.seq, prevHash: this.lastHash, ...input };
+    const hash = chainHash(base);
+    const entry: AuditEntry = { ...base, hash };
+    this.lastHash = hash;
+    if (this.ring.length === this.cap) this.ring.shift();
+    this.ring.push(entry);
+    if (this.file) {
+      const file = this.file;
+      // Serialize disk writes so concurrent records don't interleave bytes.
+      this.writeQueue = this.writeQueue.then(() =>
+        appendFile(file, JSON.stringify(entry) + "\n", "utf8").catch(() => {
+          // intentionally swallow — losing a single audit line is
+          // strictly better than crashing the management plane.
+        }),
+      );
+    }
+    return entry;
+  }
+
+  /** Snapshot of the in-memory ring (most recent last). */
+  list(opts: { from?: string; to?: string; actor?: string; action?: string; limit?: number } = {}): AuditEntry[] {
+    const lim = Math.max(1, Math.min(opts.limit ?? 100, this.cap));
+    const out: AuditEntry[] = [];
+    for (let i = this.ring.length - 1; i >= 0 && out.length < lim; i--) {
+      const e = this.ring[i];
+      if (opts.from && e.ts < opts.from) continue;
+      if (opts.to && e.ts > opts.to) continue;
+      if (opts.actor && e.actor.sub !== opts.actor) continue;
+      if (opts.action && e.action !== opts.action) continue;
+      out.push(e);
+    }
+    return out;
+  }
+
+  /** For verification scripts. */
+  get tipHash(): string { return this.lastHash; }
+  get nextSeq(): number { return this.seq + 1; }
+}
+
+/** Stable hash of an entry-without-hash, against `prevHash` already present. */
+export function chainHash(entryWithoutHash: Omit<AuditEntry, "hash">): string {
+  // Canonical JSON: sort keys alphabetically so the digest is reproducible
+  // independent of insertion order.
+  const canonical = JSON.stringify(entryWithoutHash, Object.keys(entryWithoutHash).sort());
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+/** Walk a JSONL file end-to-end and confirm every entry's hash matches
+ * the chain. Used by the offline verifier CLI. */
+export function verifyChain(entries: AuditEntry[]): { ok: true } | { ok: false; brokenAt: number; reason: string } {
+  let prev = GENESIS_HASH;
+  for (let i = 0; i < entries.length; i++) {
+    const e = entries[i];
+    if (e.prevHash !== prev) {
+      return { ok: false, brokenAt: i, reason: `prevHash mismatch (expected ${prev}, got ${e.prevHash})` };
+    }
+    const { hash: _ignored, ...without } = e;
+    const expectedHash = chainHash(without);
+    if (e.hash !== expectedHash) {
+      return { ok: false, brokenAt: i, reason: `hash mismatch (expected ${expectedHash}, got ${e.hash})` };
+    }
+    prev = e.hash;
+  }
+  return { ok: true };
+}

--- a/mcp-server/src/audit/log.ts
+++ b/mcp-server/src/audit/log.ts
@@ -150,10 +150,29 @@ export class AuditLog {
 
 /** Stable hash of an entry-without-hash, against `prevHash` already present. */
 export function chainHash(entryWithoutHash: Omit<AuditEntry, "hash">): string {
-  // Canonical JSON: sort keys alphabetically so the digest is reproducible
-  // independent of insertion order.
-  const canonical = JSON.stringify(entryWithoutHash, Object.keys(entryWithoutHash).sort());
-  return createHash("sha256").update(canonical).digest("hex");
+  // Canonical JSON: recursively sort keys so the digest is reproducible
+  // independent of insertion order. Cannot use JSON.stringify's
+  // string-array replacer here — that one filters at every level, which
+  // would strip nested properties (e.g. actor.sub) and collapse two
+  // distinct entries to the same canonical form.
+  return createHash("sha256").update(canonicalJson(entryWithoutHash)).digest("hex");
+}
+
+/** Deterministic JSON for hashing — keys sorted at every depth.
+ * Mirrors JSON.stringify's "drop undefined values" rule so a freshly-
+ * recorded entry and a round-tripped JSON.parse() of the same entry
+ * (which silently drops undefineds) hash identically. */
+function canonicalJson(v: unknown): string {
+  if (v === undefined) return ""; // caller must filter at the parent level
+  if (v === null || typeof v !== "object") return JSON.stringify(v);
+  if (Array.isArray(v)) return "[" + v.map((x) => canonicalJson(x ?? null)).join(",") + "]";
+  const o = v as Record<string, unknown>;
+  const keys = Object.keys(o).filter((k) => o[k] !== undefined).sort();
+  return "{" +
+    keys
+      .map((k) => JSON.stringify(k) + ":" + canonicalJson(o[k]))
+      .join(",") +
+    "}";
 }
 
 /** Walk a JSONL file end-to-end and confirm every entry's hash matches

--- a/mcp-server/src/audit/middleware.ts
+++ b/mcp-server/src/audit/middleware.ts
@@ -1,0 +1,56 @@
+/**
+ * Express middleware that records one audit entry per mutating
+ * /api/* request after the response has been sent. Skips read-only
+ * methods. In anonymous mode the actor is reported as
+ * `anonymous`; in basic mode the session's sub/name are used.
+ */
+
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+
+import type { AuthedRequest } from "../auth/middleware.js";
+import { AuditLog } from "./log.js";
+
+const MUTATING = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+export interface AuditMiddlewareConfig {
+  audit: AuditLog;
+  resource: string;
+  action: string;
+}
+
+/**
+ * Build a per-route audit middleware. Pairs cleanly with the RBAC
+ * `need(resource, action)` calls already on the route — pass the same
+ * (resource, action) pair so the audit entry matches the policy
+ * decision that just ran.
+ */
+export function buildAuditMiddleware(cfg: AuditMiddlewareConfig): RequestHandler {
+  return function audit(req: Request, res: Response, next: NextFunction): void {
+    if (!MUTATING.has(req.method)) {
+      next();
+      return;
+    }
+    res.on("finish", () => {
+      const sess = (req as AuthedRequest).session;
+      const target = typeof req.params?.name === "string" ? req.params.name : undefined;
+      cfg.audit
+        .record({
+          actor: sess
+            ? { sub: sess.sub, name: sess.name }
+            : { sub: "anonymous" },
+          resource: cfg.resource,
+          action: cfg.action,
+          method: req.method,
+          path: req.path,
+          status: res.statusCode,
+          ip: req.ip || undefined,
+          target,
+        })
+        .catch(() => {
+          // record() already swallows file errors — this catch only
+          // covers the synchronous Promise wiring.
+        });
+    });
+    next();
+  };
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -52,6 +52,8 @@ import {
   type Resource,
   type Action,
 } from "./auth/rbac.js";
+import { AuditLog } from "./audit/log.js";
+import { buildAuditMiddleware } from "./audit/middleware.js";
 import { getPluginLoader } from "./connectors/loader.js";
 import {
   resolveHubCatalogUrl,
@@ -547,6 +549,15 @@ async function main() {
   const requireSession = buildRequireSession(authRuntime);
   const need = (resource: Resource, action: Action) =>
     buildRequirePermission(authRuntime, resource, action);
+
+  // Management-plane audit log. Records one entry per mutating /api/*
+  // request. Writes JSONL to disk when OMCP_MGMT_AUDIT_FILE is set;
+  // otherwise an in-memory ring of the last 500 entries keeps the
+  // /api/audit endpoint useful in the demo / single-user case.
+  const mgmtAudit = new AuditLog({ file: process.env.OMCP_MGMT_AUDIT_FILE });
+  await mgmtAudit.bootstrap();
+  const audit = (resource: string, action: string) =>
+    buildAuditMiddleware({ audit: mgmtAudit, resource, action });
   // Protected route prefixes. /api/me, /api/auth/*, /api/info,
   // /api/openapi.json deliberately don't appear here — they stay public.
   for (const prefix of [
@@ -682,6 +693,23 @@ async function main() {
       permissions: listGrantedPermissions(sess.roles),
       exp: sess.exp,
     });
+  });
+
+  // --- /api/audit — management-plane audit feed -------------------------
+  // Read-only, gated by the "audit:read" permission so only viewers /
+  // operators / admins (basically anyone authenticated in the default
+  // policy) can pull it. Supports optional ?from, ?to (RFC-3339), ?actor,
+  // ?action, ?limit (default 100, capped to ring size).
+  app.get("/api/audit", need("audit", "read"), (req, res) => {
+    const q = req.query as Record<string, string | undefined>;
+    const entries = mgmtAudit.list({
+      from: q.from,
+      to: q.to,
+      actor: q.actor,
+      action: q.action,
+      limit: q.limit ? parseInt(q.limit, 10) : undefined,
+    });
+    res.json({ entries, tipHash: mgmtAudit.tipHash, persisted: !!process.env.OMCP_MGMT_AUDIT_FILE });
   });
 
   // --- /api/auth/* — login + logout for basic mode -----------------------
@@ -820,7 +848,7 @@ async function main() {
   // Only catalog tarballUrls are fetched (no arbitrary URL in the body)
   // to avoid SSRF. The connector persists to PLUGINS_DIR (back it with
   // a PVC on k8s so it survives restarts).
-  app.post("/api/connectors/install", installRateLimit, need("connectors","write"), async (req, res) => {
+  app.post("/api/connectors/install", installRateLimit, need("connectors","write"), audit("connectors","write"), async (req, res) => {
     if (process.env.ENABLE_UI_INSTALL !== "true") {
       return res.status(403).json({
         error: "UI install is disabled. Set ENABLE_UI_INSTALL=true and PLUGIN_TRUST_ROOT to enable it.",
@@ -887,7 +915,7 @@ async function main() {
   app.post(
     "/api/connectors/upload",
     installRateLimit,
-    need("connectors", "write"),
+    need("connectors", "write"), audit("connectors","write"),
     express.raw({ type: "application/octet-stream", limit: "50mb" }),
     async (req, res) => {
       if (process.env.ENABLE_UI_INSTALL !== "true") {
@@ -929,7 +957,7 @@ async function main() {
   );
 
   // Add a new source
-  app.post("/api/sources", installRateLimit, need("sources","write"), async (req, res) => {
+  app.post("/api/sources", installRateLimit, need("sources","write"), audit("sources","write"), async (req, res) => {
     const { name, type, url, enabled, auth, tls } = req.body;
     if (!name || !type || !url) {
       res.status(400).json({ error: "name, type, and url are required" });
@@ -949,7 +977,7 @@ async function main() {
   });
 
   // Update an existing source
-  app.put("/api/sources/:name", need("sources","write"), async (req, res) => {
+  app.put("/api/sources/:name", need("sources","write"), audit("sources","write"), async (req, res) => {
     const oldName = String(req.params.name);
     const { name, type, url, enabled, auth, tls } = req.body;
     const existing = registry.getSourceConfigs().find((s) => s.name === oldName);
@@ -976,7 +1004,7 @@ async function main() {
   });
 
   // Delete a source
-  app.delete("/api/sources/:name", need("sources","delete"), async (req, res) => {
+  app.delete("/api/sources/:name", need("sources","delete"), audit("sources","delete"), async (req, res) => {
     const name = String(req.params.name);
     const existing = registry.getSourceConfigs().find((s) => s.name === name);
     if (!existing) {
@@ -989,7 +1017,7 @@ async function main() {
   });
 
   // Test a source connection (without saving)
-  app.post("/api/sources/test", installRateLimit, need("sources","write"), async (req, res) => {
+  app.post("/api/sources/test", installRateLimit, need("sources","write"), audit("sources","write"), async (req, res) => {
     const { name, type, url, enabled, auth, tls } = req.body;
     if (!type || !url) {
       res.status(400).json({ error: "type and url are required" });
@@ -1009,7 +1037,7 @@ async function main() {
   });
 
   // Toggle source enabled/disabled
-  app.patch("/api/sources/:name/toggle", need("sources","write"), async (req, res) => {
+  app.patch("/api/sources/:name/toggle", need("sources","write"), audit("sources","write"), async (req, res) => {
     const name = String(req.params.name);
     const existing = registry.getSourceConfigs().find((s) => s.name === name);
     if (!existing) {
@@ -1108,7 +1136,7 @@ async function main() {
   });
 
   // Update general settings
-  app.put("/api/settings", need("settings","write"), (req, res) => {
+  app.put("/api/settings", need("settings","write"), audit("settings","write"), (req, res) => {
     config = { ...config, settings: { ...config.settings, ...req.body } };
     saveConfig(config);
     res.json({ ok: true, settings: config.settings });
@@ -1128,7 +1156,7 @@ async function main() {
     res.json(config.healthThresholds);
   });
 
-  app.put("/api/health-thresholds", need("health","write"), (req, res) => {
+  app.put("/api/health-thresholds", need("health","write"), audit("health","write"), (req, res) => {
     config = { ...config, healthThresholds: { ...config.healthThresholds, ...req.body } };
     applyConfigToRuntime(config, registry);
     saveConfig(config);
@@ -1151,7 +1179,7 @@ async function main() {
   });
 
   // Update metrics for a source
-  app.put("/api/sources/:name/metrics", need("sources","write"), async (req, res) => {
+  app.put("/api/sources/:name/metrics", need("sources","write"), audit("sources","write"), async (req, res) => {
     const name = String(req.params.name);
     const sourceIdx = config.sources.findIndex((s) => s.name === name);
     if (sourceIdx === -1) {
@@ -1166,7 +1194,7 @@ async function main() {
   });
 
   // Reset a source's metrics to connector defaults
-  app.delete("/api/sources/:name/metrics", need("sources","write"), async (req, res) => {
+  app.delete("/api/sources/:name/metrics", need("sources","write"), audit("sources","write"), async (req, res) => {
     const name = String(req.params.name);
     const sourceIdx = config.sources.findIndex((s) => s.name === name);
     if (sourceIdx === -1) {

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -1746,6 +1746,15 @@ curl -X PUT http://localhost:3000/api/enterprise/catalog \
         </h2></div>
         <div id="ent-audit"><div class="empty">Loading…</div></div>
       </div>
+      <div class="card mt-4">
+        <div class="card-header"><h2>Management changes
+          <button class="info" aria-label="About management audit"
+            data-title="Management audit"
+            data-info="Append-only hash-chained log of every mutating /api/* request (source / setting / health-threshold / connector changes). When OMCP_MGMT_AUDIT_FILE is set the log persists across restarts; otherwise it is an in-memory ring of the last 500 entries."
+            onclick="infoPop(this)">?</button>
+        </h2></div>
+        <div id="mgmt-audit"><div class="empty">Loading…</div></div>
+      </div>
     </div>
 
     <!-- ===== Governance: Entitlement ===== -->
@@ -2349,6 +2358,27 @@ async function loadEnterprise(){
       box.querySelectorAll('[data-aud]').forEach(el=>el.addEventListener('click',()=>audDetail(el.getAttribute('data-aud'))));
     }
   }catch{ document.getElementById('ent-audit').innerHTML='<div class="empty">Audit unavailable.</div>'; }
+  // Management-plane audit (separate feed from the enterprise gate).
+  try{
+    const r=await fetch('/api/audit?limit=50');
+    if(!r.ok) throw new Error('http '+r.status);
+    const a=await r.json();
+    const box=document.getElementById('mgmt-audit');
+    const entries=a.entries||[];
+    if(entries.length===0){
+      box.innerHTML='<div class="empty">No management changes recorded yet.</div>';
+    } else {
+      const rows=entries.map(e=>
+        `<tr><td class="mono">${e.seq}</td><td class="mono t-sm">${escHtml(e.ts)}</td><td>${escHtml(e.actor.name||e.actor.sub)}</td><td><span class="chip">${escHtml(e.method)}</span> <span class="mono t-sm">${escHtml(e.path)}</span></td><td>${escHtml(e.resource)}:${escHtml(e.action)}</td><td class="mono">${e.status}</td></tr>`
+      ).join('');
+      const note=a.persisted?'':' · in-memory only — set OMCP_MGMT_AUDIT_FILE for persistence';
+      box.innerHTML=`<div class="t-muted t-sm mb-2">${entries.length} entries${escHtml(note)}</div>
+        <table class="dtable"><thead><tr><th>#</th><th>When</th><th>Actor</th><th>Request</th><th>Permission</th><th>Status</th></tr></thead><tbody>${rows}</tbody></table>`;
+    }
+  }catch(e){
+    const box=document.getElementById('mgmt-audit');
+    if(box) box.innerHTML='<div class="empty">Management audit unavailable.</div>';
+  }
 }
 // ---- Minimal YAML for the flat policy/catalog schema (maps, string
 // arrays, booleans, strings). Optional alternative view to the form. ----


### PR DESCRIPTION
## Summary
Append-only audit log for the \`/api/*\` management plane. Records one entry per mutating request (resource + action + actor + method + path + status + IP + target). Persists JSONL to \`OMCP_MGMT_AUDIT_FILE\`; in-memory ring (500 entries) when unset so the demo still shows something.

### Backend
- \`audit/log.ts\` — \`AuditLog\` with append + bootstrap (replays the file on restart so seq + hash chain resume), \`list()\` filters (from/to/actor/action/limit), \`chainHash()\` over canonical-JSON-minus-hash, \`verifyChain()\` walker.
- \`audit/middleware.ts\` — fires on \`res.on(\"finish\")\` so the entry reflects the real HTTP status. Skips non-mutating methods.
- \`index.ts\`: \`await mgmtAudit.bootstrap()\` at startup. \`audit(resource, action)\` helper inserted after \`need(...)\` on **11 mutating routes**. New \`GET /api/audit\` gated by \`need(\"audit\",\"read\")\`.

### UI
- New \"Management changes\" card on the existing Audit Log page. Table view + \"in-memory only\" warning when no persistence configured.

### Tests
- 7 new \`audit/log.test.ts\`: in-memory record/list, filters, ring cap, file persist + bootstrap-on-restart, verifyChain accept + reject-prevHash + reject-content.

The existing enterprise-gate audit (MCP-tool decisions) is unaffected — separate plane.

## Test plan
- [x] Pre-push review-agent: PASS with confirmation that \`mgmtAudit.bootstrap()\` IS awaited at line 558
- [x] DEFAULT_POLICY confirmed to grant \`audit:read\` to viewer, operator, admin
- [x] CI globs updated (security.yml + Makefile)
- [ ] CI green (unit + integration + ui-smoke + CodeQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)