### PR TITLE
make: hint at Bearer-header config in connect-claude-code snippet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ connect-claude-code: ## Print the .mcp.json snippet for Claude Code / Claude Des
 	@echo "# (Claude Code: claude mcp add observability --transport http http://$(OMCP_HOST):$(OMCP_PORT)/mcp)"
 	@echo "# (Claude Desktop: ~/.config/Claude/claude_desktop_config.json on Linux,"
 	@echo "#  ~/Library/Application Support/Claude/claude_desktop_config.json on macOS)"
+	@echo "# If the server has OMCP_API_KEYS set, add a Bearer header to the"
+	@echo "# transport block: \"headers\": { \"Authorization\": \"Bearer <key>\" }"
 	@echo ""
 	@echo '{'
 	@echo '  "mcpServers": {'


### PR DESCRIPTION
## Summary
Symmetry with #282: the claude-code/claude-desktop snippet had no hint how to pass a bearer token when OMCP_API_KEYS is set. Adds a two-line comment pointing at the \`transport.headers\` block.

Pure docs / Make output change.

## Test plan
- [ ] CI green (Makefile-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)