### PR TITLE
feat(auth/oidc): plumb email + IdP issuer into /api/me — Phase E1c slice 4/5

### DIFF
--- a/mcp-server/src/auth/oidc/endpoints.test.ts
+++ b/mcp-server/src/auth/oidc/endpoints.test.ts
@@ -220,6 +220,61 @@ test("GET /api/auth/oidc/callback — surfaces IdP-side error parameter", async 
   } finally { await close(); }
 });
 
+test("GET /api/auth/oidc/callback — persists verified email; drops unverified email", async () => {
+  // Build two end-to-end runs against the same setup, varying only
+  // the `email_verified` claim. Inspect the resulting session cookie
+  // payload by parsing it client-side (the cookie shape is documented
+  // in src/auth/session.ts).
+  async function runWith(emailVerified: boolean | undefined): Promise<Record<string, unknown>> {
+    const { jwk, privateKeyPem } = rsaKey();
+    const now = Math.floor(Date.now() / 1000);
+    let mintedFlow: { state: string; nonce: string; codeVerifier: string } | null = null;
+    const cfg = configForTest();
+    const fetcher = async (url: string) => {
+      if (url.endsWith("/.well-known/openid-configuration")) return new Response(JSON.stringify(discoveryDoc()), { status: 200 });
+      if (url === `${ISSUER}/jwks`) return new Response(JSON.stringify({ keys: [jwk] }), { status: 200 });
+      if (url === `${ISSUER}/token`) {
+        const claims: Record<string, unknown> = {
+          iss: ISSUER, aud: CLIENT_ID, sub: "alice", name: "Alice",
+          email: "alice@example.test", exp: now + 60, iat: now, nonce: mintedFlow!.nonce,
+        };
+        if (emailVerified !== undefined) claims.email_verified = emailVerified;
+        const idToken = signRs256(claims, privateKeyPem, jwk.kid!);
+        return new Response(JSON.stringify({ id_token: idToken }), { status: 200 });
+      }
+      return new Response("nf", { status: 404 });
+    };
+    const baseClient = new OidcClient({ issuer: cfg.issuer, clientId: cfg.clientId, redirectUri: cfg.redirectUri, fetcher });
+    const wrapped = Object.create(baseClient);
+    wrapped.start = async () => { const o = await baseClient.start(); mintedFlow = o.flow; return o; };
+    const oidc = buildOidcRuntime(cfg, { client: wrapped });
+    const app = express();
+    registerOidcRoutes(app, { sessionCfg: { secret: SECRET }, oidc });
+    const { base, close } = await listen(app);
+    try {
+      const login = await fetch(`${base}/api/auth/oidc/login`, { redirect: "manual" });
+      const flowCookie = (login.headers.get("set-cookie") ?? "").split(";")[0];
+      const state = new URL(login.headers.get("location")!).searchParams.get("state")!;
+      const cb = await fetch(`${base}/api/auth/oidc/callback?code=ABC&state=${state}`, { redirect: "manual", headers: { cookie: flowCookie } });
+      const setCookies = (cb.headers as unknown as { getSetCookie: () => string[] }).getSetCookie();
+      const session = setCookies.find((c) => c.startsWith("omcp_session="))!;
+      const value = session.slice("omcp_session=".length).split(";")[0];
+      const payloadB64 = value.split(".")[0];
+      const pad = payloadB64.length % 4 === 0 ? "" : "=".repeat(4 - (payloadB64.length % 4));
+      return JSON.parse(Buffer.from(payloadB64.replace(/-/g, "+").replace(/_/g, "/") + pad, "base64").toString("utf8"));
+    } finally { await close(); }
+  }
+  // email_verified absent → trust the email
+  const absent = await runWith(undefined);
+  assert.equal(absent.email, "alice@example.test");
+  // email_verified=true → persist
+  const verified = await runWith(true);
+  assert.equal(verified.email, "alice@example.test");
+  // email_verified=false → drop
+  const unverified = await runWith(false);
+  assert.equal(unverified.email, undefined);
+});
+
 test("POST /api/auth/oidc/logout — 204 and clears the session cookie", async () => {
   const cfg = configForTest();
   const fetcher = async (_url: string) => new Response("nf", { status: 404 });

--- a/mcp-server/src/auth/oidc/endpoints.ts
+++ b/mcp-server/src/auth/oidc/endpoints.ts
@@ -96,8 +96,16 @@ export function registerOidcRoutes(app: Application, deps: OidcEndpointDeps): vo
       ?? sanitiseClaim(claims.preferred_username)
       ?? sanitiseClaim(claims.email)
       ?? sub;
+    // Only persist email when the IdP marked it verified — an
+    // unverified email is operator-supplied user input from the
+    // IdP's perspective and shouldn't appear next to a name in
+    // an admin UI as if it were authoritative. When the claim is
+    // absent we trust it (most IdPs default to verified for the
+    // primary identity).
+    const emailVerified = claims.email_verified === undefined || claims.email_verified === true;
+    const email = emailVerified ? sanitiseClaim(claims.email) : undefined;
     const roles = oidc.resolveRoles(claims);
-    const { cookie } = issueSession({ sub, name, roles }, sessionCfg);
+    const { cookie } = issueSession({ sub, name, email, roles }, sessionCfg);
     // Two cookies: clear the now-spent flow cookie, set the long-lived
     // session cookie. The browser accepts both in a single response.
     res.setHeader("Set-Cookie", [

--- a/mcp-server/src/auth/session.test.ts
+++ b/mcp-server/src/auth/session.test.ts
@@ -29,6 +29,26 @@ test("issueSession + verifySession — round-trips identity", () => {
   assert.deepEqual(verified.roles, ["operator"]);
 });
 
+test("issueSession + verifySession — round-trips email when present", () => {
+  const now = 1_700_000_000;
+  const { cookie } = issueSession(
+    { sub: "alice", name: "Alice", email: "alice@example.test", roles: ["operator"] },
+    { secret },
+    now,
+  );
+  const verified = verifySession(cookie, { secret }, now + 1);
+  assert.ok(verified);
+  assert.equal(verified.email, "alice@example.test");
+});
+
+test("issueSession + verifySession — omits email when caller doesn't supply one", () => {
+  const now = 1_700_000_000;
+  const { cookie } = issueSession({ sub: "alice", name: "Alice", roles: ["operator"] }, { secret }, now);
+  const verified = verifySession(cookie, { secret }, now + 1);
+  assert.ok(verified);
+  assert.equal(verified.email, undefined);
+});
+
 test("verifySession — rejects an expired cookie", () => {
   const now = 1_700_000_000;
   const { cookie } = issueSession(

--- a/mcp-server/src/auth/session.ts
+++ b/mcp-server/src/auth/session.ts
@@ -18,6 +18,10 @@ export interface SessionPayload {
   sub: string;
   /** Display name shown in the UI. May equal `sub`. */
   name: string;
+  /** Email address when the identity provider supplied one. Optional —
+   *  local-users-mode sessions usually omit this; OIDC sessions populate
+   *  from the `email` claim when present + verified by the IdP. */
+  email?: string;
   /** Optional list of role identifiers — used by later phases for RBAC. */
   roles?: string[];
   /** Issued-at, seconds since epoch. */
@@ -56,7 +60,7 @@ function sign(secret: string, payload: string): string {
 
 /** Create a signed cookie value for the given identity. */
 export function issueSession(
-  identity: Pick<SessionPayload, "sub" | "name" | "roles">,
+  identity: Pick<SessionPayload, "sub" | "name" | "roles" | "email">,
   cfg: SessionConfig,
   now: number = Math.floor(Date.now() / 1000),
 ): { cookie: string; payload: SessionPayload } {
@@ -65,6 +69,7 @@ export function issueSession(
   const payload: SessionPayload = {
     sub: identity.sub,
     name: identity.name,
+    email: identity.email,
     roles: identity.roles,
     iat: now,
     exp: now + ttl,
@@ -117,6 +122,7 @@ function isSessionPayload(v: unknown): v is SessionPayload {
   if (typeof o.sub !== "string" || typeof o.name !== "string") return false;
   if (typeof o.iat !== "number" || typeof o.exp !== "number") return false;
   if (o.roles !== undefined && !(Array.isArray(o.roles) && o.roles.every((r) => typeof r === "string"))) return false;
+  if (o.email !== undefined && typeof o.email !== "string") return false;
   return true;
 }
 

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -849,9 +849,18 @@ async function main() {
     res.json({
       authenticated: true,
       mode: authRuntime.mode,
-      user: { sub: sess.sub, name: sess.name, roles: sess.roles ?? [] },
+      user: {
+        sub: sess.sub,
+        name: sess.name,
+        email: sess.email,
+        roles: sess.roles ?? [],
+      },
       permissions: listGrantedPermissions(sess.roles),
       exp: sess.exp,
+      // When the user signed in via OIDC, surface the IdP issuer
+      // URL so the UI can render an appropriate badge or link to
+      // an IdP-side profile page. Empty / absent in basic mode.
+      idpIssuer: authRuntime.mode === "oidc" ? (oidcRuntime?.cfg.issuer ?? "") : undefined,
     });
   });
 

--- a/mcp-server/src/openapi.ts
+++ b/mcp-server/src/openapi.ts
@@ -281,12 +281,13 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
                     type: "object",
                     properties: {
                       authenticated: { type: "boolean" },
-                      mode: { type: "string", enum: ["anonymous", "basic"] },
+                      mode: { type: "string", enum: ["anonymous", "basic", "oidc"] },
                       user: {
                         type: "object",
                         properties: {
                           sub: { type: "string" },
                           name: { type: "string" },
+                          email: { type: "string", description: "Present when the IdP supplied a verified email claim (OIDC mode)." },
                           roles: { type: "array", items: { type: "string" } },
                         },
                       },
@@ -301,6 +302,10 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
                         },
                       },
                       exp: { type: "integer", description: "Cookie expiry (seconds since epoch)." },
+                      idpIssuer: {
+                        type: "string",
+                        description: "Active OIDC issuer URL. Present only when mode === \"oidc\". Useful for UI badges or IdP-side profile links.",
+                      },
                     },
                   },
                 },


### PR DESCRIPTION
## Summary

Phase **E1c slice 4 of 5** — closes the slice-4 scope: every OIDC identity attribute the UI needs (sub, name, email, roles, idpIssuer) flows from IdP claim → callback handler → session cookie → \`/api/me\` response.

### What changed
- **\`SessionPayload\`** gains optional \`email\` (validated by \`isSessionPayload\`).
- **OIDC callback** persists email gated by \`email_verified\` (absent → trust per OIDC §5.1; true → persist; false → drop). Strict-typed comparison; conservative-by-default.
- **\`/api/me\`** echoes \`user.email\` + new top-level \`idpIssuer\` (only when \`authMode === "oidc"\`).
- **OpenAPI** for \`/api/me\` updated; \`mode\` enum gains \`"oidc"\`.

### Tests
- Two new session round-trip tests (email round-trip + omit-when-absent)
- New end-to-end callback test runs three flows (email_verified absent / true / false) and parses the actual session cookie payload to assert what's persisted

### RBAC
Intentionally untouched — OIDC claim-derived roles share the same \`string[]\` shape as basic mode, so \`listGrantedPermissions\` works as-is.

### Reviewer pass
0 blockers; one optional nit (drop \`?? ""\` fallback on \`idpIssuer\`) intentionally retained as defence-in-depth.

### Remaining E1c
- **Slice 5**: UI sign-in button + Demo Keycloak setup + docs

## Test plan
- [ ] CI green: 2 new session tests + 1 new integration test pass
- [ ] No new dependencies, no release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)