### PR TITLE
feat(quota): per-identity sliding-window rate limit on /mcp

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,7 +52,7 @@ jobs:
         run: npm ci
       - name: Run tests
         working-directory: ./mcp-server
-        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/connectors/verify.test.ts src/connectors/hub.test.ts src/connectors/install.test.ts src/cli/*.test.ts
+        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/quota/*.test.ts src/connectors/verify.test.ts src/connectors/hub.test.ts src/connectors/install.test.ts src/cli/*.test.ts
       - name: Connector hub catalog (validate + in-sync)
         run: |
           node hub/build-catalog.mjs --check

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ doctor: ## Quick health check — is the mcp-server reachable on $$OMCP_HOST:$$O
 test: ## Run mcp-server unit tests in Docker
 	docker run --rm -w /app -v "$(PWD)/mcp-server:/app" node:20-alpine \
 	  sh -c "npm install --silent --no-audit --no-fund && \
-	         npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts"
+	         npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/quota/*.test.ts"
 
 lint: ## helm lint + tsc --noEmit
 	docker run --rm -v "$(PWD)/helm:/apps" alpine/helm:3.16.2 lint /apps/observability-mcp

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -56,6 +56,7 @@ import { AuditLog } from "./audit/log.js";
 import { buildAuditMiddleware } from "./audit/middleware.js";
 import { readCatalogFile, CatalogStore } from "./catalog/loader.js";
 import { redactValue } from "./policy/redact.js";
+import { IdentityRateLimiter } from "./quota/limiter.js";
 import { getPluginLoader } from "./connectors/loader.js";
 import {
   resolveHubCatalogUrl,
@@ -1342,6 +1343,16 @@ async function main() {
 
   // Single-tenant auth gate. No credentials configured → anonymous (current
   // behaviour, fully backward compatible). Configured → require a valid
+  // Per-identity sliding-window rate limit on the MCP HTTP transport.
+  // Each request from a named bearer-token caller increments that
+  // caller's bucket; once the per-window cap is hit the server replies
+  // 429 with a Retry-After. Anonymous /mcp traffic (no OMCP_API_KEYS
+  // configured) bypasses this — the global express-rate-limit IP gate
+  // still applies. Override via OMCP_TOOL_RATE_PER_MIN.
+  const toolRateLimiter = new IdentityRateLimiter({
+    limit: Number(process.env.OMCP_TOOL_RATE_PER_MIN) || 60,
+  });
+
   // Bearer/X-API-Key on every /mcp request; resolve the principal + its
   // coarse source allow-list into the RequestContext.
   function gateCtx(
@@ -1357,6 +1368,18 @@ async function main() {
       res
         .status(401)
         .json({ error: "unauthorized: valid Bearer token or X-API-Key required" });
+      return null;
+    }
+    const decision = toolRateLimiter.check(cred.name);
+    if (!decision.allowed) {
+      res.setHeader("Retry-After", String(decision.retryAfterSeconds));
+      res.status(429).json({
+        error: "rate limit exceeded for identity",
+        code: "OMCP_IDENTITY_RATE_LIMIT",
+        retryAfterSeconds: decision.retryAfterSeconds,
+        limit: decision.limit,
+        windowMs: decision.windowMs,
+      });
       return null;
     }
     return principalContext(cred.name, cred.allowedSources);

--- a/mcp-server/src/quota/limiter.test.ts
+++ b/mcp-server/src/quota/limiter.test.ts
@@ -1,0 +1,92 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { IdentityRateLimiter } from "./limiter.js";
+
+test("allows up to the configured limit, then denies", () => {
+  const lim = new IdentityRateLimiter({ limit: 3, windowMs: 60_000 });
+  const t = 1_700_000_000_000;
+  assert.equal(lim.check("alice", t + 0).allowed, true);
+  assert.equal(lim.check("alice", t + 100).allowed, true);
+  assert.equal(lim.check("alice", t + 200).allowed, true);
+  const denied = lim.check("alice", t + 300);
+  assert.equal(denied.allowed, false);
+  assert.equal(denied.count, 3);
+  assert.equal(denied.limit, 3);
+  assert.ok(denied.retryAfterSeconds >= 1);
+});
+
+test("sliding window: expired entries free up slots", () => {
+  const lim = new IdentityRateLimiter({ limit: 2, windowMs: 10_000 });
+  const t = 1_700_000_000_000;
+  lim.check("alice", t + 0);
+  lim.check("alice", t + 5_000);
+  // At t+9s alice is still at the cap.
+  assert.equal(lim.check("alice", t + 9_000).allowed, false);
+  // At t+11s the first entry has aged out → one slot opens.
+  const after = lim.check("alice", t + 11_000);
+  assert.equal(after.allowed, true);
+  assert.equal(after.count, 2);
+});
+
+test("identities are isolated from each other", () => {
+  const lim = new IdentityRateLimiter({ limit: 1, windowMs: 60_000 });
+  const t = 1_700_000_000_000;
+  assert.equal(lim.check("alice", t).allowed, true);
+  assert.equal(lim.check("alice", t).allowed, false);
+  // bob has his own fresh bucket.
+  assert.equal(lim.check("bob", t).allowed, true);
+});
+
+test("retryAfterSeconds points at the oldest in-window record's expiry", () => {
+  const lim = new IdentityRateLimiter({ limit: 1, windowMs: 30_000 });
+  const t = 1_700_000_000_000;
+  lim.check("alice", t);
+  const denied = lim.check("alice", t + 5_000);
+  assert.equal(denied.allowed, false);
+  // 30s window started at t, so expiry is t+30s → 25s from t+5s.
+  assert.equal(denied.retryAfterSeconds, 25);
+});
+
+test("denied calls do NOT push the window forward", () => {
+  const lim = new IdentityRateLimiter({ limit: 1, windowMs: 10_000 });
+  const t = 1_700_000_000_000;
+  lim.check("alice", t);
+  // Multiple denies — none of them should reset the oldest-timestamp.
+  for (let i = 1; i < 10; i++) lim.check("alice", t + i * 100);
+  // Still expecting expiry at t+10s, not pushed forward by the denies.
+  const justAfterExpiry = lim.check("alice", t + 10_001);
+  assert.equal(justAfterExpiry.allowed, true);
+});
+
+test("inspect: returns counts without consuming a slot", () => {
+  const lim = new IdentityRateLimiter({ limit: 5, windowMs: 60_000 });
+  const t = 1_700_000_000_000;
+  lim.check("alice", t);
+  lim.check("alice", t);
+  const ins = lim.inspect("alice", t);
+  assert.equal(ins.count, 2);
+  assert.equal(ins.limit, 5);
+  // Subsequent check still has room for 3 more.
+  assert.equal(lim.check("alice", t).allowed, true);
+});
+
+test("reset clears all buckets", () => {
+  const lim = new IdentityRateLimiter({ limit: 1, windowMs: 60_000 });
+  const t = 1_700_000_000_000;
+  lim.check("alice", t);
+  lim.check("bob", t);
+  lim.reset();
+  assert.equal(lim.check("alice", t).allowed, true);
+  assert.equal(lim.check("bob", t).allowed, true);
+});
+
+test("default limit applies when constructed with no args", () => {
+  const lim = new IdentityRateLimiter();
+  // Exhaust the default 60/min cap.
+  const t = 1_700_000_000_000;
+  for (let i = 0; i < 60; i++) {
+    assert.equal(lim.check("alice", t + i).allowed, true);
+  }
+  assert.equal(lim.check("alice", t + 60).allowed, false);
+});

--- a/mcp-server/src/quota/limiter.ts
+++ b/mcp-server/src/quota/limiter.ts
@@ -1,0 +1,104 @@
+/**
+ * Per-identity sliding-window rate limiter for the MCP tool surface.
+ *
+ * The bearer-token credential resolved by `auth/credentials.ts`
+ * (`OMCP_API_KEYS`) names every distinct caller; this limiter caps how
+ * many MCP tool calls each named caller can make per minute. Anonymous
+ * MCP traffic (when no `OMCP_API_KEYS` is set) bypasses the per-identity
+ * cap — the existing express-rate-limit IP gate at the /mcp transport
+ * still applies.
+ *
+ * The window is sliding: each call records its timestamp under the
+ * identity's key, and `check()` first prunes entries older than the
+ * configured window before counting. Memory bound is O(callers × N)
+ * where N is the per-window cap — a few KB even for a busy deployment.
+ *
+ * Persistence is out of scope here. A future revision can plug a
+ * Redis-backed store via the same interface.
+ */
+
+const DEFAULT_LIMIT_PER_MIN = 60;
+const DEFAULT_WINDOW_MS = 60_000;
+
+export interface LimiterConfig {
+  /** Cap per identity per window. Defaults to 60. */
+  limit?: number;
+  /** Window length in milliseconds. Defaults to 60_000. */
+  windowMs?: number;
+}
+
+export interface CheckResult {
+  /** True when the call is allowed (and the timestamp recorded). */
+  allowed: boolean;
+  /** Number of calls already made in the current window (after counting this one if allowed). */
+  count: number;
+  /** Configured per-window cap. */
+  limit: number;
+  /** Window length in ms. */
+  windowMs: number;
+  /** Seconds until the oldest in-window record falls off and a new
+   * slot opens. 0 when allowed. */
+  retryAfterSeconds: number;
+}
+
+export class IdentityRateLimiter {
+  private readonly limit: number;
+  private readonly windowMs: number;
+  // identity → ring of millisecond timestamps, newest at the end.
+  private readonly buckets = new Map<string, number[]>();
+
+  constructor(cfg: LimiterConfig = {}) {
+    this.limit = cfg.limit ?? DEFAULT_LIMIT_PER_MIN;
+    this.windowMs = cfg.windowMs ?? DEFAULT_WINDOW_MS;
+  }
+
+  /** Record-and-test a call for the given identity. Returns the
+   * decision plus enough context to render a 429 with Retry-After. */
+  check(identity: string, now: number = Date.now()): CheckResult {
+    const cutoff = now - this.windowMs;
+    const bucket = this.buckets.get(identity) ?? [];
+    // Drop expired entries from the front of the bucket.
+    let i = 0;
+    while (i < bucket.length && bucket[i] <= cutoff) i++;
+    const fresh = i === 0 ? bucket : bucket.slice(i);
+
+    if (fresh.length >= this.limit) {
+      // Compute when the oldest in-window record drops off.
+      const retryAfterMs = fresh[0] + this.windowMs - now;
+      // Don't store the call we just denied — that would push the
+      // window forward and starve the next legitimate request.
+      this.buckets.set(identity, fresh);
+      return {
+        allowed: false,
+        count: fresh.length,
+        limit: this.limit,
+        windowMs: this.windowMs,
+        retryAfterSeconds: Math.max(1, Math.ceil(retryAfterMs / 1000)),
+      };
+    }
+
+    fresh.push(now);
+    this.buckets.set(identity, fresh);
+    return {
+      allowed: true,
+      count: fresh.length,
+      limit: this.limit,
+      windowMs: this.windowMs,
+      retryAfterSeconds: 0,
+    };
+  }
+
+  /** Read-only snapshot — useful for /api/usage and tests. */
+  inspect(identity: string, now: number = Date.now()): { count: number; limit: number; windowMs: number } {
+    const cutoff = now - this.windowMs;
+    const bucket = this.buckets.get(identity) ?? [];
+    let count = 0;
+    for (const t of bucket) if (t > cutoff) count++;
+    return { count, limit: this.limit, windowMs: this.windowMs };
+  }
+
+  /** For testing — reset every identity's bucket. */
+  reset(): void {
+    this.buckets.clear();
+  }
+}


