### PR TITLE
scripts(verify-audit): --quiet flag for unattended cron monitoring

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -107,6 +107,14 @@ node scripts/verify-audit.mjs /var/log/omcp/audit.jsonl
 The script uses only node built-ins (no `node_modules`) so it works
 straight from a source checkout on an air-gapped operator workstation.
 
+For unattended cron monitoring, pass `--quiet` — success produces no
+stdout, failure still writes the `{ ok: false, brokenAt, reason }`
+JSON. Pair with a non-zero-exit handler in your job runner:
+
+```cron
+0 * * * * node /opt/observability-mcp/scripts/verify-audit.mjs --quiet /var/log/omcp/audit.jsonl
+```
+
 - File path: `OMCP_MGMT_AUDIT_FILE` (JSONL, append-only). Unset → an
   in-memory ring of the last 500 entries serves the same `GET /api/audit`
   endpoint, useful for the demo / single-user case.

--- a/scripts/verify-audit.mjs
+++ b/scripts/verify-audit.mjs
@@ -45,16 +45,28 @@ function verifyChain(entries) {
 }
 
 function usage() {
-  stderr.write(`Usage: node scripts/verify-audit.mjs <path-to-audit.jsonl>\n`);
+  stderr.write(`Usage: node scripts/verify-audit.mjs [--quiet] <path-to-audit.jsonl>\n`);
   stderr.write(`\n`);
   stderr.write(`Exits 0 on a clean chain; non-zero with a brokenAt index + reason\n`);
   stderr.write(`on the first failure. Designed for offline / air-gapped operator\n`);
   stderr.write(`use — no node_modules required.\n`);
+  stderr.write(`\n`);
+  stderr.write(`Flags:\n`);
+  stderr.write(`  --quiet, -q   silent on success; failure JSON still goes to stdout.\n`);
+  stderr.write(`                Pairs cleanly with cron — no spam on a healthy chain.\n`);
 }
 
 function main() {
-  const path = argv[2];
-  if (!path || path === "-h" || path === "--help") { usage(); exit(path ? 0 : 2); }
+  const args = argv.slice(2);
+  let quiet = false;
+  const positional = [];
+  for (const a of args) {
+    if (a === "--quiet" || a === "-q") quiet = true;
+    else if (a === "-h" || a === "--help") { usage(); exit(0); }
+    else positional.push(a);
+  }
+  const path = positional[0];
+  if (!path) { usage(); exit(2); }
   let raw;
   try { raw = readFileSync(path, "utf8"); }
   catch (e) { stderr.write(`cannot read ${path}: ${e.message}\n`); exit(1); }
@@ -68,14 +80,15 @@ function main() {
     catch { stderr.write(`line ${lineNo}: not valid JSON, skipping\n`); }
   }
   if (entries.length === 0) {
-    stdout.write(JSON.stringify({ ok: true, entries: 0, note: "empty file" }) + "\n");
+    if (!quiet) stdout.write(JSON.stringify({ ok: true, entries: 0, note: "empty file" }) + "\n");
     return;
   }
   const result = verifyChain(entries);
   if (result.ok) {
-    stdout.write(JSON.stringify({ ok: true, entries: entries.length, tipHash: entries[entries.length - 1].hash }, null, 2) + "\n");
+    if (!quiet) stdout.write(JSON.stringify({ ok: true, entries: entries.length, tipHash: entries[entries.length - 1].hash }, null, 2) + "\n");
     exit(0);
   }
+  // Failures are always loud — cron monitors key off this.
   stdout.write(JSON.stringify({ ok: false, entries: entries.length, ...result }, null, 2) + "\n");
   exit(1);
 }

--- a/scripts/verify-audit.test.mjs
+++ b/scripts/verify-audit.test.mjs
@@ -117,6 +117,35 @@ test("verify-audit — exits 1 with cannot-read on a missing file", () => {
   assert.match(r.stderr, /cannot read/);
 });
 
+test("verify-audit --quiet — silent on success, exit 0", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "omcp-verify-"));
+  try {
+    const file = join(dir, "audit.jsonl");
+    await writeChain(file, 3);
+    const r = run(["--quiet", file]);
+    assert.equal(r.status, 0);
+    assert.equal(r.stdout, "", "expected no stdout on quiet success");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("verify-audit --quiet — failure still emits JSON to stdout, exit 1", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "omcp-verify-"));
+  try {
+    const file = join(dir, "audit.jsonl");
+    await writeChain(file, 2);
+    const raw = await (await import("node:fs/promises")).readFile(file, "utf8");
+    await writeFile(file, raw.replace(/"sub":"alice"/, '"sub":"mallory"'), "utf8");
+    const r = run(["-q", file]);
+    assert.equal(r.status, 1);
+    const out = JSON.parse(r.stdout);
+    assert.equal(out.ok, false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("verify-audit — skips malformed JSONL lines, verifies the rest", async () => {
   const dir = await mkdtemp(join(tmpdir(), "omcp-verify-"));
   try {


### PR DESCRIPTION
## Summary
Adds \`--quiet\` / \`-q\` to \`verify-audit.mjs\` that suppresses the JSON output on the success path. Failures still go to stdout because the cron job runner needs something to capture / mail on a non-zero exit.

- No-arg call still emits success JSON (the existing human-friendly path).
- \`--quiet\` success: stdout empty, exit 0.
- \`--quiet\` failure: failure JSON on stdout, exit 1 — identical to the loud failure path.

Two new \`node:test\` cases pin the quiet-success and quiet-failure behaviours (8/8 cases now pass locally).

\`docs/access-control.md\` gets a sample cron line operators can copy-paste.

## Test plan
- [x] 8/8 \`scripts/verify-audit.test.mjs\` pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)