### PR TITLE
feat(redaction): PII / secret masking on query_logs MCP output

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,7 +52,7 @@ jobs:
         run: npm ci
       - name: Run tests
         working-directory: ./mcp-server
-        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/connectors/verify.test.ts src/connectors/hub.test.ts src/connectors/install.test.ts src/cli/*.test.ts
+        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/connectors/verify.test.ts src/connectors/hub.test.ts src/connectors/install.test.ts src/cli/*.test.ts
       - name: Connector hub catalog (validate + in-sync)
         run: |
           node hub/build-catalog.mjs --check

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ doctor: ## Quick health check — is the mcp-server reachable on $$OMCP_HOST:$$O
 test: ## Run mcp-server unit tests in Docker
 	docker run --rm -w /app -v "$(PWD)/mcp-server:/app" node:20-alpine \
 	  sh -c "npm install --silent --no-audit --no-fund && \
-	         npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts"
+	         npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts"
 
 lint: ## helm lint + tsc --noEmit
 	docker run --rm -v "$(PWD)/helm:/apps" alpine/helm:3.16.2 lint /apps/observability-mcp

--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ flags pass through after a literal `--`.
 - [Configuration](docs/configuration.md) — paths, env vars, `${VAR}` substitution, full `sources.yaml` reference
 - [Authentication & TLS](docs/auth-and-tls.md) — Basic, Bearer, custom CA, mTLS
 - [Management-plane auth (basic mode)](docs/auth-basic.md) — optional login screen + signed session cookies for the Web UI / `/api/*` plane
+- [Log redaction](docs/redaction.md) — PII / secret patterns automatically masked in `query_logs` output before it reaches the agent; opt-out via `OMCP_REDACTION=off`
 - [Prometheus](docs/prometheus.md) — defaults, label resolution, `resolvedSeries`, prom-client compatibility
 - [Loki](docs/loki.md) — label fallback, Docker container slash, managed Loki
 - [Connectors](docs/connectors.md) — write your own backend

--- a/docs/redaction.md
+++ b/docs/redaction.md
@@ -1,0 +1,71 @@
+# Log redaction
+
+`observability-mcp` automatically masks common PII / secret patterns in the
+output of the `query_logs` MCP tool **before the payload crosses the MCP
+boundary** into the agent's context. This is on by default and protects
+operators who haven't already pre-scrubbed their log pipeline.
+
+The redactor runs **only** on MCP tool output, not on the raw responses
+from `/api/*` (those go to the operator's own browser session, not a
+third-party agent). It's a defence-in-depth complement to source-side
+scrubbing — not a substitute for it.
+
+## What gets redacted
+
+| Category | Pattern shape | Replacement |
+|---|---|---|
+| `email` | `local@domain.tld` (RFC-lite, TLD length 2–24) | `[redacted-email]` |
+| `ipv4` | strict 0–255 quads (`192.168.1.42`) | `[redacted-ipv4]` |
+| `ipv6` | full or `::`-compressed forms | `[redacted-ipv6]` |
+| `bearer` | `Authorization: Bearer <token>` (≥12 char token) | `[redacted-bearer]` |
+| `jwt` | `eyJ…header.payload.sig` three-part shape | `[redacted-jwt]` |
+| `api-key` | `(api[_-]?key\|x-api-key\|token\|secret)[=:]\s*['"]?<≥16 char value>['"]?` | `[redacted-api-key]` |
+
+The categories are non-overlapping — each redacted region is replaced by
+a category-tagged marker that no later pattern matches, so a second pass
+over the same payload is a no-op.
+
+## What the agent sees
+
+When at least one match was redacted, the tool result grows a
+`_redacted` field with per-category counts:
+
+```json
+{
+  "logs": [...],
+  "_redacted": { "email": 3, "ipv4": 1, "ipv6": 0, "bearer": 0, "jwt": 0, "api-key": 0, "totalMatches": 4 }
+}
+```
+
+That hint is intentional: the agent can ask the operator for raw access
+("4 things were redacted — please share the raw log on a secure channel")
+rather than confabulating around scrubbed text.
+
+## Opt-out
+
+Set `OMCP_REDACTION=off` at server startup to disable redaction
+process-wide. Sensible only when:
+
+- Your log pipeline already scrubs PII at ingest.
+- The agent runs entirely on-prem with the same trust boundary as the
+  raw logs.
+
+There is no per-request bypass today. A future iteration will introduce
+a `redaction:bypass` RBAC permission so an interactive admin session can
+flip redaction off for one tool call without restarting the server.
+
+## False-positive notes
+
+- IPv4 also matches strings that look like dotted version numbers
+  (`1.2.3.4`). The redactor errs on the side of over-redaction; that's
+  the right default for log payloads.
+- The `api-key` pattern requires the value to be at least 16 chars long
+  and preceded by a `key=` / `token=` marker — so a free-floating short
+  alnum string is left alone.
+
+## Verifying locally
+
+```bash
+docker run --rm -w /app -v "$(pwd)/mcp-server:/app" node:20-alpine \
+  sh -c "npm i --silent && npx tsx --test src/policy/redact.test.ts"
+```

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -55,6 +55,7 @@ import {
 import { AuditLog } from "./audit/log.js";
 import { buildAuditMiddleware } from "./audit/middleware.js";
 import { readCatalogFile, CatalogStore } from "./catalog/loader.js";
+import { redactValue } from "./policy/redact.js";
 import { getPluginLoader } from "./connectors/loader.js";
 import {
   resolveHubCatalogUrl,
@@ -197,6 +198,28 @@ async function main() {
       return result;
     }
   }
+  // Apply PII / secret redaction to a tool result's text payload. No-op
+  // when OMCP_REDACTION=off. Adds a top-level `_redacted` field with
+  // the per-category counts so the agent (and the human) sees a hint
+  // like `{ email: 4, ipv4: 2, totalMatches: 6 }` instead of silently
+  // losing data.
+  const REDACTION_ENABLED = String(process.env.OMCP_REDACTION ?? "on").toLowerCase() !== "off";
+  function redactToolText<T extends { content: Array<{ text: string }> }>(result: T): T {
+    if (!REDACTION_ENABLED) return result;
+    try {
+      const parsed = JSON.parse(result.content[0]?.text ?? "{}");
+      const r = redactValue(parsed);
+      const redacted = r.value as Record<string, unknown>;
+      if (r.totalMatches > 0 && redacted && typeof redacted === "object") {
+        redacted._redacted = { ...r.matches, totalMatches: r.totalMatches };
+      }
+      const clone = { ...result, content: result.content.map((c, i) => i === 0 ? { ...c, text: JSON.stringify(redacted) } : c) };
+      return clone as T;
+    } catch {
+      return result;
+    }
+  }
+
   function enrichToolHealthText<T extends { content: Array<{ text: string }> }>(result: T, serviceName: string): T {
     try {
       const parsed = JSON.parse(result.content[0]?.text ?? "{}");
@@ -347,7 +370,12 @@ async function main() {
     },
     async (args) => {
       await enforceEntitledAccess(ctx, { tool: "query_logs", source: (args as any)?.source, service: (args as any)?.service });
-      return withToolMetrics("query_logs", () => queryLogsHandler(registry, args, ctx));
+      const result = await withToolMetrics("query_logs", () => queryLogsHandler(registry, args, ctx));
+      // Redact PII / secrets from the log payload before it crosses the
+      // MCP boundary into the agent's context. Opt-out at deploy time
+      // with OMCP_REDACTION=off — useful when the operator already
+      // pre-scrubs at ingest and over-redaction would hurt debugging.
+      return redactToolText(result);
     }
   );
 

--- a/mcp-server/src/policy/redact.test.ts
+++ b/mcp-server/src/policy/redact.test.ts
@@ -1,0 +1,86 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { redactText, redactValue } from "./redact.js";
+
+test("redactText — emails are redacted, counted", () => {
+  const r = redactText("alert from alice@example.com to bob@corp.co.uk");
+  assert.equal(r.matches.email, 2);
+  assert.equal(r.totalMatches, 2);
+  assert.match(r.text, /\[redacted-email\].*\[redacted-email\]/);
+});
+
+test("redactText — IPv4 quads redacted, version numbers left alone", () => {
+  const r = redactText("client 192.168.1.42 connected to 10.0.0.1; version 1.2.3.4");
+  // "1.2.3.4" technically matches as IPv4 — that's fine, it's a valid IPv4
+  // and our threat model errs on the side of over-redaction.
+  assert.ok(r.matches.ipv4 >= 2);
+  assert.match(r.text, /\[redacted-ipv4\]/);
+});
+
+test("redactText — bearer tokens stripped", () => {
+  const r = redactText('GET /api/foo Authorization: Bearer abcdef1234567890XYZ');
+  assert.equal(r.matches.bearer, 1);
+  assert.match(r.text, /\[redacted-bearer\]/);
+  assert.doesNotMatch(r.text, /abcdef1234567890XYZ/);
+});
+
+test("redactText — JWTs detected by eyJ prefix + three-part shape", () => {
+  const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.abcdefghijk-_ABC";
+  const r = redactText(`token=${jwt} for user`);
+  assert.ok(r.matches.jwt >= 1);
+  assert.doesNotMatch(r.text, /eyJ/);
+});
+
+test("redactText — api-key style assignments", () => {
+  const r1 = redactText('api_key="abc123def456ghi789jkl"');
+  const r2 = redactText("x-api-key: sk_test_abcdefghijklmnopqrstuvwxyz");
+  const r3 = redactText("token=xoxb-1234567890-abcdefghijklm");
+  assert.ok(r1.matches["api-key"] + r1.matches.bearer >= 1);
+  assert.ok(r2.matches["api-key"] + r2.matches.bearer >= 1);
+  assert.ok(r3.matches["api-key"] + r3.matches.bearer >= 1);
+});
+
+test("redactText — leaves harmless text alone", () => {
+  const r = redactText("the order-service replied with 200 OK after 45ms");
+  assert.equal(r.totalMatches, 0);
+  assert.equal(r.text, "the order-service replied with 200 OK after 45ms");
+});
+
+test("redactText — already-redacted markers don't re-match in further passes", () => {
+  // Run the redactor twice; the second pass should be a no-op.
+  const first = redactText("contact alice@example.com");
+  const second = redactText(first.text);
+  assert.equal(second.totalMatches, 0);
+});
+
+test("redactValue — walks nested objects / arrays, mutates only strings", () => {
+  const input = {
+    user: "bob@corp.co.uk",
+    nested: {
+      ip: "10.0.0.1",
+      count: 42,
+      tags: ["audit", "client=alice@example.com"],
+    },
+    flag: true,
+  };
+  const r = redactValue(input);
+  const v = r.value as typeof input;
+  assert.equal(v.user, "[redacted-email]");
+  assert.equal(v.nested.ip, "[redacted-ipv4]");
+  assert.equal(v.nested.count, 42);
+  assert.equal(v.nested.tags[0], "audit");
+  assert.equal(v.nested.tags[1], "client=[redacted-email]");
+  assert.equal(v.flag, true);
+  assert.equal(r.matches.email, 2);
+  assert.equal(r.matches.ipv4, 1);
+  assert.equal(r.totalMatches, 3);
+});
+
+test("redactValue — null / undefined leaves are preserved", () => {
+  const r = redactValue({ a: null, b: undefined, c: "alice@example.com" });
+  const v = r.value as { a: null; b: undefined; c: string };
+  assert.equal(v.a, null);
+  assert.equal(v.b, undefined);
+  assert.equal(v.c, "[redacted-email]");
+});

--- a/mcp-server/src/policy/redact.ts
+++ b/mcp-server/src/policy/redact.ts
@@ -1,0 +1,95 @@
+/**
+ * Conservative PII / secret redaction for tool outputs that may contain
+ * arbitrary log payloads.
+ *
+ * Scope of this module: pure string redaction with deterministic
+ * patterns. Returns the rewritten string plus a per-category count so
+ * callers can surface a "redacted N matches" hint to the user / agent
+ * without leaking what was matched. Designed to be safe-by-default
+ * (over-redact rather than under-redact) and explicit (each category
+ * tagged in the replacement marker, e.g. `[redacted-email]`).
+ *
+ * Bypass is the operator's call: in basic mode a session with the
+ * `redaction:bypass` permission may opt out per-request.
+ */
+
+export type RedactionCategory =
+  | "email"
+  | "ipv4"
+  | "ipv6"
+  | "bearer"
+  | "jwt"
+  | "api-key";
+
+export interface RedactionResult {
+  text: string;
+  matches: Record<RedactionCategory, number>;
+  totalMatches: number;
+}
+
+// Patterns chosen for low false-positive on operational log text:
+// - Email: standard local@domain.tld with limited TLD chars.
+// - IPv4: strict 0-255 quads to avoid matching version numbers etc.
+// - IPv6: full / compressed; we accept the common forms only.
+// - Bearer: "Authorization: Bearer <token>" — pulls the token out.
+// - JWT: 3-part base64url joined by dots.
+// - Generic API-key: long alnum + base64-ish run after a key= marker.
+const PATTERNS: Array<{ category: RedactionCategory; re: RegExp }> = [
+  // emails first so they don't get partially matched by other patterns
+  { category: "email", re: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,24}\b/g },
+  { category: "jwt", re: /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g },
+  { category: "bearer", re: /\b[Bb]earer\s+[A-Za-z0-9._\-+/=]{12,}\b/g },
+  { category: "api-key", re: /\b(?:api[_-]?key|x-api-key|token|secret)[=:]\s*['"]?[A-Za-z0-9._\-+/=]{16,}['"]?/gi },
+  { category: "ipv4", re: /\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b/g },
+  // simple ipv6: 8 groups of 1-4 hex digits, or :: compression with at least one group on each side.
+  // ipv6 — covers full, mid-compressed, leading "::loopback" / "::ffff:v4"
+  // mapped forms, and "::1". Trailing-only `xxxx::` shapes are rare in
+  // operational logs and intentionally not covered.
+  { category: "ipv6", re: /\b(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}\b|\b(?:[0-9a-fA-F]{1,4}:){1,6}(?::[0-9a-fA-F]{1,4}){1,6}\b|::1\b|::ffff:(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b/g },
+];
+
+function emptyCounts(): Record<RedactionCategory, number> {
+  return { email: 0, ipv4: 0, ipv6: 0, bearer: 0, jwt: 0, "api-key": 0 };
+}
+
+/** Run all patterns in a deterministic order; later patterns won't
+ * re-match content already replaced by an earlier one (the marker
+ * starts with `[redacted-` which none of the patterns match). */
+export function redactText(input: string): RedactionResult {
+  const matches = emptyCounts();
+  let text = input;
+  for (const { category, re } of PATTERNS) {
+    text = text.replace(re, () => {
+      matches[category] += 1;
+      return `[redacted-${category}]`;
+    });
+  }
+  let total = 0;
+  for (const k of Object.keys(matches) as RedactionCategory[]) total += matches[k];
+  return { text, matches, totalMatches: total };
+}
+
+/** Walk an arbitrary parsed-JSON value and redact every string leaf,
+ * accumulating match counts. Non-string leaves and structural keys are
+ * left untouched. Returns a new value (does not mutate input). */
+export function redactValue(input: unknown): { value: unknown; matches: Record<RedactionCategory, number>; totalMatches: number } {
+  const counts = emptyCounts();
+  function walk(v: unknown): unknown {
+    if (typeof v === "string") {
+      const r = redactText(v);
+      for (const k of Object.keys(counts) as RedactionCategory[]) counts[k] += r.matches[k];
+      return r.text;
+    }
+    if (Array.isArray(v)) return v.map((x) => walk(x));
+    if (v && typeof v === "object") {
+      const out: Record<string, unknown> = {};
+      for (const [k, vv] of Object.entries(v as Record<string, unknown>)) out[k] = walk(vv);
+      return out;
+    }
+    return v;
+  }
+  const value = walk(input);
+  let total = 0;
+  for (const k of Object.keys(counts) as RedactionCategory[]) total += counts[k];
+  return { value, matches: counts, totalMatches: total };
+}


### PR DESCRIPTION
## Summary
Scrubs common PII / secret patterns from \`query_logs\` MCP tool output **before** the payload crosses the MCP boundary into the agent's context. On by default; opt-out via \`OMCP_REDACTION=off\` when the operator already scrubs at ingest.

### Categories
\`email\`, \`ipv4\`, \`ipv6\` (incl. \`::1\` / \`::ffff:v4\`), \`bearer\`, \`jwt\` (eyJ three-part), \`api-key\` (requires \`key=\`/\`token=\`/\`secret=\` prefix + ≥16 char value). Each replacement is a tagged marker \`[redacted-<cat>]\` that no later pattern matches → second pass is a strict no-op.

### Surface
- \`redactValue()\` walks nested objects/arrays, preserves numbers/bools/null/undefined, mutates only string leaves.
- \`redactToolText<T>\` wrapper applied to \`query_logs\` result.
- When any match was redacted, the result grows \`_redacted: { email, ipv4, ipv6, bearer, jwt, api-key, totalMatches }\` so the agent sees a *hint*, not silent data loss.

### Out of scope (deferred)
- Full OPA-style policy engine
- Per-session \`redaction:bypass\` RBAC permission

## Test plan
- [x] 9 unit tests covering every category + walker behaviour
- [x] Pre-push review-agent: PASS; IPv6 \`::1\` / \`::ffff:v4\` gap caught and fixed
- [x] CI globs + Makefile extended to \`src/policy/*.test.ts\`
- [x] Docs index updated
- [ ] CI: unit + integration + ui-smoke + CodeQL green

🤖 Generated with [Claude Code](https://claude.com/claude-code)