### PR TITLE
docs(readme): point at access-control.md from the quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ The server starts with **zero sources**. Add Prometheus/Loki via the Web UI or `
 > `make connect-cursor`. `make doctor` round-trips a real MCP handshake against
 > a running server and tells you what to fix if it can't.
 
+> **Multi-user / production?** See [docs/access-control.md](docs/access-control.md)
+> for the opt-in basic-mode login + RBAC + audit log + per-identity rate limit
+> setup. All off by default; the demo above is unchanged.
+
 Want the full chaos-engineering demo (Prometheus + Loki + 3 example services + the autonomous agent)? Clone and run:
 
 ```bash


### PR DESCRIPTION
## Summary
The access-control runbook was only linked from the deep Docs section, which an operator evaluating the project for a multi-user team is unlikely to scroll past on first read.

Adds a single blockquote right under the \"make doctor\" hint in the **Try-it-in-10-seconds** section:

> **Multi-user / production?** See \`docs/access-control.md\` for the opt-in basic-mode login + RBAC + audit log + per-identity rate limit setup. All off by default; the demo above is unchanged.

Same anchor that the docs-index link uses, so search engines and README scrollers can both reach the runbook in one click. No substantive content change.

## Test plan
- [ ] CI green (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)