### PR TITLE
feat(ui+docs): OIDC sign-in button + docs/auth-oidc.md — Phase E1c slice 5a/5

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -23,6 +23,7 @@ the README quickstart promises.
 |---|---|---|---|
 | **MCP bearer auth** for the agent transport | `OMCP_API_KEYS` | anonymous | [auth-and-tls.md](auth-and-tls.md) |
 | **Web UI session login** | `OMCP_AUTH=basic` + `OMCP_USERS_FILE` | anonymous | [auth-basic.md](auth-basic.md) |
+| **Web UI SSO via OIDC** | `OMCP_AUTH=oidc` + `OMCP_OIDC_*` | anonymous | [auth-oidc.md](auth-oidc.md) |
 | **Role-based permissions** on the management API | (built-in `viewer` / `operator` / `admin`; role assigned via the user file's `roles` field) | only meaningful in basic mode | this doc, "Roles & permissions" |
 | **Audit log** of mutating `/api/*` requests | `OMCP_MGMT_AUDIT_FILE` | in-memory ring (500 entries) | this doc, "Audit log" |
 

--- a/docs/auth-basic.md
+++ b/docs/auth-basic.md
@@ -142,3 +142,5 @@ The session cookie (`omcp_session`) is:
 - [access-control.md](access-control.md) — the one-stop runbook covering
   basic-mode auth alongside RBAC, audit log, redaction, rate limits,
   reverse-proxy setup, and the investigation playbook.
+- [auth-oidc.md](auth-oidc.md) — the third auth mode, for teams that
+  already run an IdP (Keycloak, Authentik, Auth0, Azure AD, ...).

--- a/docs/auth-oidc.md
+++ b/docs/auth-oidc.md
@@ -1,0 +1,217 @@
+# Management-plane authentication — OIDC / SSO mode
+
+OMCP's third auth mode lets an identity provider (Keycloak, Authentik,
+Auth0, Okta, Azure AD, Google Workspace, any spec-compliant OIDC IdP)
+own the user database. Sign-in becomes a single "Sign in with SSO"
+button; the OMCP server only sees identity claims after the IdP has
+verified the user.
+
+This page documents the operator-side setup. The two adjacent docs
+that frame it:
+
+- [access-control.md](access-control.md) — runbook covering all auth
+  modes plus RBAC, audit, redaction, quotas.
+- [auth-basic.md](auth-basic.md) — the local-users-file mode.
+
+## When to use OIDC mode
+
+- You already run an IdP and want OMCP users + groups to come from
+  there (least surprise + central revocation).
+- You want SSO with your other internal tools.
+- You need short-lived sessions tied to upstream account state — when
+  a user is disabled at the IdP, the next OMCP session refresh fails
+  closed.
+
+Stick with basic mode when:
+
+- You're running the single-operator demo or a CI fixture.
+- You don't have an IdP and don't want to run one.
+
+## Minimum env
+
+```yaml
+env:
+  OMCP_AUTH: "oidc"
+  OMCP_OIDC_ISSUER: "https://idp.example/realms/observability"
+  OMCP_OIDC_CLIENT_ID: "observability-mcp"
+  OMCP_OIDC_REDIRECT_URI: "https://omcp.example/api/auth/oidc/callback"
+  OMCP_SESSION_SECRET: "<32+ chars, openssl rand -base64 48>"
+  # Confidential clients also set:
+  OMCP_OIDC_CLIENT_SECRET: "<your client secret>"
+```
+
+Required:
+
+| Env | Purpose |
+|---|---|
+| `OMCP_OIDC_ISSUER` | IdP base URL. OMCP appends `/.well-known/openid-configuration` and verifies the doc's own `issuer` field matches (OpenID Connect Discovery 1.0 §4.3). |
+| `OMCP_OIDC_CLIENT_ID` | Client identifier registered with the IdP. |
+| `OMCP_OIDC_REDIRECT_URI` | Absolute URL pointing at `<your-omcp-host>/api/auth/oidc/callback`. Must match the IdP registration exactly. |
+
+Optional:
+
+| Env | Default | Purpose |
+|---|---|---|
+| `OMCP_OIDC_CLIENT_SECRET` | (public client) | Set for confidential clients. Sent via HTTP Basic auth on the token endpoint. |
+| `OMCP_OIDC_SCOPES` | `openid profile email` | Space-delimited scopes requested at the authorize endpoint. |
+| `OMCP_OIDC_ROLES_CLAIM` | `groups` | Dotted path to the claim that holds the user's role-equivalent identifiers. Examples: Keycloak → `realm_access.roles`; Auth0 → `https://your.namespace/roles` (dotted-path doesn't support slashes; use a custom claim mapper instead in that case). |
+| `OMCP_OIDC_ROLE_MAP` | `{}` | JSON object mapping claim values to OMCP roles. Unknown values are silently dropped (least privilege). |
+| `OMCP_OIDC_LOGOUT_REDIRECT` | `/` | Post-logout landing URL. Point at the IdP's `end_session_endpoint` for IdP-side single sign-out. |
+| `OMCP_AUTH_ALLOW_FALLBACK` | `false` | Set to `true` to degrade to anonymous mode on misconfiguration instead of failing closed. Only sensible for throwaway demos. |
+
+## Crypto guarantees
+
+- ID tokens are verified against the IdP's JWKS (refreshed on a 60 s
+  cooldown when an unknown `kid` arrives).
+- RS256 and ES256 are accepted. `none` and HS256 are rejected.
+- Signature → `iss` → `aud` → `exp` → `nbf` → `nonce` are all checked
+  on every callback.
+- PKCE S256 protects the code exchange. Authorization-code with PKCE
+  is the only supported flow; implicit and hybrid are rejected.
+- The flow cookie (state + nonce + PKCE verifier + return_to) is
+  HMAC-SHA256-signed with the same session secret, lives 5 minutes,
+  carries `HttpOnly` + `SameSite=Lax` + `Secure`-by-default.
+
+## Role mapping
+
+Roles attach to OMCP users via two env vars:
+
+```yaml
+OMCP_OIDC_ROLES_CLAIM: "groups"   # default; or e.g. "realm_access.roles"
+OMCP_OIDC_ROLE_MAP: |
+  {
+    "omcp-admin":   "admin",
+    "omcp-ops":     "operator",
+    "omcp-viewers": "viewer"
+  }
+```
+
+The mapper:
+
+- Walks the dotted claim path (so `realm_access.roles` works out of the
+  box for Keycloak).
+- Accepts an array or scalar string value.
+- Maps each value through `OMCP_OIDC_ROLE_MAP`; **drops** unmapped
+  values (least-privilege default).
+- Dedupes — a user in both `omcp-admin` and `omcp-ops` groups doesn't
+  end up with duplicate `admin` entries in their session.
+- Resulting roles drive the existing RBAC engine (`viewer` / `operator`
+  / `admin`) unchanged — see [access-control.md](access-control.md).
+
+## IdP-specific setup
+
+### Keycloak
+
+1. Create realm `observability`.
+2. New client `observability-mcp`:
+   - Client type: OpenID Connect
+   - Standard flow only (auth-code)
+   - Valid Redirect URIs: `https://omcp.example/api/auth/oidc/callback`
+   - Confidential or public — both supported (set `OMCP_OIDC_CLIENT_SECRET` only for confidential).
+3. Add groups `omcp-admin`, `omcp-ops`, `omcp-viewers`; assign users.
+4. Realm-level "Default Client Scopes" already include `groups` for
+   the default `groups` mapper; the claim path stays the default
+   (`groups`). For realm-roles-as-roles, set `OMCP_OIDC_ROLES_CLAIM`
+   to `realm_access.roles`.
+
+Issuer URL shape: `https://<your-keycloak>/realms/observability`.
+
+### Authentik
+
+1. Create OAuth2/OpenID Provider in Authentik.
+2. New Application bound to that provider.
+3. Redirect URI: `https://omcp.example/api/auth/oidc/callback`.
+4. Default `groups` claim works; map groups via the Property Mapping
+   "default-oauth-mapper". Set `OMCP_OIDC_ROLES_CLAIM` to `groups`.
+
+### Auth0
+
+1. Create a Regular Web Application.
+2. Allowed Callback URLs: the same redirect URI.
+3. Enable Auth0's built-in **Role-Based Access Control** (Application
+   → APIs → enable RBAC + "Add Permissions in the Access Token"). This
+   emits a plain-top-level `permissions` claim — no namespaced custom
+   claim required.
+4. Set `OMCP_OIDC_ROLES_CLAIM` to `permissions`.
+5. (Optional) Or implement the same via the **Authorization Extension**
+   and ensure your post-login Action emits the role names into a
+   plain-named claim (Auth0 will silently drop non-namespaced custom
+   claims unless you opt into the Authorization Core / RBAC flow that
+   bypasses the namespacing requirement). The dotted-path walker
+   currently doesn't traverse claim names containing `/`, so
+   namespaced custom claims like `https://omcp.example/roles` can't
+   be addressed today — file an issue if you need that, or use the
+   RBAC `permissions` route above.
+
+### Azure AD / Entra ID
+
+1. App registration → Authentication → Add platform: Web → redirect URI.
+2. Add an `appRoles` block to the manifest, assign users.
+3. Set `OMCP_OIDC_ROLES_CLAIM` to `roles` (Azure AD emits role names
+   under the `roles` claim).
+
+### Generic OIDC
+
+If your IdP publishes a discovery document, you're done — point
+`OMCP_OIDC_ISSUER` at the base URL, find the claim that carries
+role-equivalent strings, and configure `OMCP_OIDC_ROLES_CLAIM` +
+`OMCP_OIDC_ROLE_MAP` accordingly.
+
+## Verifying posture
+
+```bash
+curl -s "$URL/api/info" | jq '.governance | { authMode, oidcIssuer, redaction, auditPersisted }'
+# {
+#   "authMode": "oidc",
+#   "oidcIssuer": "https://idp.example/realms/observability",
+#   "redaction": true,
+#   "auditPersisted": true
+# }
+```
+
+`make doctor` surfaces the same single-line summary.
+
+## Investigation runbook
+
+### "Why am I redirected straight back to /login without an error?"
+
+The flow cookie expired (5 min default) or the browser dropped it
+between `/login` and `/callback`. Cookie expiry is intentional — re-
+clicking "Sign in with SSO" gets you a fresh flow.
+
+### "I see `oidc_idp_error access_denied`"
+
+The IdP refused to issue a token — typically the user cancelled
+consent or isn't allowed to access the OMCP application. Check the
+IdP-side audit log; the OMCP audit log records only the truncated
+error code.
+
+### "I see `oidc_token_exchange_failed`"
+
+The token exchange round-trip failed. Likely causes:
+- `OMCP_OIDC_CLIENT_SECRET` wrong / unset for a confidential client.
+- `OMCP_OIDC_REDIRECT_URI` doesn't exactly match the IdP-side
+  registration (trailing slash counts).
+- The IdP rate-limited the token endpoint.
+
+### "I'm logged in but `/api/me` shows `roles: []`"
+
+The roles-claim path is right but no group maps. Check the raw claim
+set via the IdP's "test token" feature, confirm `OMCP_OIDC_ROLES_CLAIM`
+points at the right field, and that `OMCP_OIDC_ROLE_MAP` has entries
+for the values that actually appear.
+
+### "Sign-in worked but pages still 401"
+
+The session cookie was set on the OIDC callback but isn't sent back
+on subsequent `/api/*` requests. Usually a `Secure` / cross-origin
+issue: ensure the OMCP redirect URI and the UI URL share an origin
+(or you're behind a reverse proxy with `OMCP_TRUST_PROXY` set).
+
+## See also
+
+- [access-control.md](access-control.md) — RBAC, audit log, rate
+  limits, redaction.
+- [auth-basic.md](auth-basic.md) — local-users-file alternative.
+- [auth-and-tls.md](auth-and-tls.md) — TLS termination + the `/mcp`
+  bearer-token gate.

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -1282,13 +1282,24 @@
       <div class="modal-header"><h3>Sign in</h3></div>
       <div class="modal-body">
         <div id="login-banner" class="form-banner"></div>
-        <div class="form-group">
-          <label>Username</label>
-          <input id="login-username" type="text" autocomplete="username" onkeydown="omcpLoginKey(event)">
+        <!-- OIDC: shown when authMode=oidc. Single primary button — the
+             IdP collects credentials, not us. -->
+        <div id="login-oidc" style="display:none;" class="form-group">
+          <button class="btn btn-primary" id="login-sso" onclick="omcpStartSso()" style="width:100%;">
+            Sign in with SSO
+          </button>
+          <div class="form-hint t-sm" id="login-sso-hint" style="margin-top: var(--sp-2);"></div>
         </div>
-        <div class="form-group">
-          <label>Password</label>
-          <input id="login-password" type="password" autocomplete="current-password" onkeydown="omcpLoginKey(event)">
+        <!-- Basic: shown when authMode=basic. Hidden in oidc mode. -->
+        <div id="login-basic">
+          <div class="form-group">
+            <label>Username</label>
+            <input id="login-username" type="text" autocomplete="username" onkeydown="omcpLoginKey(event)">
+          </div>
+          <div class="form-group">
+            <label>Password</label>
+            <input id="login-password" type="password" autocomplete="current-password" onkeydown="omcpLoginKey(event)">
+          </div>
         </div>
       </div>
       <div class="modal-footer">
@@ -1962,10 +1973,29 @@ function omcpEnsureLoggedIn() {
   _omcpLoginInflight = new Promise((resolve) => { _omcpLoginResolve = resolve; });
   const m = document.getElementById('login-modal');
   if (m) m.classList.add('open');
-  // Prefill the most recent username (kept in localStorage; the password
-  // field never persists). Focus jumps straight to password when we
-  // already have a username, otherwise to username.
+  // Toggle SSO vs basic mode form based on what the server told us.
+  // OIDC mode hides the basic-mode submit button entirely — the SSO
+  // button is the only path.
+  const me = window.__omcpMe || {};
+  const isOidc = me.mode === 'oidc';
+  const ssoBlock = document.getElementById('login-oidc');
+  const basicBlock = document.getElementById('login-basic');
+  const ssoHint = document.getElementById('login-sso-hint');
+  const submitBtn = document.getElementById('login-submit');
+  if (ssoBlock) ssoBlock.style.display = isOidc ? '' : 'none';
+  if (basicBlock) basicBlock.style.display = isOidc ? 'none' : '';
+  if (submitBtn) submitBtn.style.display = isOidc ? 'none' : '';
+  if (ssoHint && isOidc) {
+    ssoHint.textContent = me.idpIssuer ? 'You will be redirected to ' + me.idpIssuer : '';
+  }
+  // Prefill the most recent username (basic mode only — OIDC needs no
+  // local credential). Focus rules unchanged.
   setTimeout(() => {
+    if (isOidc) {
+      const sso = document.getElementById('login-sso');
+      if (sso) sso.focus();
+      return;
+    }
     const u = document.getElementById('login-username');
     const p = document.getElementById('login-password');
     let lastUser = '';
@@ -1975,6 +2005,16 @@ function omcpEnsureLoggedIn() {
     else if (u) u.focus();
   }, 50);
   return _omcpLoginInflight;
+}
+// Kick off the OIDC redirect. The return_to carries the current path
+// so the user lands back where they were after the IdP round-trip.
+function omcpStartSso() {
+  const ret = location.pathname + location.search + location.hash;
+  // Only same-origin paths are valid (isSafeReturnTo on the server
+  // enforces this — but we sanitise client-side too so the URL stays
+  // tidy in browser history).
+  const safe = ret && ret.startsWith('/') && !ret.startsWith('//') ? ret : '/';
+  location.href = '/api/auth/oidc/login?return_to=' + encodeURIComponent(safe);
 }
 function omcpLoginKey(e) { if (e.key === 'Enter') { e.preventDefault(); omcpSubmitLogin(); } }
 async function omcpSubmitLogin() {
@@ -2045,7 +2085,20 @@ async function omcpSyncIdentity() {
     const me = await r.json();
     window.__omcpMe = me;
     if (me.authenticated && badge) {
-      badge.querySelector('.user-name').textContent = me.user.name;
+      // Show the email next to the name when the IdP gave us a
+      // verified one. Also surface the IdP issuer host as a title
+      // tooltip when this is an OIDC session — operators with
+      // multiple IdPs can tell at a glance which one they're on.
+      const nameEl = badge.querySelector('.user-name');
+      if (nameEl) {
+        const u = me.user || {};
+        nameEl.textContent = u.email ? (u.name + ' · ' + u.email) : u.name;
+      }
+      if (me.mode === 'oidc' && me.idpIssuer) {
+        try { badge.title = 'signed in via ' + new URL(me.idpIssuer).host; } catch (e) { badge.title = 'signed in via ' + me.idpIssuer; }
+      } else {
+        badge.removeAttribute('title');
+      }
       badge.style.display = '';
     } else if (badge) {
       badge.style.display = 'none';


### PR DESCRIPTION
## Summary

Phase **E1c slice 5a** of the 5-slice OIDC build-out. UI + operator-docs half — the Demo Keycloak + Playwright smoke + \`make demo-oidc\` target ship as **slice 5b** in a follow-up PR.

### UI (\`mcp-server/src/ui/index.html\`)
- Login modal grows a hidden "Sign in with SSO" block alongside the existing username/password block; \`omcpEnsureLoggedIn()\` toggles which block shows based on \`me.mode\` and routes focus.
- \`omcpStartSso()\` navigates to \`/api/auth/oidc/login?return_to=<safe current path>\` with client-side sanitisation (server's \`isSafeReturnTo\` remains the authoritative gate).
- User badge renders "\`<name> · <email>\`" when the IdP supplied a verified email + a title-tooltip "signed in via \`<issuer-host>\`".

### Docs
- New \`docs/auth-oidc.md\` (~210 lines) — minimum env, crypto guarantees, role-mapping, **per-IdP quickstarts** (Keycloak / Authentik / Auth0 / Azure AD / generic), investigation runbook.
- \`docs/access-control.md\` + \`docs/auth-basic.md\` cross-link.

### Reviewer pass
- ✅ Fixed pre-push: wrong spec reference (RFC 8414 → OpenID Connect Discovery 1.0 §4.3); Auth0 namespaced-claim advice rewritten to recommend Auth0's RBAC \`permissions\` claim.
- 🕒 Intentionally deferred to slice 5b (noted in PR): a narrow modal-flash race on first load (UI defaults to anonymous mode before \`/api/me\` lands); \`OMCP_OIDC_LOGOUT_REDIRECT\` wiring into \`omcpLogout()\` (RP-initiated logout was already deferred in slice 3).

## Test plan
- [ ] CI green: docs + UI-only change; no new tests
- [ ] No new dependencies, no release artifacts

### Remaining E1c
- Slice 5b: Demo Keycloak \`--profile auth\`, \`make demo-oidc\` target, Playwright headless login smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)