### PR TITLE
feat(info): expose governance posture on /api/info

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -759,6 +759,19 @@ async function main() {
         platform: process.platform,
         arch: process.arch,
       },
+      // Governance posture — surfaces the active management-plane
+      // configuration so external dashboards / discovery probes don't
+      // need a session to learn the deployment shape. Booleans only;
+      // file paths and the session secret stay private.
+      governance: {
+        authMode: authRuntime.mode,
+        authSecretEphemeral: !!authRuntime.secretEphemeral,
+        auditPersisted: !!process.env.OMCP_MGMT_AUDIT_FILE,
+        catalogConfigured: catalog.count() > 0 || !!process.env.OMCP_SERVICE_CATALOG_FILE,
+        redaction: REDACTION_ENABLED,
+        trustProxy: !!(process.env.OMCP_TRUST_PROXY && process.env.OMCP_TRUST_PROXY !== "false"),
+        toolRatePerMin: Number(process.env.OMCP_TOOL_RATE_PER_MIN) || 60,
+      },
       plugins: loader.list().map((p) => ({
         name: p.name,
         source: p.source,


### PR DESCRIPTION
## Summary
External dashboards / discovery probes hitting \`/api/info\` had no way to learn the deployment's governance shape without an authenticated session — knowing \"is auth on?\" is a legitimate operator question that doesn't need a credential.

Adds a new \`governance\` block to the \`/api/info\` response:

\`\`\`json
{
  \"governance\": {
    \"authMode\": \"basic\",
    \"authSecretEphemeral\": false,
    \"auditPersisted\": true,
    \"catalogConfigured\": true,
    \"redaction\": true,
    \"trustProxy\": true,
    \"toolRatePerMin\": 60
  }
}
\`\`\`

**Booleans + the rate-limit number only** — no file paths, no session secret, no user counts. External tooling can now alert on \"production reverted to anonymous mode\" without holding a session cookie.

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)