### PR TITLE
docs(readme): note that make doctor now reports governance posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ The server starts with **zero sources**. Add Prometheus/Loki via the Web UI or `
 > If you'd rather have the snippets above printed by a Make target — including
 > custom-host / custom-port substitution — use `make connect-claude-code` or
 > `make connect-cursor`. `make doctor` round-trips a real MCP handshake against
-> a running server and tells you what to fix if it can't.
+> a running server, reports the live governance posture (auth mode, redaction,
+> audit-log persistence, per-identity rate cap), and tells you what to fix if
+> it can't.
 
 > **Multi-user / production?** See [docs/access-control.md](docs/access-control.md)
 > for the opt-in basic-mode login + RBAC + audit log + per-identity rate limit


### PR DESCRIPTION
## Summary
Previous refine (#280) added a \`/api/info\` probe to \`make doctor\` that prints authMode / redaction / auditPersisted / rate cap. README still described doctor as just "round-trips a real MCP handshake".

One-sentence expansion of the existing tip block.

## Test plan
- [ ] CI green (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)