### PR TITLE
test: include the 4 test files CI was silently skipping

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,7 +52,7 @@ jobs:
         run: npm ci
       - name: Run tests
         working-directory: ./mcp-server
-        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/quota/*.test.ts src/connectors/verify.test.ts src/connectors/hub.test.ts src/connectors/install.test.ts src/cli/*.test.ts
+        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/quota/*.test.ts src/connectors/verify.test.ts src/connectors/hub.test.ts src/connectors/install.test.ts src/cli/*.test.ts src/tools/*.test.ts src/net/*.test.ts src/openapi.test.ts src/enterprise-gate.test.ts
       - name: Connector hub catalog (validate + in-sync)
         run: |
           node hub/build-catalog.mjs --check

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ doctor: ## Quick health check — is the mcp-server reachable on $$OMCP_HOST:$$O
 test: ## Run mcp-server unit tests in Docker
 	docker run --rm -w /app -v "$(PWD)/mcp-server:/app" node:20-alpine \
 	  sh -c "npm install --silent --no-audit --no-fund && \
-	         npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/quota/*.test.ts"
+	         npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/quota/*.test.ts src/tools/*.test.ts src/net/*.test.ts src/openapi.test.ts src/enterprise-gate.test.ts"
 
 lint: ## helm lint + tsc --noEmit
 	docker run --rm -v "$(PWD)/helm:/apps" alpine/helm:3.16.2 lint /apps/observability-mcp


### PR DESCRIPTION
## Summary
The CI \`unit-tests\` job and \`make test\` both ran a hand-rolled list of test patterns. Four test files lived outside that list and never executed:

- \`src/openapi.test.ts\` (added in #275) — pins the 17 documented routes
- \`src/enterprise-gate.test.ts\`
- \`src/net/egress-policy.test.ts\`
- \`src/tools/{context-seam,handlers,topology,validation}.test.ts\`

The openapi.test.ts case is the worst: it was written to catch undocumented \`/api/*\` endpoints, but since it never ran, the regression-detection it's supposed to provide didn't actually exist. PR #275 went green only because the test was skipped.

Adds all four patterns to both the workflow and the Makefile.

## Test plan
- [ ] CI green: previously-skipped tests now execute and pass
- [ ] If any of them fail, that's a real regression to fix before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)