### PR TITLE
ui: drop rsms.me Inter CDN, use system font stack everywhere

### DIFF
--- a/docs/airgapped-deployment.md
+++ b/docs/airgapped-deployment.md
@@ -135,6 +135,24 @@ GitOps-friendly: commit `values.yaml` + a sealed `auth.token` secret. No state i
 
 observability-mcp ships **no built-in telemetry** — no startup phone-home, no usage pings, no error reporting back to the maintainer. Logs go to stdout, metrics go to your Prometheus, and that's it. Safe to run inside a fully isolated network without redaction.
 
+## Web UI fonts — no external CDN
+
+The bundled Web UI does **not** load any third-party font from a public
+CDN. It uses the OS-native system font stack
+(`-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica
+Neue', Arial, ui-sans-serif, sans-serif`), so the management surface
+renders cleanly in browsers behind an air-gap without any external
+network access at all.
+
+If the operator's policy requires a verified custom font, bake it
+into a derived image: add an `@font-face` block at the top of
+`mcp-server/src/ui/index.html` referencing a `.woff2` shipped under
+`mcp-server/src/ui/`, rebuild the image with `docker compose build
+mcp-server`, push to your internal registry, and point the Helm
+chart's `image.repository` at the rebuilt tag. The bundled UI is a
+single file by design — no plugin or values-override mechanism for
+fonts.
+
 ## Updates
 
 Releases are tagged in the GitHub repo. The recommended workflow:

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -31,11 +31,17 @@
       } catch (e) { document.documentElement.setAttribute('data-rail','expanded'); }
     })();
   </script>
-  <link rel="preconnect" href="https://rsms.me/">
-  <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
+  <!--
+    No external font CDN. The system-font fallback chain below renders
+    cleanly on every supported OS (macOS / iOS → -apple-system,
+    Windows → Segoe UI, Android / ChromeOS → Roboto, Linux → ui-sans-serif
+    / DejaVu). Air-gapped deployments work out of the box.
+    See docs/airgapped-deployment.md.
+  -->
   <style>
-    @supports (font-variation-settings: normal) {
-      :root { font-family: 'Inter var', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+    :root {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+                   'Helvetica Neue', Arial, ui-sans-serif, sans-serif;
     }
   </style>
   <style>
@@ -161,8 +167,8 @@
     *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
     html { -webkit-text-size-adjust: 100%; }
     body {
-      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      font-feature-settings: 'cv11', 'ss01', 'ss03';
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+                   'Helvetica Neue', Arial, ui-sans-serif, sans-serif;
       font-size: var(--fs-md);
       line-height: 1.5;
       background: var(--bg);
@@ -461,7 +467,7 @@
       margin-bottom: var(--sp-6);
       display: flex; align-items: center; justify-content: space-between;
     }
-    .endpoint-bar::before { content: 'POST'; display: inline-block; padding: 2px 6px; margin-right: 10px; background: var(--accent-soft); color: var(--accent); border-radius: 3px; font-size: var(--fs-xs); font-weight: 700; font-family: 'Inter var', sans-serif; }
+    .endpoint-bar::before { content: 'POST'; display: inline-block; padding: 2px 6px; margin-right: 10px; background: var(--accent-soft); color: var(--accent); border-radius: 3px; font-size: var(--fs-xs); font-weight: 700; font-family: inherit; }
     .empty {
       color: var(--text-dim); text-align: center;
       padding: var(--sp-10) var(--sp-4); font-size: var(--fs-md);


### PR DESCRIPTION
## Summary
The Web UI was the last piece making an outbound request at page load (Inter from \`rsms.me\`). Air-gapped browsers either silently fell back to the next stack entry or stalled on a failed preconnect.

This PR removes the two \`<link>\` tags and switches every \`'Inter'\` / \`'Inter var'\` font-family declaration to a pure system stack:
\`\`\`
-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, ui-sans-serif, sans-serif
\`\`\`

- macOS/iOS → SF Pro
- Windows → Segoe UI
- Android/ChromeOS → Roboto
- Linux → ui-sans-serif (or Arial fallback)

JetBrains Mono references already had a robust mono fallback chain and were never CDN-loaded, so the monospace surface is identical.

\`docs/airgapped-deployment.md\` gets a new "Web UI fonts — no external CDN" section describing the choice and the (image-rebuild-only) path to bake in a custom font.

## Test plan
- [x] Pre-push review-agent caught an orphan \`'Inter var'\` on \`.endpoint-bar::before\` → fixed via \`font-family: inherit\`
- [x] Pre-push review-agent caught an inaccurate doc paragraph about a non-existent chart-side \`extraConfig\` mechanism → rewritten to match reality (image-rebuild path)
- [x] All \"Inter\" hits in the file are now \"Interval\" identifiers, not font references
- [ ] CI: unit + integration + ui-smoke + CodeQL green

🤖 Generated with [Claude Code](https://claude.com/claude-code)