### PR TITLE
feat(demo+ui): Keycloak demo + make demo-oidc + modal-flash fix — Phase E1c slice 5b/5 (FINAL)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build up demo down logs test lint smoke ui-smoke clean release-dryrun benchmark-up benchmark-down benchmark-run benchmark-deps connect-claude-code connect-cursor doctor
+.PHONY: help build up demo demo-oidc down logs test lint smoke ui-smoke clean release-dryrun benchmark-up benchmark-down benchmark-run benchmark-deps connect-claude-code connect-cursor doctor
 
 # Print every target with its leading-comment description.
 help: ## Show this help
@@ -14,6 +14,22 @@ up: ## Start only mcp-server (point at external Prometheus/Loki)
 
 demo: ## Full demo stack: mcp-server + Prometheus + Loki + example services + agent
 	docker compose --profile demo up --build --wait
+
+demo-oidc: ## OIDC demo: Keycloak + mcp-server in OMCP_AUTH=oidc mode (port 3001)
+	@echo "==> Booting Keycloak + OIDC-flavored mcp-server"
+	docker compose --profile auth up --build --wait
+	@echo
+	@echo "OIDC demo ready:"
+	@echo "  UI:         http://localhost:3001/   ('Sign in with SSO')"
+	@echo "  Keycloak:   http://localhost:8088/   (keycloak / keycloak)"
+	@echo "  Realm:      omcp-demo"
+	@echo
+	@echo "Demo users (passwords match username; DEMO ONLY):"
+	@echo "  admin      → group omcp-admin    → OMCP role admin"
+	@echo "  operator   → group omcp-ops      → OMCP role operator"
+	@echo "  viewer     → group omcp-viewers  → OMCP role viewer"
+	@echo
+	@echo "Tear down with: docker compose --profile auth down"
 
 # One command, fully on-prem, zero external calls: starts the stack, injects
 # a real incident, and shows raw-vs-analyzed side by side. KEEP_UP=1 to keep

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ The server starts with **zero sources**. Add Prometheus/Loki via the Web UI or `
 > **Multi-user / production?** See [docs/access-control.md](docs/access-control.md)
 > for the opt-in basic-mode login + RBAC + audit log + per-identity rate limit
 > setup. All off by default; the demo above is unchanged.
+>
+> **SSO via OIDC?** `make demo-oidc` boots a Keycloak + an OIDC-flavored
+> mcp-server on port **3001** with three pre-provisioned users
+> (`admin` / `operator` / `viewer`, password = username, DEMO ONLY).
+> See [docs/auth-oidc.md](docs/auth-oidc.md) for production Keycloak /
+> Authentik / Auth0 / Azure AD setups.
 
 Want the full chaos-engineering demo (Prometheus + Loki + 3 example services + the autonomous agent)? Clone and run:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -224,6 +224,84 @@ services:
         required: false
 
   # ============================================================
+  # AUTH PROFILE — `docker compose --profile auth up` adds a Keycloak
+  # with the omcp-demo realm pre-imported. The mcp-server boot env
+  # under this profile flips OMCP_AUTH to "oidc" so visiting
+  # http://localhost:3000 redirects to the IdP for sign-in.
+  #
+  # Demo credentials (DO NOT USE IN PROD) live in
+  #   examples/keycloak/omcp-demo-realm.json
+  # admin/admin, operator/operator, viewer/viewer.
+  # ============================================================
+
+  keycloak:
+    profiles: ["auth"]
+    image: quay.io/keycloak/keycloak:26.3.5
+    command: ["start-dev", "--import-realm", "--http-port=8080"]
+    environment:
+      - KEYCLOAK_ADMIN=keycloak
+      - KEYCLOAK_ADMIN_PASSWORD=keycloak
+      - KC_HEALTH_ENABLED=true
+      - KC_HOSTNAME_STRICT=false
+      # Pin the advertised issuer so the discovery doc and OMCP's
+      # OMCP_OIDC_ISSUER match deterministically, independent of the
+      # Host header on the discovery request.
+      - KC_HOSTNAME=http://localhost:8088
+    ports:
+      - "8088:8080"
+    volumes:
+      - ./examples/keycloak/omcp-demo-realm.json:/opt/keycloak/data/import/omcp-demo-realm.json:ro
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/8080 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\n\\r\\n' >&3 && head -n1 <&3 | grep -q '200'"]
+      interval: 10s
+      timeout: 5s
+      retries: 24
+      start_period: 30s
+    restart: unless-stopped
+    networks:
+      - observability
+
+  # OIDC-flavored mcp-server. Binds host port 3001 so it doesn't fight
+  # the default mcp-server's 3000 binding when both profiles are active
+  # (also lets you run `--profile demo --profile auth` to compare). All
+  # of the OIDC URLs reference :3001 accordingly.
+  mcp-server-oidc:
+    profiles: ["auth"]
+    build:
+      context: ./mcp-server
+    ports:
+      - "3001:3000"
+    environment:
+      - OMCP_AUTH=oidc
+      # Inside the docker network keycloak is reachable by hostname;
+      # from the browser it's localhost:8088. Both URLs MUST match what
+      # Keycloak advertises in the discovery doc — Keycloak emits the
+      # issuer from KC_HOSTNAME so we use the localhost form throughout.
+      - OMCP_OIDC_ISSUER=http://localhost:8088/realms/omcp-demo
+      - OMCP_OIDC_CLIENT_ID=observability-mcp
+      - OMCP_OIDC_REDIRECT_URI=http://localhost:3001/api/auth/oidc/callback
+      - OMCP_OIDC_ROLES_CLAIM=groups
+      - OMCP_OIDC_ROLE_MAP={"omcp-admin":"admin","omcp-ops":"operator","omcp-viewers":"viewer"}
+      # 32-char demo secret — stable across restarts so demo sessions
+      # survive. DO NOT use this value in production.
+      - OMCP_SESSION_SECRET=demo-omcp-session-secret-32chars
+    extra_hosts:
+      - "localhost:host-gateway"
+    healthcheck:
+      # /healthz is anonymous-readable in every auth mode; /api/sources
+      # would 401 under OMCP_AUTH=oidc and trip `--wait` indefinitely.
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/healthz"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - observability
+    depends_on:
+      keycloak:
+        condition: service_healthy
+
+  # ============================================================
   # BENCHMARK PROFILE — `docker compose --profile benchmark up` adds:
   #   * Tempo (single-binary) with the metrics-generator enabled, so
   #     trace-derived service-graph signals are visible to the topology

--- a/docs/auth-oidc.md
+++ b/docs/auth-oidc.md
@@ -13,6 +13,25 @@ that frame it:
   modes plus RBAC, audit, redaction, quotas.
 - [auth-basic.md](auth-basic.md) — the local-users-file mode.
 
+## Try it locally
+
+The repo ships a one-command Keycloak demo with three pre-provisioned
+users so you can verify the round-trip without configuring a real IdP:
+
+```bash
+make demo-oidc
+# UI:        http://localhost:3001  ("Sign in with SSO")
+# Keycloak:  http://localhost:8088  (keycloak / keycloak)
+# Users (password = username, DEMO ONLY):
+#   admin    → omcp-admin    → role admin
+#   operator → omcp-ops      → role operator
+#   viewer   → omcp-viewers  → role viewer
+```
+
+The realm export lives at
+[`examples/keycloak/omcp-demo-realm.json`](../examples/keycloak/omcp-demo-realm.json);
+its README documents the client / mappers / groups.
+
 ## When to use OIDC mode
 
 - You already run an IdP and want OMCP users + groups to come from

--- a/examples/keycloak/README.md
+++ b/examples/keycloak/README.md
@@ -1,0 +1,49 @@
+# Demo Keycloak realm
+
+This directory ships a single Keycloak realm export, `omcp-demo-realm.json`,
+that drives the `docker-compose --profile auth` demo of OMCP's OIDC mode.
+
+## What's inside
+
+| Username | Password | Group | OMCP role |
+|---|---|---|---|
+| `admin` | `admin` | `omcp-admin` | `admin` |
+| `operator` | `operator` | `omcp-ops` | `operator` |
+| `viewer` | `viewer` | `omcp-viewers` | `viewer` |
+
+Mapping happens via `OMCP_OIDC_ROLES_CLAIM=groups` plus
+`OMCP_OIDC_ROLE_MAP={"omcp-admin":"admin","omcp-ops":"operator","omcp-viewers":"viewer"}`
+(both set in `docker-compose.yml` under the `auth` profile).
+
+**These credentials are DEMO ONLY.** Do not copy this realm to a
+production Keycloak — every user has a static, well-known password
+and there is no MFA enrolment.
+
+## OIDC client
+
+- Client ID: `observability-mcp`
+- Public (PKCE S256, no client secret)
+- Redirect URI: `http://localhost:3001/api/auth/oidc/callback`
+- Realm: `omcp-demo`
+- Issuer URL: `http://localhost:8088/realms/omcp-demo`
+
+## Quickstart
+
+```bash
+make demo-oidc        # boots keycloak + mcp-server, waits for /healthz
+# Visit http://localhost:3001 — the login modal shows "Sign in with SSO"
+```
+
+## Verifying the realm without the demo stack
+
+```bash
+# Run keycloak standalone with the realm pre-imported:
+docker run --rm -p 8088:8080 \
+  -e KEYCLOAK_ADMIN=keycloak -e KEYCLOAK_ADMIN_PASSWORD=keycloak \
+  -v "$(pwd)/examples/keycloak/omcp-demo-realm.json:/opt/keycloak/data/import/realm.json:ro" \
+  quay.io/keycloak/keycloak:26.3.5 \
+  start-dev --import-realm
+
+# In another terminal, hit the discovery doc:
+curl http://localhost:8088/realms/omcp-demo/.well-known/openid-configuration | jq .
+```

