### PR TITLE
docs(redact): fix docstring promising a per-request bypass we don't ship

### DIFF
--- a/mcp-server/src/policy/redact.ts
+++ b/mcp-server/src/policy/redact.ts
@@ -9,8 +9,11 @@
  * (over-redact rather than under-redact) and explicit (each category
  * tagged in the replacement marker, e.g. `[redacted-email]`).
  *
- * Bypass is the operator's call: in basic mode a session with the
- * `redaction:bypass` permission may opt out per-request.
+ * Bypass today is process-wide only: set `OMCP_REDACTION=off` if the
+ * upstream is already PII-clean. A per-request `redaction:bypass` RBAC
+ * permission for interactive admin sessions is on the roadmap — see
+ * docs/access-control.md "Why are my logs returning [redacted-email]?"
+ * and docs/redaction.md for the current state.
  */
 
 export type RedactionCategory =


### PR DESCRIPTION
## Summary
\`mcp-server/src/policy/redact.ts\` documented a \`redaction:bypass\` RBAC permission that does not exist in the code. \`docs/access-control.md\` and \`docs/redaction.md\` already (correctly) list it as a roadmap item; only the source-tree docstring overstated current capability.

Rewrites the bypass paragraph to describe what actually ships (\`OMCP_REDACTION=off\` process-wide) and links to the two operator docs that already mention the future RBAC permission.

Comment-only change. No code or test change.

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)