### PR TITLE
feat(redaction): high-confidence cloud-credential patterns

### DIFF
--- a/docs/redaction.md
+++ b/docs/redaction.md
@@ -20,6 +20,10 @@ scrubbing — not a substitute for it.
 | `bearer` | `Authorization: Bearer <token>` (≥12 char token) | `[redacted-bearer]` |
 | `jwt` | `eyJ…header.payload.sig` three-part shape | `[redacted-jwt]` |
 | `api-key` | `(api[_-]?key\|x-api-key\|token\|secret)[=:]\s*['"]?<≥16 char value>['"]?` | `[redacted-api-key]` |
+| `aws-key` | AWS access key id (`AKIA…` / `ASIA…` / `AROA…` + 16–20 chars) | `[redacted-aws-key]` |
+| `slack-token` | `xox[abprsu]-…` Slack tokens | `[redacted-slack-token]` |
+| `gh-pat` | `gh[opsuru]_…` and `github_pat_…` GitHub personal access tokens | `[redacted-gh-pat]` |
+| `private-key` | PEM-encoded `-----BEGIN [...] PRIVATE KEY-----` blocks (greedy across newlines) | `[redacted-private-key]` |
 
 The categories are non-overlapping — each redacted region is replaced by
 a category-tagged marker that no later pattern matches, so a second pass

--- a/mcp-server/src/policy/redact.test.ts
+++ b/mcp-server/src/policy/redact.test.ts
@@ -32,13 +32,21 @@ test("redactText — JWTs detected by eyJ prefix + three-part shape", () => {
   assert.doesNotMatch(r.text, /eyJ/);
 });
 
