### PR TITLE
feat(net): OMCP_TRUST_PROXY for real client IP behind a reverse proxy

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -189,6 +189,23 @@ The agent sees ownership context inline — no separate CMDB hop.
 Without the env var the file is missing → empty catalog → enrichment
 is a no-op.
 
+## Behind a reverse proxy
+
+By default `req.ip` is the raw socket address, so a fronting nginx / Envoy
+/ ingress controller makes every audit entry look like `127.0.0.1`. Set
+`OMCP_TRUST_PROXY` to one of:
+
+| Value | Meaning |
+|---|---|
+| `true` | trust every upstream hop (Express default-on shape) |
+| `loopback` | trust `127.0.0.1` / `::1` only (sensible same-host nginx default) |
+| an integer | trust the last *n* hops |
+| comma-separated IPs | explicit list of upstreams to trust |
+
+Unset / `false` keeps the safe default. The same setting also fixes the
+`Secure` cookie attribute behind TLS-terminating proxies (the server
+detects HTTPS via `req.secure || X-Forwarded-Proto`).
+
 ## Investigation runbook
 
 ### "Who changed source `payment-prod` yesterday?"

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -563,6 +563,32 @@ async function main() {
 
   // --- HTTP server ---
   const app = express();
+
+  // Trust-proxy: when set, Express will read req.ip / req.secure from
+  // X-Forwarded-For + X-Forwarded-Proto. OFF by default — forging those
+  // headers behind a misconfigured deployment is the kind of mistake
+  // that gives every audit entry the same client IP. Set
+  // `OMCP_TRUST_PROXY` to:
+  //   "true"            — trust every hop (Express default-on shape)
+  //   "loopback"        — trust 127.0.0.1 / ::1 only (sensible default
+  //                       when running behind a same-host nginx)
+  //   "<n>"             — trust the last <n> hops
+  //   "<ip>,<ip>"       — explicit list (single value or comma-separated)
+  // Any falsy / unset value leaves it OFF so req.ip stays the raw
+  // socket address.
+  const trustProxy = process.env.OMCP_TRUST_PROXY;
+  if (trustProxy && trustProxy !== "false") {
+    if (trustProxy === "true") {
+      app.set("trust proxy", true);
+    } else if (/^\d+$/.test(trustProxy)) {
+      app.set("trust proxy", parseInt(trustProxy, 10));
+    } else {
+      // string or comma-separated IPs / "loopback" / etc — let Express's
+      // parser handle the lookup (it accepts any of the above forms).
+      app.set("trust proxy", trustProxy);
+    }
+  }
+
   app.use(express.json({ limit: "1mb" }));
 
   // Security headers


### PR DESCRIPTION
## Summary
A fronting nginx / Envoy / ingress controller hides the real client IP — every audit entry ends up tagged \`127.0.0.1\`, every per-IP rate limit sees one bucket, the \`Secure\` cookie attribute doesn't trip because \`req.secure\` is false on the back-channel HTTP hop.

Adds \`OMCP_TRUST_PROXY\` honoured at startup. Accepted forms:

| Value | Meaning |
|---|---|
| \`true\` | trust every upstream hop |
| \`loopback\` | trust \`127.0.0.1\` / \`::1\` only |
| integer | trust the last *n* hops |
| comma-separated IPs | explicit list |

Unset / \`false\` keeps the safe default — \`req.ip\` stays the raw socket address and \`X-Forwarded-*\` headers are ignored, so a forged header on a public listener can't impersonate a different IP.

The setting feeds Express's existing \`trust proxy\` app-setting, which the audit middleware, rate limiter, and Secure-cookie detection already read. **No call-site changes required.**

\`docs/access-control.md\` gets a \"Behind a reverse proxy\" section.

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)