### PR TITLE
ui: surface catalog enrichment in the Services list

### DIFF
--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -3018,9 +3018,22 @@ function renderServices() {
     return;
   }
   const visible = servicesData.filter(filterSvcRow);
+  // Catalog enrichment is optional — when /api/services returned a
+  // `.catalog` field (because OMCP_SERVICE_CATALOG_FILE is set and
+  // the service name matched an entry), surface the most useful
+  // fields inline: owner chip, criticality tier pill, on-call link.
+  // Otherwise the row renders exactly as before.
+  const catalogStrip = (c) => {
+    if (!c) return '';
+    const parts = [];
+    if (c.owner) parts.push(`<span class="chip">owner: ${esc(c.owner)}</span>`);
+    if (c.tier)  parts.push(`<span class="chip">${esc(c.tier)}</span>`);
+    if (c.onCall) parts.push(`<a class="chip" href="${esc(c.onCall)}" target="_blank" rel="noopener">on-call ↗</a>`);
+    return parts.length ? ` <span class="row-inline gap-2">${parts.join('')}</span>` : '';
+  };
   const rowsHtml = visible.length === 0
     ? `<div class="empty">No services match "${esc(svcFilter)}".</div>`
-    : visible.map(s=>`<div class="service-row" data-svc="${esc(s.name)}"><div><span class="name">${esc(s.name)}</span>${s.signalTypes.map(t=>`<span class="tag tag-${t}">${t}</span>`).join('')}</div><span class="t-muted t-sm">${s.sources.join(', ')}</span></div>`).join('');
+    : visible.map(s=>`<div class="service-row" data-svc="${esc(s.name)}"><div><span class="name">${esc(s.name)}</span>${s.signalTypes.map(t=>`<span class="tag tag-${t}">${t}</span>`).join('')}${catalogStrip(s.catalog)}</div><span class="t-muted t-sm">${s.sources.join(', ')}</span></div>`).join('');
   if (sl) {
     const filterBar = `<div class="list-filter">
       <input id="svc-filter" type="search" placeholder="Filter services by name or source…" value="${esc(svcFilter)}" oninput="setSvcFilter(this.value)" aria-label="Filter services">


### PR DESCRIPTION
## Summary
#233 hooked the service catalog into the \`/api/services\` response, but the Web UI's Services tab ignored the \`.catalog\` enrichment. The agent saw it; the operator didn't.

Renders the three most operationally-useful fields inline on each service row when the enrichment is present:

\`\`\`
payment-service [metrics] [logs] owner: team-payments  tier-1  on-call ↗
\`\`\`

Reuses existing \`.chip\` + \`.row-inline\` utility classes — **no new CSS, no layout change** for rows without catalog data, no behaviour change when \`OMCP_SERVICE_CATALOG_FILE\` is unset.

On-call URLs open in a new tab with \`rel=\"noopener\"\` — operator-curated config is trusted but the target may not be. SLO / runbooks / dataClassification stay reserved for the future detail drawer.

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)