--- a/examples/keycloak/omcp-demo-realm.json
+++ b/examples/keycloak/omcp-demo-realm.json
@@ -1,0 +1,92 @@
+{
+  "realm": "omcp-demo",
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": true,
+  "accessTokenLifespan": 300,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "groups": [
+    { "name": "omcp-admin" },
+    { "name": "omcp-ops" },
+    { "name": "omcp-viewers" }
+  ],
+  "users": [
+    {
+      "username": "admin",
+      "enabled": true,
+      "email": "admin@omcp.test",
+      "emailVerified": true,
+      "firstName": "Demo",
+      "lastName": "Admin",
+      "credentials": [{ "type": "password", "value": "admin", "temporary": false }],
+      "groups": ["/omcp-admin"]
+    },
+    {
+      "username": "operator",
+      "enabled": true,
+      "email": "operator@omcp.test",
+      "emailVerified": true,
+      "firstName": "Demo",
+      "lastName": "Operator",
+      "credentials": [{ "type": "password", "value": "operator", "temporary": false }],
+      "groups": ["/omcp-ops"]
+    },
+    {
+      "username": "viewer",
+      "enabled": true,
+      "email": "viewer@omcp.test",
+      "emailVerified": true,
+      "firstName": "Demo",
+      "lastName": "Viewer",
+      "credentials": [{ "type": "password", "value": "viewer", "temporary": false }],
+      "groups": ["/omcp-viewers"]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "observability-mcp",
+      "name": "observability-mcp (demo)",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "frontchannelLogout": false,
+      "rootUrl": "http://localhost:3001",
+      "baseUrl": "http://localhost:3001/",
+      "redirectUris": [
+        "http://localhost:3001/api/auth/oidc/callback"
+      ],
+      "webOrigins": [
+        "http://localhost:3001"
+      ],
+      "protocol": "openid-connect",
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "post.logout.redirect.uris": "http://localhost:3001/"
+      },
+      "defaultClientScopes": ["web-origins", "profile", "roles", "email"],
+      "optionalClientScopes": ["address", "phone", "offline_access", "microprofile-jwt"],
+      "protocolMappers": [
+        {
+          "name": "groups-claim",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "false",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "claim.name": "groups"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/helm/observability-mcp/values.yaml
+++ b/helm/observability-mcp/values.yaml
@@ -61,7 +61,12 @@ sources:
 # Use the list-of-{name, value | valueFrom} shape Kubernetes expects.
 # Common knobs:
 #   - MCP_LOG_LEVEL  — runtime log verbosity (info / debug)
-#   - OMCP_AUTH      — anonymous (default) | basic; see docs/auth-basic.md
+#   - OMCP_AUTH      — anonymous (default) | basic | oidc
+#                        anonymous → demo / single-operator
+#                        basic     → see docs/auth-basic.md
+#                        oidc      → see docs/auth-oidc.md
+#   - OMCP_OIDC_ISSUER / _CLIENT_ID / _REDIRECT_URI / _CLIENT_SECRET
+#   - OMCP_OIDC_SCOPES / _ROLES_CLAIM / _ROLE_MAP / _LOGOUT_REDIRECT
 #   - OMCP_USERS_FILE              path to the local-users JSON file (basic mode)
 #   - OMCP_SESSION_SECRET          ≥32-char HMAC key for signing session cookies
 #   - OMCP_API_KEYS                bearer tokens for the /mcp transport

--- a/mcp-server/src/auth/oidc/jwt.test.ts
+++ b/mcp-server/src/auth/oidc/jwt.test.ts
@@ -94,10 +94,19 @@ test("verifyIdToken — bad signature is rejected", () => {
   const { jwk, privateKeyPem } = rsaKeypair();
   const now = 1_700_000_000;
   const jwt = signRs256({ iss: "https://idp.test", aud: "c", exp: now + 60 }, privateKeyPem, jwk.kid!);
-  // Flip a bit in the signature segment
+  // Flip the FIRST char of the signature. Every bit of position-0
+  // contributes to the decoded bytes; the LAST char of a 342-char
+  // signature (RSA-2048 → 256 bytes = 4·85+2) shares a 12-bit
+  // window encoding only 8 useful bits, so its bottom 4 bits are
+  // discarded — flipping A↔B there preserved the decoded byte and
+  // the signature still verified, making the test flaky.
   const parts = jwt.split(".");
-  const bad = parts[2].replace(/.$/, (c) => (c === "A" ? "B" : "A"));
-  const tampered = `${parts[0]}.${parts[1]}.${bad}`;
+  const sig = parts[2];
+  const first = sig.charAt(0);
+  const flipped = first >= "A" && first <= "Z" ? first.toLowerCase()
+    : first >= "a" && first <= "z" ? first.toUpperCase()
+    : first === "_" ? "-" : "_";
+  const tampered = `${parts[0]}.${parts[1]}.${flipped}${sig.slice(1)}`;
   assert.throws(
     () => verifyIdToken(tampered, [jwk], { issuer: "https://idp.test", audience: "c", now: () => now * 1000 }),
     /signature verification failed/,

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -1968,14 +1968,19 @@ window.fetch = async function omcpAuthedFetch(input, init) {
   await omcpEnsureLoggedIn();
   return _omcpRawFetch(input, init);
 };
-function omcpEnsureLoggedIn() {
+async function omcpEnsureLoggedIn() {
   if (_omcpLoginInflight) return _omcpLoginInflight;
   _omcpLoginInflight = new Promise((resolve) => { _omcpLoginResolve = resolve; });
+  // Race fix (deferred from #290 reviewer): when a protected fetch
+  // 401s before omcpSyncIdentity() has run, __omcpMe defaults to
+  // anonymous and the basic-mode form would flash for one paint
+  // even in OIDC mode. Force a sync before deciding which block to
+  // show so the operator never sees the wrong form.
+  if ((window.__omcpMe || {}).mode === 'anonymous') {
+    try { await omcpSyncIdentity(); } catch (e) {}
+  }
   const m = document.getElementById('login-modal');
   if (m) m.classList.add('open');
-  // Toggle SSO vs basic mode form based on what the server told us.
-  // OIDC mode hides the basic-mode submit button entirely — the SSO
-  // button is the only path.
   const me = window.__omcpMe || {};
   const isOidc = me.mode === 'oidc';
   const ssoBlock = document.getElementById('login-oidc');


### PR DESCRIPTION
## Summary

**Phase E1c slice 5b — final slice of the OIDC build-out.** Ships a one-command Keycloak demo and closes the two items the 5a reviewer deferred.

### Demo stack — \`make demo-oidc\` / \`docker compose --profile auth up\`

- **Keycloak 26.3.5** with the \`omcp-demo\` realm pre-imported:
  - 3 users (admin/operator/viewer, password = username, DEMO ONLY)
  - 3 groups → \`omcp-admin\` / \`omcp-ops\` / \`omcp-viewers\`
  - Public OIDC client \`observability-mcp\` (PKCE S256, no client secret)
  - \`groups\` claim mapper emitting bare names
  - \`KC_HOSTNAME=http://localhost:8088\` pins the advertised issuer (reviewer suggestion)
- **mcp-server-oidc** binds host port **3001** (default mcp-server keeps 3000)
  - Full \`OMCP_OIDC_*\` env block, role map: \`omcp-admin → admin\`, …
  - Healthcheck on \`/healthz\` (reviewer **blocker** — \`/api/sources\` 401s under OIDC and hung \`--wait\`)
  - \`extra_hosts: localhost:host-gateway\` so container-side discovery + token exchange reach the host-published Keycloak

### Modal-flash race fix
- \`omcpEnsureLoggedIn()\` now \`await\`s \`omcpSyncIdentity()\` when \`__omcpMe.mode\` is still the anonymous default. Eliminates the one-paint basic-mode form flash on OIDC deployments.
- No infinite-loop risk: \`omcpSyncIdentity\` uses the raw-fetch path that won't re-enter the modal flow.

### Docs
- \`docs/auth-oidc.md\` — new "Try it locally" section
- \`examples/keycloak/README.md\` — realm contents + standalone Keycloak command
- \`README.md\` — OIDC quickstart note alongside the existing access-control hint
- \`helm/observability-mcp/values.yaml\` — extraEnv comment lists OMCP_OIDC_* knobs

### Reviewer pass
- ✅ **Blocker fixed**: healthcheck path
- ✅ **Suggestion applied**: \`KC_HOSTNAME\` pinned
- 🧹 No sensitive data — only RFC 6761 \`@omcp.test\` emails and obviously-demo passwords

### E1c status
After this PR is merged, E1c (OIDC/SSO) is **production-ready end-to-end**: server core + runtime wiring + HTTP endpoints + /api/me extension + UI + Docs + Demo. Next per the plan: **E5 (Full OPA + redaction:bypass)**.

## Test plan
- [ ] CI green
- [ ] (local manual) \`make demo-oidc\` → http://localhost:3001 → "Sign in with SSO" → log in as admin → land on UI as admin role
- [ ] No new dependencies, no release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)