### PR TITLE
docs: cross-link auth-basic.md and redaction.md to the access-control runbook

### DIFF
--- a/docs/auth-basic.md
+++ b/docs/auth-basic.md
@@ -136,3 +136,9 @@ The session cookie (`omcp_session`) is:
   stored in plaintext, never committed to git.
 - [ ] If you also expose `/mcp`, set `OMCP_API_KEYS` so the MCP transport
   isn't anonymous.
+
+## See also
+
+- [access-control.md](access-control.md) — the one-stop runbook covering
+  basic-mode auth alongside RBAC, audit log, redaction, rate limits,
+  reverse-proxy setup, and the investigation playbook.

--- a/docs/redaction.md
+++ b/docs/redaction.md
@@ -74,3 +74,10 @@ flip redaction off for one tool call without restarting the server.
 docker run --rm -w /app -v "$(pwd)/mcp-server:/app" node:20-alpine \
   sh -c "npm i --silent && npx tsx --test src/policy/redact.test.ts"
 ```
+
+## See also
+
+- [access-control.md](access-control.md) — the runbook for the surrounding
+  governance layers (basic-mode auth, RBAC, audit log, rate limits) and
+  the investigation playbook entry "Why are my logs returning
+  `[redacted-email]`?".


### PR DESCRIPTION
## Summary
\`docs/access-control.md\` is the operator's one-stop runbook, but the two per-feature pages it depends on (\`auth-basic.md\`, \`redaction.md\`) didn't link back. An operator landing on a single-feature page from search or a UI link had no obvious breadcrumb to the wider runbook.

Adds a short \"See also\" section at the bottom of each file naming the runbook and the specific section that's most useful.

Pure docs, no code change.

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)