### PR TITLE
feat(redaction): Luhn-checked credit-card redaction

### DIFF
--- a/docs/redaction.md
+++ b/docs/redaction.md
@@ -24,6 +24,7 @@ scrubbing — not a substitute for it.
 | `slack-token` | `xox[abprsu]-…` Slack tokens | `[redacted-slack-token]` |
 | `gh-pat` | `gh[opsuru]_…` and `github_pat_…` GitHub personal access tokens | `[redacted-gh-pat]` |
 | `private-key` | PEM-encoded `-----BEGIN [...] PRIVATE KEY-----` blocks (greedy across newlines) | `[redacted-private-key]` |
+| `credit-card` | 13–19 digit sequences (with optional `- ` separators) that pass a **Luhn check** so order IDs and timestamps don't get over-redacted | `[redacted-credit-card]` |
 
 The categories are non-overlapping — each redacted region is replaced by
 a category-tagged marker that no later pattern matches, so a second pass

--- a/mcp-server/src/policy/redact.test.ts
+++ b/mcp-server/src/policy/redact.test.ts
@@ -55,6 +55,15 @@ test("redactText — leaves harmless text alone", () => {
   assert.equal(r.text, "the order-service replied with 200 OK after 45ms");
 });
 
+test("redactText — long digit strings without Luhn don't trigger credit-card", () => {
+  // 16-digit telemetry sequence (UNIX nanos + service id) — should pass through.
+  const r = redactText("ts=1717000000000000000 seq=4242424242424242 user=test");
+  // 4242424242424242 IS Luhn-valid (Visa test number), so that counts as a hit;
+  // but ts=1717... starts with a non-bordered digit run that includes "1717" pattern.
+  // The assertion: only the Luhn-valid 16-digit string is counted as credit-card.
+  assert.equal(r.matches["credit-card"], 1);
+});
+
 test("redactText — already-redacted markers don't re-match in further passes", () => {
   // Run the redactor twice; the second pass should be a no-op.
   const first = redactText("contact alice@example.com");
@@ -108,6 +117,27 @@ test("redactText — GitHub PATs are redacted (ghp_ / github_pat_)", () => {
   const r2 = redactText("token github_pat_ABCDEFGH_IJKLMNOPQRSTUVWXYZ012345678ABCDEFGHIJKLMNOP");
   assert.equal(r1.matches["gh-pat"], 1);
   assert.equal(r2.matches["gh-pat"], 1);
+});
+
+test("redactText — Luhn-valid credit-card numbers are redacted, invalid ones pass through", () => {
+  // Visa test number 4111 1111 1111 1111 (Luhn-valid)
+  const r1 = redactText("charge attempted on card 4111111111111111 for $42.00");
+  assert.equal(r1.matches["credit-card"], 1);
+  assert.match(r1.text, /\[redacted-credit-card\]/);
+
+  // Same number with separators
+  const r2 = redactText("card 4111-1111-1111-1111 declined");
+  assert.equal(r2.matches["credit-card"], 1);
+  assert.doesNotMatch(r2.text, /4111-1111-1111-1111/);
+
+  // Random 16 digits that DON'T pass Luhn → left alone (e.g. order ID)
+  const r3 = redactText("order 1234567890123456 created");
+  assert.equal(r3.matches["credit-card"], 0);
+  assert.match(r3.text, /1234567890123456/);
+
+  // Too short / too long stays as-is
+  const r4 = redactText("seq 123456789012 and 12345678901234567890");
+  assert.equal(r4.matches["credit-card"], 0);
 });
 
 test("redactText — PEM private-key blocks are redacted greedily", () => {

--- a/mcp-server/src/policy/redact.ts
+++ b/mcp-server/src/policy/redact.ts
@@ -23,7 +23,8 @@ export type RedactionCategory =
   | "aws-key"
   | "slack-token"
   | "private-key"
-  | "gh-pat";
+  | "gh-pat"
+  | "credit-card";
 
 export interface RedactionResult {
   text: string;
@@ -66,7 +67,27 @@ function emptyCounts(): Record<RedactionCategory, number> {
   return {
     email: 0, ipv4: 0, ipv6: 0, bearer: 0, jwt: 0, "api-key": 0,
     "aws-key": 0, "slack-token": 0, "private-key": 0, "gh-pat": 0,
+    "credit-card": 0,
   };
+}
+
+/** Luhn check — accepts digits-only string of 13–19 chars. Used to
+ * keep the credit-card redaction from over-matching random digit
+ * strings (order IDs, timestamps, etc.). */
+function luhn(digits: string): boolean {
+  let sum = 0;
+  let alt = false;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let n = digits.charCodeAt(i) - 48;
+    if (n < 0 || n > 9) return false;
+    if (alt) {
+      n *= 2;
+      if (n > 9) n -= 9;
+    }
+    sum += n;
+    alt = !alt;
+  }
+  return sum % 10 === 0;
 }
 
 /** Run all patterns in a deterministic order; later patterns won't
@@ -81,6 +102,16 @@ export function redactText(input: string): RedactionResult {
       return `[redacted-${category}]`;
     });
   }
+  // Credit-card pass runs last so an inner-substring of a longer
+  // already-redacted token can't accidentally match. Luhn-validated
+  // so order numbers / timestamps / random digit strings stay intact.
+  text = text.replace(/\b(?:\d[ -]?){12,18}\d\b/g, (match) => {
+    const digits = match.replace(/[ -]/g, "");
+    if (digits.length < 13 || digits.length > 19) return match;
+    if (!luhn(digits)) return match;
+    matches["credit-card"] += 1;
+    return "[redacted-credit-card]";
+  });
   let total = 0;
   for (const k of Object.keys(matches) as RedactionCategory[]) total += matches[k];
   return { text, matches, totalMatches: total };


### PR DESCRIPTION
## Summary
Adds a \`credit-card\` category to the redactor. Matches 13–19 digit sequences (with optional dash / space separators) and gates the match behind a **Luhn check** so random digit strings — order IDs, UNIX-nano timestamps, correlation IDs — don't get over-redacted.

Runs as the **last pass** after every other pattern so an embedded credit-card-shape substring of an already-redacted token can't match.

## Test plan
- [x] 5 new unit tests: visa test number with/without separators, random 16 digits (no Luhn → pass through), too-short / too-long, telemetry-with-embedded-Luhn-valid-substring
- [x] Docs table extended with the Luhn-validation note
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)