### PR TITLE
quota: centralize OMCP_TOOL_RATE_PER_MIN parsing, pin the limit=0 footgun

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -57,7 +57,7 @@ import { AuditLog } from "./audit/log.js";
 import { buildAuditMiddleware } from "./audit/middleware.js";
 import { readCatalogFile, CatalogStore } from "./catalog/loader.js";
 import { redactValue } from "./policy/redact.js";
-import { IdentityRateLimiter } from "./quota/limiter.js";
+import { IdentityRateLimiter, resolveToolRatePerMin } from "./quota/limiter.js";
 import { getPluginLoader } from "./connectors/loader.js";
 import {
   resolveHubCatalogUrl,
@@ -770,7 +770,7 @@ async function main() {
         catalogConfigured: catalog.count() > 0 || !!process.env.OMCP_SERVICE_CATALOG_FILE,
         redaction: REDACTION_ENABLED,
         trustProxy: !!(process.env.OMCP_TRUST_PROXY && process.env.OMCP_TRUST_PROXY !== "false"),
-        toolRatePerMin: Number(process.env.OMCP_TOOL_RATE_PER_MIN) || 60,
+        toolRatePerMin: resolveToolRatePerMin(process.env.OMCP_TOOL_RATE_PER_MIN),
       },
       plugins: loader.list().map((p) => ({
         name: p.name,
@@ -860,7 +860,7 @@ async function main() {
     });
     res.json({
       identities,
-      defaultLimit: Number(process.env.OMCP_TOOL_RATE_PER_MIN) || 60,
+      defaultLimit: resolveToolRatePerMin(process.env.OMCP_TOOL_RATE_PER_MIN),
       windowMs: 60_000,
     });
   });
@@ -1465,7 +1465,7 @@ async function main() {
   // configured) bypasses this — the global express-rate-limit IP gate
   // still applies. Override via OMCP_TOOL_RATE_PER_MIN.
   const toolRateLimiter = new IdentityRateLimiter({
-    limit: Number(process.env.OMCP_TOOL_RATE_PER_MIN) || 60,
+    limit: resolveToolRatePerMin(process.env.OMCP_TOOL_RATE_PER_MIN),
   });
 
   // Bearer/X-API-Key on every /mcp request; resolve the principal + its

--- a/mcp-server/src/quota/limiter.test.ts
+++ b/mcp-server/src/quota/limiter.test.ts
@@ -1,7 +1,30 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { IdentityRateLimiter } from "./limiter.js";
+import { IdentityRateLimiter, resolveToolRatePerMin } from "./limiter.js";
+
+test("resolveToolRatePerMin — unset / empty / non-numeric returns default 60", () => {
+  assert.equal(resolveToolRatePerMin(undefined), 60);
+  assert.equal(resolveToolRatePerMin(""), 60);
+  assert.equal(resolveToolRatePerMin("not-a-number"), 60);
+  assert.equal(resolveToolRatePerMin("NaN"), 60);
+});
+
+test("resolveToolRatePerMin — zero / negative falls back to default (limit=0 would deny every call)", () => {
+  // Footgun pin: "0" looks like "disable" but the limiter treats it as
+  // "instantly over-cap". Treat as default so operators don't lock
+  // themselves out by mistake.
+  assert.equal(resolveToolRatePerMin("0"), 60);
+  assert.equal(resolveToolRatePerMin("-1"), 60);
+  assert.equal(resolveToolRatePerMin("-1000"), 60);
+});
+
+test("resolveToolRatePerMin — positive integer passes through; decimals floored", () => {
+  assert.equal(resolveToolRatePerMin("1"), 1);
+  assert.equal(resolveToolRatePerMin("120"), 120);
+  assert.equal(resolveToolRatePerMin("240"), 240);
+  assert.equal(resolveToolRatePerMin("60.7"), 60);
+});
 
 test("allows up to the configured limit, then denies", () => {
   const lim = new IdentityRateLimiter({ limit: 3, windowMs: 60_000 });

--- a/mcp-server/src/quota/limiter.ts
+++ b/mcp-server/src/quota/limiter.ts
@@ -20,6 +20,28 @@
 const DEFAULT_LIMIT_PER_MIN = 60;
 const DEFAULT_WINDOW_MS = 60_000;
 
+/** Resolve `OMCP_TOOL_RATE_PER_MIN` (or any equivalent caller-supplied
+ * string) into the per-identity cap used by the limiter and reported
+ * by `/api/info` + `/api/usage`. Single source of truth, so the three
+ * call sites don't drift.
+ *
+ * Behaviour:
+ * - unset / empty / non-numeric → DEFAULT_LIMIT_PER_MIN (60)
+ * - `"0"` → DEFAULT_LIMIT_PER_MIN (limit=0 would deny every request,
+ *   which is almost never what an operator setting "0" wants — they
+ *   either mean "default" or "disable"; we treat it as "default" and
+ *   leave the explicit disable path on the roadmap)
+ * - negative → DEFAULT_LIMIT_PER_MIN (limit=-1 with the current
+ *   `count >= limit` check would also deny every request)
+ * - any positive integer ≥ 1 → that value
+ */
+export function resolveToolRatePerMin(raw: string | undefined): number {
+  if (raw === undefined || raw === "") return DEFAULT_LIMIT_PER_MIN;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 1) return DEFAULT_LIMIT_PER_MIN;
+  return Math.floor(n);
+}
+
 export interface LimiterConfig {
   /** Cap per identity per window. Defaults to 60. */
   limit?: number;


### PR DESCRIPTION
## Summary
\`Number(process.env.OMCP_TOOL_RATE_PER_MIN) || 60\` appeared in three places and silently misbehaved on operator inputs:
- \`"0"\` → 60 via the \`|| 60\` fallback (reads as "instantly over-cap" in the limiter contract; masking is confusing if the operator meant "disable")
- \`"-1"\` → \`-1\` (truthy), then \`count >= -1\` is permanently true → every MCP request rejected with 429

Extracts a single \`resolveToolRatePerMin()\` helper in \`quota/limiter.ts\` and replaces all three call sites. Adds three test cases pinning the contract (unset / zero / negative → 60; positive integers pass through; decimals floored).

Behaviour on positive-integer input is unchanged.

## Test plan
- [ ] CI green: existing limiter tests + the three new resolver tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)