### PR TITLE
feat(catalog): service catalog backend + MCP tool enrichment

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,7 +52,7 @@ jobs:
         run: npm ci
       - name: Run tests
         working-directory: ./mcp-server
-        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/audit/*.test.ts src/connectors/verify.test.ts src/connectors/hub.test.ts src/connectors/install.test.ts src/cli/*.test.ts
+        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/connectors/verify.test.ts src/connectors/hub.test.ts src/connectors/install.test.ts src/cli/*.test.ts
       - name: Connector hub catalog (validate + in-sync)
         run: |
           node hub/build-catalog.mjs --check

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ doctor: ## Quick health check — is the mcp-server reachable on $$OMCP_HOST:$$O
 test: ## Run mcp-server unit tests in Docker
 	docker run --rm -w /app -v "$(PWD)/mcp-server:/app" node:20-alpine \
 	  sh -c "npm install --silent --no-audit --no-fund && \
-	         npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/audit/*.test.ts"
+	         npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts"
 
 lint: ## helm lint + tsc --noEmit
 	docker run --rm -v "$(PWD)/helm:/apps" alpine/helm:3.16.2 lint /apps/observability-mcp

--- a/mcp-server/src/auth/rbac.test.ts
+++ b/mcp-server/src/auth/rbac.test.ts
@@ -41,7 +41,7 @@ test("DEFAULT_POLICY — operator writes sources + settings but never deletes", 
 });
 
 test("DEFAULT_POLICY — admin can do everything across every resource", () => {
-  for (const resource of ["sources", "services", "health", "topology", "settings", "connectors", "audit", "users"] as const) {
+  for (const resource of ["sources", "services", "health", "topology", "settings", "connectors", "audit", "catalog", "users"] as const) {
     for (const action of ["read", "write", "delete"] as const) {
       assert.equal(hasPermission(["admin"], resource, action), true, `admin should ${action} ${resource}`);
     }
@@ -120,8 +120,8 @@ test("listGrantedPermissions — deduplicates across overlapping roles", () => {
 
 test("listGrantedPermissions — admin lists every (resource, action) once", () => {
   const p = listGrantedPermissions(["admin"]);
-  // 8 resources * 3 actions = 24 unique entries
-  assert.equal(p.length, 24);
+  // 9 resources * 3 actions = 27 unique entries
+  assert.equal(p.length, 27);
 });
 
 test("DEFAULT_POLICY shape — has the three built-in roles", () => {

--- a/mcp-server/src/auth/rbac.ts
+++ b/mcp-server/src/auth/rbac.ts
@@ -28,6 +28,7 @@ export type Resource =
   | "settings"
   | "connectors"
   | "audit"
+  | "catalog"
   | "users";
 
 export interface Permission {
@@ -45,6 +46,7 @@ export const DEFAULT_POLICY: Record<string, Permission[]> = {
     { resource: "settings", action: "read" },
     { resource: "connectors", action: "read" },
     { resource: "audit", action: "read" },
+    { resource: "catalog", action: "read" },
   ],
   operator: [
     // Inherits viewer's read set + write on operational resources.
@@ -58,10 +60,11 @@ export const DEFAULT_POLICY: Record<string, Permission[]> = {
     { resource: "settings", action: "write" },
     { resource: "connectors", action: "read" },
     { resource: "audit", action: "read" },
+    { resource: "catalog", action: "read" },
   ],
   admin: [
     // Full surface — readable + writable + deletable.
-    ...(["sources", "services", "health", "topology", "settings", "connectors", "audit", "users"] as Resource[])
+    ...(["sources", "services", "health", "topology", "settings", "connectors", "audit", "catalog", "users"] as Resource[])
       .flatMap((r) =>
         (["read", "write", "delete"] as Action[]).map<Permission>((a) => ({ resource: r, action: a })),
       ),

--- a/mcp-server/src/catalog/loader.test.ts
+++ b/mcp-server/src/catalog/loader.test.ts
@@ -1,0 +1,99 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { readCatalogFile, validateCatalog, CatalogStore } from "./loader.js";
+
+test("readCatalogFile — missing path returns empty catalog", async () => {
+  const c = await readCatalogFile(undefined);
+  assert.deepEqual(c, { services: {} });
+});
+
+test("readCatalogFile — missing file returns empty catalog (no crash)", async () => {
+  const c = await readCatalogFile("/tmp/definitely-does-not-exist-omcp.json");
+  assert.deepEqual(c, { services: {} });
+});
+
+test("readCatalogFile — malformed JSON returns empty catalog", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "omcp-catalog-"));
+  try {
+    const file = join(dir, "catalog.json");
+    await writeFile(file, "{this is not json", "utf8");
+    const c = await readCatalogFile(file);
+    assert.deepEqual(c, { services: {} });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("readCatalogFile — valid file returns parsed catalog", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "omcp-catalog-"));
+  try {
+    const file = join(dir, "catalog.json");
+    await writeFile(
+      file,
+      JSON.stringify({
+        services: {
+          "payment-service": {
+            owner: "team-payments",
+            tier: "tier-1",
+            dataClassification: "confidential",
+            slo: "99.9%",
+            runbooks: ["https://runbooks.example/payments"],
+            tags: ["pci", "regulated"],
+          },
+        },
+      }),
+      "utf8",
+    );
+    const c = await readCatalogFile(file);
+    assert.equal(c.services["payment-service"].owner, "team-payments");
+    assert.equal(c.services["payment-service"].tier, "tier-1");
+    assert.deepEqual(c.services["payment-service"].tags, ["pci", "regulated"]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("validateCatalog — rejects invalid tier values", () => {
+  const c = validateCatalog({ services: { svc: { tier: "tier-9" } } });
+  assert.equal(c.services.svc.tier, undefined);
+});
+
+test("validateCatalog — rejects invalid data classification", () => {
+  const c = validateCatalog({ services: { svc: { dataClassification: "ultra-secret" } } });
+  assert.equal(c.services.svc.dataClassification, undefined);
+});
+
+test("validateCatalog — strips non-string entries from runbooks / tags", () => {
+  const c = validateCatalog({
+    services: { svc: { runbooks: ["a", 1, "b", null], tags: [{}, "tag1"] } },
+  });
+  assert.deepEqual(c.services.svc.runbooks, ["a", "b"]);
+  assert.deepEqual(c.services.svc.tags, ["tag1"]);
+});
+
+test("validateCatalog — skips non-object service entries", () => {
+  const c = validateCatalog({ services: { svc1: "string", svc2: null, svc3: { owner: "team" } } });
+  assert.equal(c.services.svc1, undefined);
+  assert.equal(c.services.svc2, undefined);
+  assert.equal(c.services.svc3.owner, "team");
+});
+
+test("CatalogStore — get / list / count / replace", () => {
+  const store = new CatalogStore({
+    services: {
+      a: { owner: "team-a" },
+      b: { owner: "team-b" },
+    },
+  });
+  assert.equal(store.count(), 2);
+  assert.equal(store.get("a")?.owner, "team-a");
+  assert.equal(store.get("nope"), undefined);
+  assert.equal(Object.keys(store.list()).length, 2);
+  store.replace({ services: { x: { owner: "team-x" } } });
+  assert.equal(store.count(), 1);
+  assert.equal(store.get("x")?.owner, "team-x");
+});

--- a/mcp-server/src/catalog/loader.ts
+++ b/mcp-server/src/catalog/loader.ts
@@ -1,0 +1,121 @@
+/**
+ * Service catalog: an operator-curated map of service name → ownership /
+ * criticality / on-call metadata. Hooked into the existing /api/services
+ * and /api/health responses so the UI (and the agent through the MCP
+ * tools that derive from those endpoints) can see "this is owned by
+ * team-payments, criticality tier-1, on-call URL …" without having to
+ * cross-reference an external CMDB.
+ *
+ * On-disk format: JSON file (commit-friendly, easy to diff in PRs). Path
+ * defaults to `mcp-server/config/catalog.json`; override via
+ * `OMCP_SERVICE_CATALOG_FILE`. Missing or malformed file => no catalog
+ * (the server boots fine, enrichment is a no-op).
+ *
+ * Distinct from the enterprise-gate `OMCP_CATALOG` "product catalog"
+ * which lives behind the entitlement gate and governs MCP-tool grants —
+ * different trust model, different schema.
+ */
+
+import { promises as fs } from "node:fs";
+
+export type CriticalityTier = "tier-1" | "tier-2" | "tier-3" | "tier-4";
+export type DataClassification = "public" | "internal" | "confidential" | "restricted";
+
+export interface ServiceCatalogEntry {
+  /** Stable short owner identifier — team slug, squad, individual handle. */
+  owner?: string;
+  /** Human-readable description. One sentence. */
+  description?: string;
+  /** Page-the-team URL — Slack channel, on-call rota, runbook index. */
+  onCall?: string;
+  /** Operator-defined criticality bucket. */
+  tier?: CriticalityTier;
+  /** Data classification of what flows through the service. */
+  dataClassification?: DataClassification;
+  /** Free-form SLO label ("99.9% / month" / "99.5%"). Not parsed. */
+  slo?: string;
+  /** Optional list of relevant runbook URLs. */
+  runbooks?: string[];
+  /** Optional list of free-form tags. */
+  tags?: string[];
+}
+
+export interface ServiceCatalog {
+  /** Map service name → entry. Service-name key is the same string
+   * `list_services` returns; no fuzzy matching. */
+  services: Record<string, ServiceCatalogEntry>;
+}
+
+const EMPTY_CATALOG: ServiceCatalog = { services: {} };
+const VALID_TIERS = new Set<CriticalityTier>(["tier-1", "tier-2", "tier-3", "tier-4"]);
+const VALID_CLASS = new Set<DataClassification>(["public", "internal", "confidential", "restricted"]);
+
+/** Read + validate a catalog file. Returns the empty catalog on any
+ * problem and (when configured) emits a single warn-level console.error
+ * so the operator notices but the server keeps booting. */
+export async function readCatalogFile(path: string | undefined): Promise<ServiceCatalog> {
+  if (!path) return EMPTY_CATALOG;
+  let raw: string;
+  try {
+    raw = await fs.readFile(path, "utf8");
+  } catch {
+    return EMPTY_CATALOG;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    console.error(`[catalog] OMCP_SERVICE_CATALOG_FILE=${path} is not valid JSON: ${(e as Error).message}`);
+    return EMPTY_CATALOG;
+  }
+  return validateCatalog(parsed);
+}
+
+/** Pure validator — useful in tests and when feeding in-memory data. */
+export function validateCatalog(input: unknown): ServiceCatalog {
+  if (!input || typeof input !== "object") return EMPTY_CATALOG;
+  const obj = input as Record<string, unknown>;
+  const rawServices = obj.services;
+  if (!rawServices || typeof rawServices !== "object") return EMPTY_CATALOG;
+  const out: Record<string, ServiceCatalogEntry> = {};
+  for (const [name, value] of Object.entries(rawServices as Record<string, unknown>)) {
+    if (!value || typeof value !== "object") continue;
+    const e = value as Record<string, unknown>;
+    const entry: ServiceCatalogEntry = {};
+    if (typeof e.owner === "string") entry.owner = e.owner;
+    if (typeof e.description === "string") entry.description = e.description;
+    if (typeof e.onCall === "string") entry.onCall = e.onCall;
+    if (typeof e.tier === "string" && VALID_TIERS.has(e.tier as CriticalityTier)) {
+      entry.tier = e.tier as CriticalityTier;
+    }
+    if (typeof e.dataClassification === "string" && VALID_CLASS.has(e.dataClassification as DataClassification)) {
+      entry.dataClassification = e.dataClassification as DataClassification;
+    }
+    if (typeof e.slo === "string") entry.slo = e.slo;
+    if (Array.isArray(e.runbooks)) {
+      entry.runbooks = e.runbooks.filter((x): x is string => typeof x === "string");
+    }
+    if (Array.isArray(e.tags)) {
+      entry.tags = e.tags.filter((x): x is string => typeof x === "string");
+    }
+    out[name] = entry;
+  }
+  return { services: out };
+}
+
+/** Lookup wrapper used by the enricher / API handlers. */
+export class CatalogStore {
+  constructor(private catalog: ServiceCatalog = EMPTY_CATALOG) {}
+  get(serviceName: string): ServiceCatalogEntry | undefined {
+    return this.catalog.services[serviceName];
+  }
+  list(): Record<string, ServiceCatalogEntry> {
+    return this.catalog.services;
+  }
+  count(): number {
+    return Object.keys(this.catalog.services).length;
+  }
+  replace(catalog: ServiceCatalog): void {
+    this.catalog = catalog;
+  }
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -177,8 +177,12 @@ async function main() {
   // parse as JSON. The HTTP `/api/services` + `/api/health` handlers
   // call the loader.ts CatalogStore directly; this path mirrors that
   // behaviour for MCP clients (Claude Desktop, the agent, ...).
-  type McpToolText = { content: Array<{ text: string; type?: string }> };
-  function enrichToolServicesText(result: McpToolText): McpToolText {
+  // McpToolResult is whatever the wrapped handler returned — keep it
+  // untyped so we don't fight the SDK's narrow `content: [{type:"text",...}]`
+  // overload. We pass the value back unchanged when it doesn't parse,
+  // and otherwise mutate the parsed JSON before re-stringifying into a
+  // fresh wrapper that mirrors the handler's own shape.
+  function enrichToolServicesText<T extends { content: Array<{ text: string }> }>(result: T): T {
     try {
       const parsed = JSON.parse(result.content[0]?.text ?? "{}");
       if (parsed && Array.isArray(parsed.services)) {
@@ -187,17 +191,19 @@ async function main() {
           if (entry) s.catalog = entry;
         }
       }
-      return { content: [{ ...result.content[0], text: JSON.stringify(parsed) }] };
+      const clone = { ...result, content: result.content.map((c, i) => i === 0 ? { ...c, text: JSON.stringify(parsed) } : c) };
+      return clone as T;
     } catch {
       return result;
     }
   }
-  function enrichToolHealthText(result: McpToolText, serviceName: string): McpToolText {
+  function enrichToolHealthText<T extends { content: Array<{ text: string }> }>(result: T, serviceName: string): T {
     try {
       const parsed = JSON.parse(result.content[0]?.text ?? "{}");
       const entry = serviceName ? catalog.get(serviceName) : undefined;
       if (entry && parsed && typeof parsed === "object") parsed.catalog = entry;
-      return { content: [{ ...result.content[0], text: JSON.stringify(parsed) }] };
+      const clone = { ...result, content: result.content.map((c, i) => i === 0 ? { ...c, text: JSON.stringify(parsed) } : c) };
+      return clone as T;
     } catch {
       return result;
     }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -54,6 +54,7 @@ import {
 } from "./auth/rbac.js";
 import { AuditLog } from "./audit/log.js";
 import { buildAuditMiddleware } from "./audit/middleware.js";
+import { readCatalogFile, CatalogStore } from "./catalog/loader.js";
 import { getPluginLoader } from "./connectors/loader.js";
 import {
   resolveHubCatalogUrl,
@@ -169,6 +170,39 @@ async function main() {
   // so we cannot share a single McpServer across HTTP sessions. Each new
   // session needs its own server. The factory captures the live registry
   // by reference so tool handlers always see the current configuration.
+  // Catalog enrichers for the MCP tool surface: wrap the standard
+  // tool-result shape ({content:[{text: json}]}) and inject .catalog
+  // metadata where it matches a known service name. No-op when the
+  // catalog is empty (the demo case) or when the payload doesn't
+  // parse as JSON. The HTTP `/api/services` + `/api/health` handlers
+  // call the loader.ts CatalogStore directly; this path mirrors that
+  // behaviour for MCP clients (Claude Desktop, the agent, ...).
+  type McpToolText = { content: Array<{ text: string; type?: string }> };
+  function enrichToolServicesText(result: McpToolText): McpToolText {
+    try {
+      const parsed = JSON.parse(result.content[0]?.text ?? "{}");
+      if (parsed && Array.isArray(parsed.services)) {
+        for (const s of parsed.services) {
+          const entry = typeof s?.name === "string" ? catalog.get(s.name) : undefined;
+          if (entry) s.catalog = entry;
+        }
+      }
+      return { content: [{ ...result.content[0], text: JSON.stringify(parsed) }] };
+    } catch {
+      return result;
+    }
+  }
+  function enrichToolHealthText(result: McpToolText, serviceName: string): McpToolText {
+    try {
+      const parsed = JSON.parse(result.content[0]?.text ?? "{}");
+      const entry = serviceName ? catalog.get(serviceName) : undefined;
+      if (entry && parsed && typeof parsed === "object") parsed.catalog = entry;
+      return { content: [{ ...result.content[0], text: JSON.stringify(parsed) }] };
+    } catch {
+      return result;
+    }
+  }
+
   function createMcpServer(ctx: RequestContext): McpServer {
     const mcpServer = new McpServer({
       name: "observability-mcp",
@@ -210,7 +244,8 @@ async function main() {
     },
     async (args) => {
       await enforceEntitledAccess(ctx, { tool: "list_services" });
-      return withToolMetrics("list_services", () => listServicesHandler(registry, args, ctx));
+      const result = await withToolMetrics("list_services", () => listServicesHandler(registry, args, ctx));
+      return enrichToolServicesText(result);
     }
   );
 
@@ -327,7 +362,8 @@ async function main() {
     },
     async (args) => {
       await enforceEntitledAccess(ctx, { tool: "get_service_health", service: (args as any)?.service });
-      return withToolMetrics("get_service_health", () => getServiceHealthHandler(registry, args, ctx));
+      const result = await withToolMetrics("get_service_health", () => getServiceHealthHandler(registry, args, ctx));
+      return enrichToolHealthText(result, String((args as any)?.service ?? ""));
     }
   );
 
@@ -558,6 +594,12 @@ async function main() {
   await mgmtAudit.bootstrap();
   const audit = (resource: string, action: string) =>
     buildAuditMiddleware({ audit: mgmtAudit, resource, action });
+
+  // Service catalog: optional operator-curated ownership / criticality /
+  // on-call metadata, keyed on the service name list_services returns.
+  // No file ⇒ empty catalog, enrichment is a no-op (anonymous demos
+  // see no behaviour change).
+  const catalog = new CatalogStore(await readCatalogFile(process.env.OMCP_SERVICE_CATALOG_FILE));
   // Protected route prefixes. /api/me, /api/auth/*, /api/info,
   // /api/openapi.json deliberately don't appear here — they stay public.
   for (const prefix of [
@@ -572,6 +614,7 @@ async function main() {
     "/api/enterprise",
     "/api/hub",
     "/api/audit",
+    "/api/catalog",
   ]) {
     app.use(prefix, requireSession);
   }
@@ -1060,15 +1103,37 @@ async function main() {
   app.get("/api/services", async (_req, res) => {
     try {
       const result = await listServicesHandler(registry, {}, defaultContext());
-      res.json(parseToolResult(result));
+      const parsed = parseToolResult(result) as { services?: Array<Record<string, unknown> & { name?: string }> };
+      // Enrich each entry with the catalog metadata (no-op when empty).
+      if (parsed?.services) {
+        for (const s of parsed.services) {
+          const entry = typeof s.name === "string" ? catalog.get(s.name) : undefined;
+          if (entry) s.catalog = entry;
+        }
+      }
+      res.json(parsed);
     } catch { res.status(500).json({ error: "Failed to list services" }); }
+  });
+
+  // Read-only view of the configured catalog. Gated by the same
+  // "catalog:read" permission Phase E4 added to DEFAULT_POLICY.
+  app.get("/api/catalog", need("catalog", "read"), (_req, res) => {
+    res.json({
+      services: catalog.list(),
+      count: catalog.count(),
+      configured: !!process.env.OMCP_SERVICE_CATALOG_FILE,
+    });
   });
 
   // Health endpoint for UI dashboard
   app.get("/api/health/:service", async (req, res) => {
     try {
-      const result = await getServiceHealthHandler(registry, { service: req.params.service }, defaultContext());
-      res.json(parseToolResult(result));
+      const service = String(req.params.service);
+      const result = await getServiceHealthHandler(registry, { service }, defaultContext());
+      const parsed = parseToolResult(result) as Record<string, unknown>;
+      const entry = catalog.get(service);
+      if (entry && parsed && typeof parsed === "object") parsed.catalog = entry;
+      res.json(parsed);
     } catch {
       res.status(500).json({ error: "Failed to get service health" });
     }
@@ -1084,7 +1149,10 @@ async function main() {
       for (const svc of services) {
         try {
           const result = await getServiceHealthHandler(registry, { service: svc.name }, defaultContext());
-          health[svc.name] = parseToolResult(result);
+          const h = parseToolResult(result) as Record<string, unknown>;
+          const entry = catalog.get(svc.name);
+          if (entry && h && typeof h === "object") h.catalog = entry;
+          health[svc.name] = h;
         } catch { health[svc.name] = { error: "failed to fetch health" }; }
       }
       res.json(health);


### PR DESCRIPTION
## Summary
Operator-curated service catalog (owner / tier / data classification / on-call / SLO / runbooks / tags) hooked into both the HTTP management plane **and** the MCP tool surface so the agent sees ownership context the same way the UI does.

Distinct from the existing \`/api/enterprise/catalog\` (product catalog behind the entitlement gate — different trust model).

### Backend
- \`catalog/loader.ts\` — JSON loader with strict allowlist for \`tier\` (tier-1..tier-4) and \`dataClassification\` (public/internal/confidential/restricted). Missing / unreadable / malformed file → empty catalog (no-op enrichment).
- \`OMCP_SERVICE_CATALOG_FILE\` env var.

### Surface
- \`GET /api/catalog\` (gated by \`need(\"catalog\",\"read\")\`).
- \`/api/services\`, \`/api/health/:service\`, \`/api/health\` enriched with \`.catalog\`.
- **MCP tools** \`list_services\` and \`get_service_health\` post-processed via in-closure helpers so Claude Desktop / the agent see the same enrichment.

### RBAC
- New \`catalog\` resource. DEFAULT_POLICY grants \`catalog:read\` to viewer/operator/admin; admin full CRUD (admin total now 9×3 = 27).

### Tests
- 9 new \`loader.test.ts\` unit tests (missing/malformed/valid/invalid-tier/invalid-classification/runbooks-tags filter/non-object/CatalogStore).
- rbac.test.ts admin-count updated 24 → 27.
- CI globs extended.

## Test plan
- [x] Pre-push review-agent caught missing MCP-tool enrichment; fixed by post-processing in the tool-handler closures
- [ ] CI: unit + integration + ui-smoke + CodeQL green

🤖 Generated with [Claude Code](https://claude.com/claude-code)