### PR TITLE
make: hint at Bearer-header config in connect-cursor snippet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,14 @@ connect-claude-code: ## Print the .mcp.json snippet for Claude Code / Claude Des
 
 connect-cursor: ## Print the MCP config snippet for Cursor
 	@echo "# Drop into ~/.cursor/mcp.json (create the file if it doesn't exist)"
+	@echo "# If the server has OMCP_API_KEYS set, add a Bearer header — see"
+	@echo "# the commented \"headers\" block below."
 	@echo ""
 	@echo '{'
 	@echo '  "mcpServers": {'
 	@echo '    "observability": {'
 	@echo '      "url": "http://$(OMCP_HOST):$(OMCP_PORT)/mcp"'
+	@echo '      // "headers": { "Authorization": "Bearer <your-api-key>" }'
 	@echo '    }'
 	@echo '  }'
 	@echo '}'


### PR DESCRIPTION
## Summary
\`make connect-cursor\` printed only \`url\` — fine for the anonymous default, but operators who set OMCP_API_KEYS on the server had no hint how to pass the bearer token from Cursor.

Adds a hint comment and a commented \`headers\` line inside the JSON block so the user can uncomment-and-fill.

## Test plan
- [ ] CI green (Makefile-only output change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)