### PR TITLE
feat(usage): /api/usage snapshot of the per-identity rate buckets

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -135,6 +135,23 @@ Content-Type: application/json
 Granularity is per HTTP request, not per JSON-RPC message. A batched
 JSON-RPC request counts as one; a multi-tool LLM turn counts as N.
 
+Live snapshot: `GET /api/usage` (gated by `audit:read`) returns the
+current windowed count per identity:
+
+```json
+{
+  "identities": [
+    { "actor": "agent-prod", "count": 14, "limit": 60, "windowMs": 60000 },
+    { "actor": "ci",         "count":  3, "limit": 60, "windowMs": 60000 }
+  ],
+  "defaultLimit": 60,
+  "windowMs": 60000
+}
+```
+
+Pass `?actor=<name>` to inspect a single identity (count is 0 for
+identities the server has never seen).
+
 ## Service catalog enrichment
 
 When `OMCP_SERVICE_CATALOG_FILE` points at a JSON catalog (schema in

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -649,6 +649,7 @@ async function main() {
     "/api/enterprise",
     "/api/hub",
     "/api/audit",
+    "/api/usage",
     "/api/catalog",
   ]) {
     app.use(prefix, requireSession);
@@ -788,6 +789,26 @@ async function main() {
       limit: q.limit ? parseInt(q.limit, 10) : undefined,
     });
     res.json({ entries, tipHash: mgmtAudit.tipHash, persisted: !!process.env.OMCP_MGMT_AUDIT_FILE });
+  });
+
+  // --- /api/usage — per-identity MCP rate-limit snapshot -----------------
+  // Read-only view of the IdentityRateLimiter's bucket state. Gated by
+  // need("audit","read") — the same role set that already sees the
+  // audit log can see who is calling what. Anonymous /mcp traffic
+  // never enters a bucket so it doesn't show up here.
+  app.get("/api/usage", need("audit", "read"), (req, res) => {
+    const q = req.query as Record<string, string | undefined>;
+    const ids = q.actor ? [q.actor] : toolRateLimiter.knownIdentities();
+    const now = Date.now();
+    const identities = ids.map((id) => {
+      const s = toolRateLimiter.inspect(id, now);
+      return { actor: id, count: s.count, limit: s.limit, windowMs: s.windowMs };
+    });
+    res.json({
+      identities,
+      defaultLimit: Number(process.env.OMCP_TOOL_RATE_PER_MIN) || 60,
+      windowMs: 60_000,
+    });
   });
 
   // --- /api/auth/* — login + logout for basic mode -----------------------

--- a/mcp-server/src/quota/limiter.test.ts
+++ b/mcp-server/src/quota/limiter.test.ts
@@ -71,6 +71,23 @@ test("inspect: returns counts without consuming a slot", () => {
   assert.equal(lim.check("alice", t).allowed, true);
 });
 
+test("knownIdentities — returns every identity that has been checked", () => {
+  const lim = new IdentityRateLimiter({ limit: 5, windowMs: 60_000 });
+  const t = 1_700_000_000_000;
+  lim.check("alice", t);
+  lim.check("bob", t);
+  lim.check("alice", t);
+  const ids = lim.knownIdentities().sort();
+  assert.deepEqual(ids, ["alice", "bob"]);
+});
+
+test("inspect on an unknown identity returns count=0", () => {
+  const lim = new IdentityRateLimiter({ limit: 5, windowMs: 60_000 });
+  const ins = lim.inspect("never-seen");
+  assert.equal(ins.count, 0);
+  assert.equal(ins.limit, 5);
+});
+
 test("reset clears all buckets", () => {
   const lim = new IdentityRateLimiter({ limit: 1, windowMs: 60_000 });
   const t = 1_700_000_000_000;

--- a/mcp-server/src/quota/limiter.ts
+++ b/mcp-server/src/quota/limiter.ts
@@ -97,6 +97,11 @@ export class IdentityRateLimiter {
     return { count, limit: this.limit, windowMs: this.windowMs };
   }
 
+  /** All identities we've ever seen — for /api/usage aggregation. */
+  knownIdentities(): string[] {
+    return Array.from(this.buckets.keys());
+  }
+
   /** For testing — reset every identity's bucket. */
   reset(): void {
     this.buckets.clear();


### PR DESCRIPTION
## Summary
E6 deferred the \`/api/usage\` endpoint. The bucket state is already there from the rate limiter — just needed to be exposed.

- \`IdentityRateLimiter.knownIdentities()\` enumerates every caller the limiter has seen.
- \`GET /api/usage\` gated by \`need(\"audit\",\"read\")\` returns \`{ identities: [{actor, count, limit, windowMs}], defaultLimit, windowMs }\`. Optional \`?actor=<name>\` narrows the response.
- Doc table extended with the response shape.

Tests cover \`knownIdentities()\` returning every checked id and \`inspect()\` being safe on unknown identities.

## Test plan
- [x] 2 new unit tests
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)