### PR TITLE
feat(quota): emit X-RateLimit-* headers on /mcp responses

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -133,6 +133,15 @@ The `/mcp` HTTP transport carries one per-identity sliding window:
 (no `OMCP_API_KEYS`) is unaffected; the existing IP-level
 express-rate-limit still applies.
 
+Every `/mcp` response carries the live bucket state in headers so a
+well-behaved client can self-pace before hitting the cap:
+
+```http
+X-RateLimit-Limit: 60
+X-RateLimit-Remaining: 47
+X-RateLimit-Window-Ms: 60000
+```
+
 A breached cap returns:
 
 ```http

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1447,6 +1447,12 @@ async function main() {
       return null;
     }
     const decision = toolRateLimiter.check(cred.name);
+    // Standard RateLimit response headers — let well-behaved clients
+    // self-pace before they hit a 429. Emitted on BOTH allowed and
+    // denied paths so the caller always sees the live state.
+    res.setHeader("X-RateLimit-Limit", String(decision.limit));
+    res.setHeader("X-RateLimit-Remaining", String(Math.max(0, decision.limit - decision.count)));
+    res.setHeader("X-RateLimit-Window-Ms", String(decision.windowMs));
     if (!decision.allowed) {
       res.setHeader("Retry-After", String(decision.retryAfterSeconds));
       res.status(429).json({


### PR DESCRIPTION
## Summary
A well-behaved client wants to self-pace before hitting a 429. The limiter already knows the live count + limit at request time — just needed to surface them.

Adds three headers on every gated \`/mcp\` response (both allowed and denied paths):
\`\`\`
X-RateLimit-Limit:        60
X-RateLimit-Remaining:    47   (clamped at 0 on the denied path)
X-RateLimit-Window-Ms:    60000
\`\`\`

Matches the convention \`express-rate-limit\`'s \`standardHeaders\` option already uses on the management plane, so the two surfaces speak the same vocabulary.

\`docs/access-control.md\` picks up a short example block showing the healthy headers immediately before the 429 sample.

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)