### PR TITLE
fix(audit): coerce non-finite list({limit}) to default instead of returning empty

### DIFF
--- a/mcp-server/src/audit/log.test.ts
+++ b/mcp-server/src/audit/log.test.ts
@@ -74,6 +74,23 @@ test("AuditLog — in-memory ring honours cap", async () => {
   assert.deepEqual(entries.map((e) => e.actor.sub), ["u9", "u8", "u7"]);
 });
 
+test("AuditLog.list — non-finite / non-positive limit falls back to the 100 default", async () => {
+  const log = new AuditLog({ inMemoryCap: 10 });
+  for (let i = 0; i < 5; i++) {
+    await log.record({ actor: { sub: `u${i}` }, resource: "sources", action: "write", method: "POST", path: "/api/sources", status: 200 });
+  }
+  // NaN — what /api/audit?limit=foo previously produced via parseInt
+  assert.equal(log.list({ limit: Number.NaN }).length, 5);
+  // Negative — no point pretending the caller meant "minus three entries"
+  assert.equal(log.list({ limit: -3 }).length, 5);
+  // Zero — same. The default keeps the response useful.
+  assert.equal(log.list({ limit: 0 }).length, 5);
+  // Sanity: a sensible positive limit still constrains the result
+  assert.equal(log.list({ limit: 2 }).length, 2);
+  // Decimal positive — floored, so 2.9 → 2
+  assert.equal(log.list({ limit: 2.9 }).length, 2);
+});
+
 test("AuditLog — file mode persists and bootstraps", async () => {
   const dir = await mkdtemp(join(tmpdir(), "omcp-audit-"));
   const file = join(dir, "audit.jsonl");

--- a/mcp-server/src/audit/log.ts
+++ b/mcp-server/src/audit/log.ts
@@ -130,7 +130,15 @@ export class AuditLog {
 
   /** Snapshot of the in-memory ring (most recent last). */
   list(opts: { from?: string; to?: string; actor?: string; action?: string; limit?: number } = {}): AuditEntry[] {
-    const lim = Math.max(1, Math.min(opts.limit ?? 100, this.cap));
+    // Coerce non-finite / non-positive limits (NaN from a bad query
+    // string, negative, undefined) to the 100 default. Previously
+    // NaN propagated through Math.min / Math.max and the comparison
+    // `out.length < NaN` was always false, so `?limit=foo` returned
+    // an empty array instead of the default page.
+    const requested = typeof opts.limit === "number" && Number.isFinite(opts.limit) && opts.limit > 0
+      ? Math.floor(opts.limit)
+      : 100;
+    const lim = Math.min(requested, this.cap);
     const out: AuditEntry[] = [];
     for (let i = this.ring.length - 1; i >= 0 && out.length < lim; i--) {
       const e = this.ring[i];


### PR DESCRIPTION
## Summary
\`AuditLog.list({ limit: NaN })\` previously returned an empty array (the loop's \`out.length < NaN\` was always false). The exposing path: \`GET /api/audit?limit=foo\` → \`parseInt("foo", 10)\` → NaN → empty result, with no error surfaced.

Coerces non-finite / non-positive limits to the documented 100 default in one place, and floors positive decimals.

Adds a node:test case pinning the four edge cases (NaN, negative, zero, decimal) plus the positive happy path.

## Test plan
- [ ] CI green: existing audit tests + the new edge-case test

🤖 Generated with [Claude Code](https://claude.com/claude-code)