### PR TITLE
feat(auth): hot-reload OMCP_USERS_FILE on the next login attempt

### DIFF
--- a/docs/auth-basic.md
+++ b/docs/auth-basic.md
@@ -87,6 +87,16 @@ Set `OMCP_AUTH_ALLOW_FALLBACK=true` to opt back into the older
 "log-and-degrade-to-anonymous" behaviour — only sensible for throwaway
 demos.
 
+### Hot-reload
+
+Editing `OMCP_USERS_FILE` while the server is running takes effect on
+the **next login attempt**. Each `POST /api/auth/login` stats the file
+and re-reads it when the mtime has changed since the previous attempt
+— no server restart needed. The server logs a single `[auth]
+OMCP_USERS_FILE changed — reloaded N user(s)` line each time the file
+reloads. A transient read error (network FS hiccup) keeps the cached
+set so logins continue to work with the last known users.
+
 ## What's gated, what isn't
 
 In basic mode the cookie is required for every `/api/*` route **except**:

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -838,11 +838,51 @@ async function main() {
     legacyHeaders: false,
     message: { error: "too many login attempts, slow down" },
   });
-  app.post("/api/auth/login", loginRateLimit, (req, res) => {
+  // Cached users-file mtime — on every login we stat the file and
+  // re-read when it's changed since the last check. Adding/removing
+  // a user therefore takes effect on the next login attempt, no server
+  // restart required. Cheap path: a single stat() per attempt; the
+  // rate limit caps that at 20/min/IP anyway.
+  let lastUsersMtimeMs: number | null = null;
+  async function maybeReloadUsers(): Promise<void> {
+    const path = process.env.OMCP_USERS_FILE;
+    if (!path) return;
+    try {
+      const { stat } = await import("node:fs/promises");
+      const st = await stat(path);
+      const mtime = st.mtimeMs;
+      if (lastUsersMtimeMs === null || mtime !== lastUsersMtimeMs) {
+        const fresh = await readUsersFile(path);
+        if (fresh && fresh.users.length > 0) {
+          usersStore = fresh;
+          lastUsersMtimeMs = mtime;
+          if (lastUsersMtimeMs !== null) {
+            console.log(`[auth] OMCP_USERS_FILE changed — reloaded ${fresh.users.length} user(s)`);
+          }
+        }
+      }
+    } catch {
+      // File transiently unreadable — keep the cached store; logins
+      // will continue to work with the last known set.
+    }
+  }
+  // Prime the cache so the first login doesn't log "changed" on every boot.
+  if (authRuntime.mode === "basic") {
+    const path = process.env.OMCP_USERS_FILE;
+    if (path) {
+      try {
+        const { statSync } = await import("node:fs");
+        lastUsersMtimeMs = statSync(path).mtimeMs;
+      } catch { /* ignore — first login will pick it up */ }
+    }
+  }
+
+  app.post("/api/auth/login", loginRateLimit, async (req, res) => {
     if (authRuntime.mode !== "basic" || !sessionCfg || !usersStore) {
       res.status(503).json({ error: "auth mode does not accept logins" });
       return;
     }
+    await maybeReloadUsers();
     const body = (req.body || {}) as { username?: unknown; password?: unknown };
     const username = typeof body.username === "string" ? body.username.trim() : "";
     const password = typeof body.password === "string" ? body.password : "";


### PR DESCRIPTION
## Summary
Editing the users file while the server is running used to require a restart for new entries to take effect — fine for a demo, painful in real ops (\"Alice was just hired, add her without a deploy?\").

\`POST /api/auth/login\` now stats \`OMCP_USERS_FILE\` and re-reads when the mtime has changed since the last attempt. One extra \`fstat()\` per login; the 20/min/IP rate limit caps the cost regardless.

### Failure modes
- mtime cache primed at startup so the first real login doesn't log a spurious \"reloaded\" line.
- Transient read error (NFS hiccup) silently retains the cached store — logins keep working with the last known users.
- Empty reload result is ignored — same fail-closed-on-empty rule the boot path uses.
- One info log line per actual reload for trace in journalctl / kubectl logs.

\`docs/auth-basic.md\` gets a \"Hot-reload\" section under the env-var table.

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)