### PR DESCRIPTION
## Summary
Caps how many \`/mcp\` HTTP requests each named bearer-token caller can make per minute. Anonymous \`/mcp\` traffic (no \`OMCP_API_KEYS\`) is unaffected — the existing IP-level \`express-rate-limit\` already covers that case.

### Behaviour
- Default **60 req/min per identity**; override via \`OMCP_TOOL_RATE_PER_MIN\`.
- Sliding-window — pruned by cutoff at every check. **Denied calls do not push the window forward** (otherwise an attacker spamming during the cooldown could starve a legitimate caller indefinitely).
- Denied → HTTP 429, \`Retry-After\` header (integer seconds, RFC 7231), JSON body \`{ code: \"OMCP_IDENTITY_RATE_LIMIT\", retryAfterSeconds, limit, windowMs }\`.

### Granularity caveat
Enforcement sits in \`gateCtx\` so it fires **per HTTP request**, not per JSON-RPC message. A batched JSON-RPC request counts as one; a multi-tool LLM turn counts as N requests.

### Deferred
- Per-identity daily quota
- Token-budget tracking
- \`/api/usage\` endpoint + UI strip

## Test plan
- [x] 8 unit tests (allow/deny, sliding expiry, identity isolation, retry-after math, no-push-on-deny, non-consuming inspect, reset, default 60-cap exhaustion)
- [x] Pre-push review-agent: PASS
- [x] CI globs + Makefile extended to \`src/quota/*.test.ts\`
- [ ] CI: unit + integration + ui-smoke + CodeQL green

🤖 Generated with [Claude Code](https://claude.com/claude-code)