### PR TITLE
feat(rbac): GET /api/policy — admin-only view of the active policy

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -79,6 +79,15 @@ under `permissions: […]` so the Web UI hides write controls (Add
 Source, Save Settings, etc.) the current user can't operate. The
 server is still the authoritative gate — UI hiding is purely a UX win.
 
+Admins debugging "why did role X get a 403?" can pull the full active
+policy without a source checkout:
+
+```bash
+curl -s -b "omcp_session=$ADMIN_COOKIE" "$URL/api/policy" | jq .
+# { "policy": { "viewer": [...], "operator": [...], "admin": [...] },
+#   "roles": ["viewer", "operator", "admin"], "note": "..." }
+```
+
 ## Audit log
 
 Every mutating `/api/*` request produces one append-only entry with

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -49,6 +49,7 @@ import {
 import {
   buildRequirePermission,
   listGrantedPermissions,
+  DEFAULT_POLICY,
   type Resource,
   type Action,
 } from "./auth/rbac.js";
@@ -651,6 +652,7 @@ async function main() {
     "/api/audit",
     "/api/usage",
     "/api/catalog",
+    "/api/policy",
   ]) {
     app.use(prefix, requireSession);
   }
@@ -771,6 +773,19 @@ async function main() {
       user: { sub: sess.sub, name: sess.name, roles: sess.roles ?? [] },
       permissions: listGrantedPermissions(sess.roles),
       exp: sess.exp,
+    });
+  });
+
+  // --- /api/policy — read-only view of the RBAC policy in effect -------
+  // Useful when an operator is debugging "why did role X get a 403" and
+  // doesn't have a checkout to read DEFAULT_POLICY from source. Gated
+  // by admin-only delete-on-users so the policy schema isn't visible
+  // to non-admin sessions.
+  app.get("/api/policy", need("users", "delete"), (_req, res) => {
+    res.json({
+      policy: DEFAULT_POLICY,
+      roles: Object.keys(DEFAULT_POLICY),
+      note: "DEFAULT_POLICY shipped with this build. Custom policies are not yet hot-reloadable.",
     });
   });
 

--- a/mcp-server/src/openapi.ts
+++ b/mcp-server/src/openapi.ts
@@ -335,6 +335,30 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
           },
         },
       },
+      "/api/policy": {
+        get: {
+          tags: ["auth"],
+          summary: "Read-only view of the active RBAC DEFAULT_POLICY (admin-only).",
+          responses: {
+            "200": {
+              description: "Policy map keyed by role.",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      policy: { type: "object", additionalProperties: true },
+                      roles: { type: "array", items: { type: "string" } },
+                      note: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+            "403": { description: "Missing users:delete permission (admin-only)." },
+          },
+        },
+      },
       "/api/catalog": {
         get: {
           tags: ["catalog"],


### PR DESCRIPTION
## Summary
Operators debugging \"why did role X get a 403?\" had to read \`DEFAULT_POLICY\` from \`src/auth/rbac.ts\`. Exposes a read-only view at \`GET /api/policy\` gated by \`need(\"users\",\"delete\")\` — admin-only.

Response shape:
\`\`\`json
{
  \"policy\": { \"viewer\": [...], \"operator\": [...], \"admin\": [...] },
  \"roles\": [\"viewer\", \"operator\", \"admin\"],
  \"note\": \"DEFAULT_POLICY shipped with this build. Custom policies are not yet hot-reloadable.\"
}
\`\`\`

OpenAPI entry added under the \`auth\` tag with the 403 case. \`/api/policy\` added to the protected-route prefix list so basic mode requires a session before the RBAC gate runs. \`docs/access-control.md\` updated with a curl snippet.

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)