### PR TITLE
scripts: verify-audit.mjs — offline audit-chain verifier

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -84,8 +84,19 @@ server is still the authoritative gate — UI hiding is purely a UX win.
 Every mutating `/api/*` request produces one append-only entry with
 actor + resource + action + status + IP + the optional `:name` path
 parameter as `target`. Entries are hash-chained: each entry's `hash`
-covers the previous entry's `hash`, so `scripts/verify-audit.mjs`
-(future) can prove the log hasn't been silently truncated or reordered.
+covers the previous entry's `hash`, so
+[`scripts/verify-audit.mjs`](../scripts/verify-audit.mjs) can prove
+the log hasn't been silently truncated or reordered:
+
+```bash
+node scripts/verify-audit.mjs /var/log/omcp/audit.jsonl
+# → { "ok": true, "entries": 1234, "tipHash": "…" }   (exit 0)
+# or, on a tamper:
+# → { "ok": false, "entries": 1234, "brokenAt": 42, "reason": "…" }   (exit 1)
+```
+
+The script uses only node built-ins (no `node_modules`) so it works
+straight from a source checkout on an air-gapped operator workstation.
 
 - File path: `OMCP_MGMT_AUDIT_FILE` (JSONL, append-only). Unset → an
   in-memory ring of the last 500 entries serves the same `GET /api/audit`
@@ -199,6 +210,7 @@ node -e "
 "
 ```
 
-A break reports `{ ok: false, brokenAt: N, reason: '...' }`. Most
-common cause is hand-editing the file; restore from backup and replay
-any missed changes via the Web UI.
+A break reports `{ ok: false, brokenAt: N, reason: '...' }` and the
+script exits non-zero so a cron-driven monitor can alert. Most common
+cause is hand-editing the file; restore from backup and replay any
+missed changes via the Web UI.

--- a/scripts/verify-audit.mjs
+++ b/scripts/verify-audit.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Offline verifier for the management-plane audit log
+// (OMCP_MGMT_AUDIT_FILE). Walks the JSONL file line-by-line, replays
+// the SHA-256 hash chain in src/audit/log.ts:chainHash, and exits 0
+// when every entry's prevHash + hash check out — non-zero otherwise.
+//
+// Standalone: no transpiled dist needed. Re-implements canonicalJson
+// + chainHash + verifyChain identically to the server-side module so
+// this script works straight from a source checkout (and from an air-
+// gapped operator workstation).
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { stderr, stdout, argv, exit } from "node:process";
+
+const GENESIS_HASH = "0".repeat(64);
+
+function canonicalJson(v) {
+  if (v === undefined) return "";
+  if (v === null || typeof v !== "object") return JSON.stringify(v);
+  if (Array.isArray(v)) return "[" + v.map((x) => canonicalJson(x ?? null)).join(",") + "]";
+  const keys = Object.keys(v).filter((k) => v[k] !== undefined).sort();
+  return "{" + keys.map((k) => JSON.stringify(k) + ":" + canonicalJson(v[k])).join(",") + "}";
+}
+
+function chainHash(entryWithoutHash) {
+  return createHash("sha256").update(canonicalJson(entryWithoutHash)).digest("hex");
+}
+
+function verifyChain(entries) {
+  let prev = GENESIS_HASH;
+  for (let i = 0; i < entries.length; i++) {
+    const e = entries[i];
+    if (e.prevHash !== prev) {
+      return { ok: false, brokenAt: i, reason: `entry ${e.seq ?? "?"}: prevHash mismatch (expected ${prev}, got ${e.prevHash})` };
+    }
+    const { hash: _h, ...rest } = e;
+    const expectedHash = chainHash(rest);
+    if (e.hash !== expectedHash) {
+      return { ok: false, brokenAt: i, reason: `entry ${e.seq ?? "?"}: hash mismatch (expected ${expectedHash}, got ${e.hash})` };
+    }
+    prev = e.hash;
+  }
+  return { ok: true };
+}
+
+function usage() {
+  stderr.write(`Usage: node scripts/verify-audit.mjs <path-to-audit.jsonl>\n`);
+  stderr.write(`\n`);
+  stderr.write(`Exits 0 on a clean chain; non-zero with a brokenAt index + reason\n`);
+  stderr.write(`on the first failure. Designed for offline / air-gapped operator\n`);
+  stderr.write(`use — no node_modules required.\n`);
+}
+
+function main() {
+  const path = argv[2];
+  if (!path || path === "-h" || path === "--help") { usage(); exit(path ? 0 : 2); }
+  let raw;
+  try { raw = readFileSync(path, "utf8"); }
+  catch (e) { stderr.write(`cannot read ${path}: ${e.message}\n`); exit(1); }
+  const entries = [];
+  let lineNo = 0;
+  for (const line of raw.split("\n")) {
+    lineNo++;
+    const t = line.trim();
+    if (!t) continue;
+    try { entries.push(JSON.parse(t)); }
+    catch { stderr.write(`line ${lineNo}: not valid JSON, skipping\n`); }
+  }
+  if (entries.length === 0) {
+    stdout.write(JSON.stringify({ ok: true, entries: 0, note: "empty file" }) + "\n");
+    return;
+  }
+  const result = verifyChain(entries);
+  if (result.ok) {
+    stdout.write(JSON.stringify({ ok: true, entries: entries.length, tipHash: entries[entries.length - 1].hash }, null, 2) + "\n");
+    exit(0);
+  }
+  stdout.write(JSON.stringify({ ok: false, entries: entries.length, ...result }, null, 2) + "\n");
+  exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary
\`docs/access-control.md\` described \`scripts/verify-audit.mjs\` as \"future\" work — shipping it now.

Reads a JSONL file the way the in-process \`AuditLog\` wrote it, re-runs \`canonicalJson\` + \`chainHash\` + \`verifyChain\` on every line, exits **0** on a clean chain and **1** with \`{ brokenAt, reason }\` on the first failure.

Re-implements the canonical-JSON + hash-chain logic instead of importing from the transpiled \`dist/\` so the script works straight from a source checkout on an air-gapped operator workstation — no \`npm install\`, no \`tsc\` required.

## Test plan
- [x] Local smoke against a two-entry chain: clean → exit 0 + correct \`tipHash\`; content-tampered → exit 1 + correct \`brokenAt\` index + diagnostic message
- [x] Docs cross-reference updated (replaced \"future\" placeholder with a live link to the script + exit-code semantics)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)