### PR TITLE
make(doctor): probe /api/me to report the active auth mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,15 @@ doctor: ## Quick health check — is the mcp-server reachable on $$OMCP_HOST:$$O
 	else \
 	  echo "FAIL — server is up but MCP handshake did not return serverInfo"; exit 1; \
 	fi
+	@printf "Probing /api/me identity discovery ... "
+	@me=$$(curl -fsS --max-time 3 "http://$(OMCP_HOST):$(OMCP_PORT)/api/me" 2>/dev/null || echo ''); \
+	if [ -z "$$me" ]; then \
+	  echo "FAIL — endpoint missing (older server build?)"; \
+	else \
+	  mode=$$(echo "$$me" | jq -r '.mode // "?"'); \
+	  auth=$$(echo "$$me" | jq -r '.authenticated // false'); \
+	  echo "ok (mode=$$mode authenticated=$$auth)"; \
+	fi
 	@echo
 	@echo "All good. Wire your agent up with:"
 	@echo "  make connect-claude-code   # Claude Code / Claude Desktop"


### PR DESCRIPTION
## Summary
\`make doctor\` already verifies \`/healthz\` + the MCP handshake. Adds a third probe against \`/api/me\` so the operator sees the active auth mode + authenticated state without an extra curl:

\`\`\`
Probing /api/me identity discovery ... ok (mode=anonymous authenticated=false)
Probing /api/me identity discovery ... ok (mode=basic authenticated=true)
\`\`\`

Reports a graceful FAIL (no exit) when the endpoint is missing — older 1.7.x servers don't have it, and doctor's other probes still report ok. Pairs cleanly with the reverse-proxy check (#254): both the auth mode and the trust-proxy effect are now observable from a single command.

## Test plan
- [ ] CI green (Makefile-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)