-test("redactText — api-key style assignments", () => {
+test("redactText — api-key / cloud-token style assignments", () => {
+  // r1: generic prefix-based api-key match.
+  // r2: x-api-key with an opaque body — falls through to api-key.
+  // r3: token= with a Slack-shape value — the new slack-token pattern
+  //     wins because it runs before api-key; either outcome is fine,
+  //     the contract is "the secret is gone after one pass".
   const r1 = redactText('api_key="abc123def456ghi789jkl"');
   const r2 = redactText("x-api-key: sk_test_abcdefghijklmnopqrstuvwxyz");
   const r3 = redactText("token=xoxb-1234567890-abcdefghijklm");
-  assert.ok(r1.matches["api-key"] + r1.matches.bearer >= 1);
-  assert.ok(r2.matches["api-key"] + r2.matches.bearer >= 1);
-  assert.ok(r3.matches["api-key"] + r3.matches.bearer >= 1);
+  assert.ok(r1.totalMatches >= 1, "expected r1 to be redacted somewhere");
+  assert.ok(r2.totalMatches >= 1, "expected r2 to be redacted somewhere");
+  assert.ok(r3.totalMatches >= 1, "expected r3 to be redacted somewhere");
+  assert.doesNotMatch(r1.text, /abc123def456ghi789jkl/);
+  assert.doesNotMatch(r2.text, /sk_test_abcdefghijklmnopqrstuvwxyz/);
+  assert.doesNotMatch(r3.text, /xoxb-1234567890/);
 });
 
 test("redactText — leaves harmless text alone", () => {

--- a/mcp-server/src/policy/redact.test.ts
+++ b/mcp-server/src/policy/redact.test.ts
@@ -77,6 +77,40 @@ test("redactValue — walks nested objects / arrays, mutates only strings", () =
   assert.equal(r.totalMatches, 3);
 });
 
+test("redactText — AWS access key IDs (AKIA / ASIA / AROA) are redacted", () => {
+  const r1 = redactText("log: assumed role AKIAIOSFODNN7EXAMPLE today");
+  const r2 = redactText("temporary creds ASIAY34FZKBOKMUTVV7A logged");
+  const r3 = redactText("role-arn AROAIIAFOO2ZBADBCEXAMPLE");
+  assert.equal(r1.matches["aws-key"], 1);
+  assert.equal(r2.matches["aws-key"], 1);
+  assert.equal(r3.matches["aws-key"], 1);
+  assert.match(r1.text, /\[redacted-aws-key\]/);
+  assert.doesNotMatch(r1.text, /AKIAIOSFODNN7EXAMPLE/);
+});
+
+test("redactText — Slack tokens (xoxa / xoxb / xoxp / …) are redacted", () => {
+  const r = redactText("slack notify: token=xoxb-1234567890-abcdefghijklm result: ok");
+  assert.equal(r.matches["slack-token"], 1);
+  assert.doesNotMatch(r.text, /xoxb-1234567890/);
+});
+
+test("redactText — GitHub PATs are redacted (ghp_ / github_pat_)", () => {
+  const r1 = redactText("git remote set-url origin https://ghp_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789@github.com/x/y.git");
+  // Use a 40-char body, which matches `[A-Za-z0-9_]{40,}` (note: includes underscore)
+  const r2 = redactText("token github_pat_ABCDEFGH_IJKLMNOPQRSTUVWXYZ012345678ABCDEFGHIJKLMNOP");
+  assert.equal(r1.matches["gh-pat"], 1);
+  assert.equal(r2.matches["gh-pat"], 1);
+});
+
+test("redactText — PEM private-key blocks are redacted greedily", () => {
+  const pem = `-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAwLPVKj…
+-----END RSA PRIVATE KEY-----`;
+  const r = redactText(`config:\n${pem}\nend`);
+  assert.equal(r.matches["private-key"], 1);
+  assert.doesNotMatch(r.text, /MIIEpAIBAA/);
+});
+
 test("redactValue — null / undefined leaves are preserved", () => {
   const r = redactValue({ a: null, b: undefined, c: "alice@example.com" });
   const v = r.value as { a: null; b: undefined; c: string };

--- a/mcp-server/src/policy/redact.ts
+++ b/mcp-server/src/policy/redact.ts
@@ -19,7 +19,11 @@ export type RedactionCategory =
   | "ipv6"
   | "bearer"
   | "jwt"
-  | "api-key";
+  | "api-key"
+  | "aws-key"
+  | "slack-token"
+  | "private-key"
+  | "gh-pat";
 
 export interface RedactionResult {
   text: string;
@@ -35,13 +39,23 @@ export interface RedactionResult {
 // - JWT: 3-part base64url joined by dots.
 // - Generic API-key: long alnum + base64-ish run after a key= marker.
 const PATTERNS: Array<{ category: RedactionCategory; re: RegExp }> = [
-  // emails first so they don't get partially matched by other patterns
+  // High-confidence cloud-vendor secrets go first — their prefixes are
+  // distinctive enough that they don't conflict with generic patterns.
+  // - AWS access key id: 16-32 chars after AKIA/ASIA/AROA prefix.
+  // - Slack tokens: xoxa-/xoxb-/xoxp-/xoxr-/xoxs- + 10+ chars.
+  // - GitHub PAT: github_pat_<base62 segments> or ghp_/gho_/ghs_/ghu_/ghr_ + 36 chars.
+  // - PEM private-key blocks: greedy match across newlines.
+  { category: "aws-key", re: /\b(?:AKIA|ASIA|AROA)[0-9A-Z]{16,20}\b/g },
+  { category: "slack-token", re: /\bxox[abprsu]-[A-Za-z0-9-]{10,}\b/g },
+  { category: "gh-pat", re: /\b(?:github_pat_[A-Za-z0-9_]{40,}|gh[opsuru]_[A-Za-z0-9]{36})\b/g },
+  { category: "private-key", re: /-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY-----/g },
+
+  // emails before other patterns so they don't get eaten partially
   { category: "email", re: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,24}\b/g },
   { category: "jwt", re: /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g },
   { category: "bearer", re: /\b[Bb]earer\s+[A-Za-z0-9._\-+/=]{12,}\b/g },
   { category: "api-key", re: /\b(?:api[_-]?key|x-api-key|token|secret)[=:]\s*['"]?[A-Za-z0-9._\-+/=]{16,}['"]?/gi },
   { category: "ipv4", re: /\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b/g },
-  // simple ipv6: 8 groups of 1-4 hex digits, or :: compression with at least one group on each side.
   // ipv6 — covers full, mid-compressed, leading "::loopback" / "::ffff:v4"
   // mapped forms, and "::1". Trailing-only `xxxx::` shapes are rare in
   // operational logs and intentionally not covered.
@@ -49,7 +63,10 @@ const PATTERNS: Array<{ category: RedactionCategory; re: RegExp }> = [
 ];
 
 function emptyCounts(): Record<RedactionCategory, number> {
-  return { email: 0, ipv4: 0, ipv6: 0, bearer: 0, jwt: 0, "api-key": 0 };
+  return {
+    email: 0, ipv4: 0, ipv6: 0, bearer: 0, jwt: 0, "api-key": 0,
+    "aws-key": 0, "slack-token": 0, "private-key": 0, "gh-pat": 0,
+  };
 }
 
 /** Run all patterns in a deterministic order; later patterns won't


### PR DESCRIPTION
## Summary
Extends the redactor with four new categories that the generic \`api-key\` pattern only caught when prefixed with \`token=\` / \`secret=\` — leaving the bare token in a log line slipping through:

| Category | Pattern | Replacement |
|---|---|---|
| \`aws-key\` | \`AKIA\` / \`ASIA\` / \`AROA\` + 16–20 chars | \`[redacted-aws-key]\` |
| \`slack-token\` | \`xox[abprsu]-…\` | \`[redacted-slack-token]\` |
| \`gh-pat\` | \`gh[opsuru]_\` + 36 chars, and \`github_pat_…\` | \`[redacted-gh-pat]\` |
| \`private-key\` | PEM \`-----BEGIN [...] PRIVATE KEY-----\` blocks (greedy across newlines) | \`[redacted-private-key]\` |

The four new patterns sit **first** in the PATTERNS array so their distinctive prefixes win over the generic api-key matcher. The \`[redacted-<cat>]\` marker convention means a second pass still finds nothing to redo.

Counts surface in the existing \`_redacted\` hint so the agent sees which kinds of secrets were stripped without seeing the values.

## Test plan
- [x] 4 new unit tests in \`redact.test.ts\` covering each category with a known-shape synthetic secret
- [x] Doc table extended
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)