### PR TITLE
ui: prefill last-used username in the login modal

### DIFF
--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -1944,7 +1944,18 @@ function omcpEnsureLoggedIn() {
   _omcpLoginInflight = new Promise((resolve) => { _omcpLoginResolve = resolve; });
   const m = document.getElementById('login-modal');
   if (m) m.classList.add('open');
-  setTimeout(() => { const u = document.getElementById('login-username'); if (u) u.focus(); }, 50);
+  // Prefill the most recent username (kept in localStorage; the password
+  // field never persists). Focus jumps straight to password when we
+  // already have a username, otherwise to username.
+  setTimeout(() => {
+    const u = document.getElementById('login-username');
+    const p = document.getElementById('login-password');
+    let lastUser = '';
+    try { lastUser = localStorage.getItem('omcp-last-user') || ''; } catch (e) {}
+    if (u && lastUser && !u.value) u.value = lastUser;
+    if (u && p && u.value) p.focus();
+    else if (u) u.focus();
+  }, 50);
   return _omcpLoginInflight;
 }
 function omcpLoginKey(e) { if (e.key === 'Enter') { e.preventDefault(); omcpSubmitLogin(); } }
@@ -1974,6 +1985,9 @@ async function omcpSubmitLogin() {
     document.getElementById('login-modal').classList.remove('open');
     document.getElementById('login-password').value = '';
     banner.className = 'form-banner';
+    // Remember the username for next time so the operator doesn't
+    // retype it on every cookie expiry. Password field never persists.
+    try { localStorage.setItem('omcp-last-user', u); } catch (e) {}
     if (_omcpLoginResolve) { const r = _omcpLoginResolve; _omcpLoginResolve = null; _omcpLoginInflight = null; r(); }
     await omcpSyncIdentity();
   } finally { btn.disabled = false; }


### PR DESCRIPTION
## Summary
Operators renewing their 12-hour session had to retype their username every time. Persist it in localStorage (\`omcp-last-user\`) on every successful sign-in and prefill on next modal open.

**Focus heuristic:** when prefill populated the username, focus jumps straight to the password field; otherwise the username field stays focused as before.

Password explicitly never persists — only the username (not a secret). \`localStorage\` write is wrapped in try/catch so private-browsing tabs still work.

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)