### PR TITLE
feat(auth): PolicyEngine + RBAC policy file + dry-run + bypass-audit — Phase E5 slice 2/5

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,7 +52,7 @@ jobs:
         run: npm ci
       - name: Run tests
         working-directory: ./mcp-server
-        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/auth/oidc/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/quota/*.test.ts src/connectors/verify.test.ts src/connectors/hub.test.ts src/connectors/install.test.ts src/cli/*.test.ts src/tools/*.test.ts src/net/*.test.ts src/openapi.test.ts src/enterprise-gate.test.ts
+        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/auth/oidc/*.test.ts src/auth/policy/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/quota/*.test.ts src/connectors/verify.test.ts src/connectors/hub.test.ts src/connectors/install.test.ts src/cli/*.test.ts src/tools/*.test.ts src/net/*.test.ts src/openapi.test.ts src/enterprise-gate.test.ts
       - name: Connector hub catalog (validate + in-sync)
         run: |
           node hub/build-catalog.mjs --check

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ doctor: ## Quick health check — is the mcp-server reachable on $$OMCP_HOST:$$O
 test: ## Run mcp-server unit tests in Docker
 	docker run --rm -w /app -v "$(PWD)/mcp-server:/app" node:20-alpine \
 	  sh -c "npm install --silent --no-audit --no-fund && \
-	         npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/auth/oidc/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/quota/*.test.ts src/tools/*.test.ts src/net/*.test.ts src/openapi.test.ts src/enterprise-gate.test.ts"
+	         npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/auth/oidc/*.test.ts src/auth/policy/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/quota/*.test.ts src/tools/*.test.ts src/net/*.test.ts src/openapi.test.ts src/enterprise-gate.test.ts"
 
 lint: ## helm lint + tsc --noEmit
 	docker run --rm -v "$(PWD)/helm:/apps" alpine/helm:3.16.2 lint /apps/observability-mcp

--- a/mcp-server/src/auth/policy/engine.test.ts
+++ b/mcp-server/src/auth/policy/engine.test.ts
@@ -1,0 +1,112 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { BuiltinPolicyEngine } from "./engine.js";
+import { DEFAULT_POLICY } from "../rbac.js";
+import { loadPolicyFromString, PolicyLoadError } from "./loader.js";
+
+test("BuiltinPolicyEngine — evaluate returns allowed for granted perm", () => {
+  const e = new BuiltinPolicyEngine(DEFAULT_POLICY);
+  const r = e.evaluate(["viewer"], "sources", "read");
+  assert.equal(r.allowed, true);
+  assert.match(r.reason!, /granted by role viewer/);
+});
+
+test("BuiltinPolicyEngine — evaluate returns denied with role context", () => {
+  const e = new BuiltinPolicyEngine(DEFAULT_POLICY);
+  const r = e.evaluate(["viewer"], "sources", "write");
+  assert.equal(r.allowed, false);
+  assert.match(r.reason!, /viewer.*do not grant sources:write/);
+});
+
+test("BuiltinPolicyEngine — evaluate denies when roles missing / empty", () => {
+  const e = new BuiltinPolicyEngine(DEFAULT_POLICY);
+  assert.equal(e.evaluate(undefined, "sources", "read").allowed, false);
+  assert.equal(e.evaluate([], "sources", "read").allowed, false);
+});
+
+test("BuiltinPolicyEngine — list dedupes across overlapping roles", () => {
+  const e = new BuiltinPolicyEngine(DEFAULT_POLICY);
+  const both = e.list(["viewer", "operator"]);
+  // operator inherits viewer's reads; the union shouldn't contain dupes
+  const keys = new Set(both.map((p) => p.resource + ":" + p.action));
+  assert.equal(keys.size, both.length);
+});
+
+test("BuiltinPolicyEngine.roles / kind", () => {
+  const e = new BuiltinPolicyEngine(DEFAULT_POLICY);
+  assert.deepEqual(e.roles().sort(), ["admin", "operator", "viewer"]);
+  assert.equal(e.kind(), "builtin");
+});
+
+test("loadPolicyFromString — happy path YAML", () => {
+  const yamlText = `
+roles:
+  viewer:
+    - { resource: sources, action: read }
+    - { resource: services, action: read }
+  custom-bot:
+    - { resource: redaction, action: bypass }
+`;
+  const e = loadPolicyFromString(yamlText, "test");
+  assert.equal(e.kind(), "test");
+  assert.equal(e.evaluate(["viewer"], "sources", "read").allowed, true);
+  assert.equal(e.evaluate(["custom-bot"], "redaction", "bypass").allowed, true);
+  assert.equal(e.evaluate(["viewer"], "redaction", "bypass").allowed, false);
+});
+
+test("loadPolicyFromString — rejects unknown resource", () => {
+  const yamlText = `
+roles:
+  viewer:
+    - { resource: sourcez, action: read }
+`;
+  assert.throws(() => loadPolicyFromString(yamlText, "t"), /resource 'sourcez' unknown/);
+});
+
+test("loadPolicyFromString — rejects unknown action", () => {
+  const yamlText = `
+roles:
+  viewer:
+    - { resource: sources, action: peek }
+`;
+  assert.throws(() => loadPolicyFromString(yamlText, "t"), /action 'peek' unknown/);
+});
+
+test("loadPolicyFromString — rejects unexpected key (typo guard)", () => {
+  const yamlText = `
+roles:
+  viewer:
+    - { tesource: sources, action: read }
+`;
+  assert.throws(() => loadPolicyFromString(yamlText, "t"), /unexpected key 'tesource'/);
+});
+
+test("loadPolicyFromString — rejects non-object root / missing roles", () => {
+  assert.throws(() => loadPolicyFromString("[1,2,3]", "t"), /expected an object/);
+  assert.throws(() => loadPolicyFromString("foo: bar", "t"), /missing or non-object 'roles'/);
+});
+
+test("loadPolicyFromString — rejects role with non-array grants", () => {
+  assert.throws(() => loadPolicyFromString("roles:\n  viewer: 'read-everything'", "t"), /viewer must be a list/);
+});
+
+test("loadPolicyFromString — surfaces YAML parse errors with origin", () => {
+  // Tab character is invalid YAML indentation.
+  assert.throws(() => loadPolicyFromString("\troles:\n\tviewer: []", "my-test"), PolicyLoadError);
+});
+
+test("loadPolicyFromString — file-supplied admin REPLACES built-in admin (no merge)", () => {
+  // The default admin role gets redaction:bypass. A custom admin that
+  // omits it must not silently inherit; otherwise an operator's
+  // attempt to lock down the role would be defeated.
+  const text = `
+roles:
+  admin:
+    - { resource: sources, action: read }
+`;
+  const e = loadPolicyFromString(text, "t");
+  assert.equal(e.evaluate(["admin"], "sources", "read").allowed, true);
+  assert.equal(e.evaluate(["admin"], "redaction", "bypass").allowed, false, "custom admin must NOT inherit redaction:bypass");
+  assert.equal(e.evaluate(["admin"], "users", "delete").allowed, false, "custom admin must NOT inherit users:delete");
+});

--- a/mcp-server/src/auth/policy/engine.ts
+++ b/mcp-server/src/auth/policy/engine.ts
@@ -1,0 +1,96 @@
+/**
+ * Policy-engine abstraction.
+ *
+ * Today the management-plane RBAC checks call `hasPermission()` /
+ * `listGrantedPermissions()` which read the built-in DEFAULT_POLICY
+ * map. That's fine for the single-deployment case, but the plan
+ * (E5) wires in:
+ *
+ *   - File-loaded custom policies (slice 2, this module)
+ *   - External OPA via HTTP eval (slice 4)
+ *
+ * Both surfaces share the same shape: given (role, resource, action),
+ * answer allowed / not allowed; and given a role, enumerate every
+ * granted (resource, action) pair for UI display.
+ *
+ * This interface is deliberately narrow so a future Rego engine, a
+ * remote OPA call, or any operator-supplied evaluator drops in
+ * without touching the call sites.
+ */
+
+import type { Permission, Resource, Action } from "../rbac.js";
+
+export interface EvalResult {
+  allowed: boolean;
+  /** Optional human-readable explanation (for /api/policy?dry-run). */
+  reason?: string;
+}
+
+export interface PolicyEngine {
+  /** One-shot evaluation: does this role-set grant the permission? */
+  evaluate(roles: string[] | undefined, resource: Resource, action: Action): EvalResult;
+  /** Enumerate every (resource, action) the role-set grants. */
+  list(roles: string[] | undefined): Permission[];
+  /** Surface the active role catalogue (for UI tabs / docs). */
+  roles(): string[];
+  /** Short identifier for logging / /api/info — "builtin", "file:…",
+   *  "opa:…". */
+  kind(): string;
+}
+
+/** Built-in engine — wraps a plain {role: Permission[]} map. */
+export class BuiltinPolicyEngine implements PolicyEngine {
+  private readonly policy: Record<string, Permission[]>;
+  private readonly origin: string;
+
+  constructor(policy: Record<string, Permission[]>, origin: string = "builtin") {
+    this.policy = policy;
+    this.origin = origin;
+  }
+
+  evaluate(roles: string[] | undefined, resource: Resource, action: Action): EvalResult {
+    if (!roles || roles.length === 0) {
+      return { allowed: false, reason: "no roles on principal" };
+    }
+    for (const r of roles) {
+      const grants = this.policy[r];
+      if (!grants) continue;
+      for (const g of grants) {
+        if (g.resource === resource && g.action === action) {
+          return { allowed: true, reason: `granted by role ${r}` };
+        }
+      }
+    }
+    return { allowed: false, reason: `roles [${roles.join(",")}] do not grant ${resource}:${action}` };
+  }
+
+  list(roles: string[] | undefined): Permission[] {
+    if (!roles || roles.length === 0) return [];
+    const seen = new Set<string>();
+    const out: Permission[] = [];
+    for (const r of roles) {
+      const grants = this.policy[r];
+      if (!grants) continue;
+      for (const g of grants) {
+        const key = g.resource + ":" + g.action;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push(g);
+      }
+    }
+    return out;
+  }
+
+  roles(): string[] {
+    return Object.keys(this.policy);
+  }
+
+  kind(): string {
+    return this.origin;
+  }
+
+  /** Expose the underlying policy for /api/policy reflection. */
+  raw(): Record<string, Permission[]> {
+    return this.policy;
+  }
+}

--- a/mcp-server/src/auth/policy/loader.ts
+++ b/mcp-server/src/auth/policy/loader.ts
@@ -1,0 +1,102 @@
+/**
+ * Load a policy from a YAML or JSON file and turn it into a
+ * BuiltinPolicyEngine. Validation enforces every entry has a
+ * known resource + action shape; unknown fields are rejected so a
+ * typo in operator-facing config fails fast and loud rather than
+ * silently dropping grants.
+ *
+ * File shape:
+ *   roles:
+ *     viewer:
+ *       - { resource: sources, action: read }
+ *       - { resource: services, action: read }
+ *     operator:
+ *       - { resource: sources, action: write }
+ *       - { resource: settings, action: write }
+ *     admin:
+ *       - { resource: redaction, action: bypass }
+ *       # etc.
+ *
+ * The loader does NOT inherit-merge built-in roles — a file-supplied
+ * `admin` REPLACES the built-in `admin`. Inheritance / patching is
+ * an operator-side concern (anchor / merge in YAML, jq filters, etc.).
+ */
+
+import { readFileSync } from "node:fs";
+import yaml from "js-yaml";
+
+import type { Permission, Resource, Action } from "../rbac.js";
+import { BuiltinPolicyEngine, type PolicyEngine } from "./engine.js";
+
+export const VALID_RESOURCES: ReadonlySet<Resource> = new Set([
+  "sources", "services", "health", "topology", "settings",
+  "connectors", "audit", "catalog", "users", "redaction",
+]);
+export const VALID_ACTIONS: ReadonlySet<Action> = new Set(["read", "write", "delete", "bypass"]);
+
+export class PolicyLoadError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "PolicyLoadError";
+  }
+}
+
+/** Parse a YAML/JSON string into a validated policy + return an engine. */
+export function loadPolicyFromString(text: string, origin: string): PolicyEngine {
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(text);
+  } catch (e) {
+    throw new PolicyLoadError(`failed to parse policy ${origin}: ${(e as Error).message}`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new PolicyLoadError(`${origin}: expected an object with a 'roles' map`);
+  }
+  const roles = (parsed as Record<string, unknown>).roles;
+  if (!roles || typeof roles !== "object" || Array.isArray(roles)) {
+    throw new PolicyLoadError(`${origin}: missing or non-object 'roles' field`);
+  }
+  const policy: Record<string, Permission[]> = {};
+  for (const [role, grants] of Object.entries(roles as Record<string, unknown>)) {
+    if (!Array.isArray(grants)) {
+      throw new PolicyLoadError(`${origin}: roles.${role} must be a list of {resource, action} entries`);
+    }
+    const perms: Permission[] = [];
+    for (let i = 0; i < grants.length; i++) {
+      const g = grants[i];
+      if (!g || typeof g !== "object" || Array.isArray(g)) {
+        throw new PolicyLoadError(`${origin}: roles.${role}[${i}] must be an object`);
+      }
+      const resource = (g as Record<string, unknown>).resource;
+      const action = (g as Record<string, unknown>).action;
+      if (typeof resource !== "string" || !VALID_RESOURCES.has(resource as Resource)) {
+        throw new PolicyLoadError(`${origin}: roles.${role}[${i}].resource '${String(resource)}' unknown (allowed: ${[...VALID_RESOURCES].join(", ")})`);
+      }
+      if (typeof action !== "string" || !VALID_ACTIONS.has(action as Action)) {
+        throw new PolicyLoadError(`${origin}: roles.${role}[${i}].action '${String(action)}' unknown (allowed: ${[...VALID_ACTIONS].join(", ")})`);
+      }
+      // Reject unexpected keys to prevent typos (e.g. `tesource`) from
+      // silently producing a grant with the default `resource`.
+      for (const k of Object.keys(g as Record<string, unknown>)) {
+        if (k !== "resource" && k !== "action") {
+          throw new PolicyLoadError(`${origin}: roles.${role}[${i}] has unexpected key '${k}'`);
+        }
+      }
+      perms.push({ resource: resource as Resource, action: action as Action });
+    }
+    policy[role] = perms;
+  }
+  return new BuiltinPolicyEngine(policy, origin);
+}
+
+/** Read a file (utf-8) and load it as a policy. Lets operators
+ *  surface the on-disk path in error messages. */
+export function loadPolicyFromFile(path: string): PolicyEngine {
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch (e) {
+    throw new PolicyLoadError(`failed to read policy ${path}: ${(e as Error).message}`);
+  }
+  return loadPolicyFromString(text, `file:${path}`);
+}

--- a/mcp-server/src/auth/policy/loader.ts
+++ b/mcp-server/src/auth/policy/loader.ts
@@ -67,6 +67,16 @@ export function loadPolicyFromString(text: string, origin: string): PolicyEngine
       if (!g || typeof g !== "object" || Array.isArray(g)) {
         throw new PolicyLoadError(`${origin}: roles.${role}[${i}] must be an object`);
       }
+      // Reject unexpected keys FIRST so a typo like `tesource:` gets
+      // the helpful "unexpected key 'tesource'" message instead of
+      // the misleading "resource 'undefined' unknown" that the value
+      // check below would otherwise emit (no `resource` field
+      // present in the object).
+      for (const k of Object.keys(g as Record<string, unknown>)) {
+        if (k !== "resource" && k !== "action") {
+          throw new PolicyLoadError(`${origin}: roles.${role}[${i}] has unexpected key '${k}'`);
+        }
+      }
       const resource = (g as Record<string, unknown>).resource;
       const action = (g as Record<string, unknown>).action;
       if (typeof resource !== "string" || !VALID_RESOURCES.has(resource as Resource)) {
@@ -74,13 +84,6 @@ export function loadPolicyFromString(text: string, origin: string): PolicyEngine
       }
       if (typeof action !== "string" || !VALID_ACTIONS.has(action as Action)) {
         throw new PolicyLoadError(`${origin}: roles.${role}[${i}].action '${String(action)}' unknown (allowed: ${[...VALID_ACTIONS].join(", ")})`);
-      }
-      // Reject unexpected keys to prevent typos (e.g. `tesource`) from
-      // silently producing a grant with the default `resource`.
-      for (const k of Object.keys(g as Record<string, unknown>)) {
-        if (k !== "resource" && k !== "action") {
-          throw new PolicyLoadError(`${origin}: roles.${role}[${i}] has unexpected key '${k}'`);
-        }
       }
       perms.push({ resource: resource as Resource, action: action as Action });
     }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -50,11 +50,14 @@ import {
   buildRequirePermission,
   listGrantedPermissions,
   DEFAULT_POLICY,
+  type Permission,
   type Resource,
   type Action,
 } from "./auth/rbac.js";
 import { resolveOidcConfig, buildOidcRuntime } from "./auth/oidc/runtime.js";
 import { registerOidcRoutes } from "./auth/oidc/endpoints.js";
+import { BuiltinPolicyEngine, type PolicyEngine } from "./auth/policy/engine.js";
+import { loadPolicyFromFile, PolicyLoadError, VALID_RESOURCES, VALID_ACTIONS } from "./auth/policy/loader.js";
 import { AuditLog } from "./audit/log.js";
 import { buildAuditMiddleware } from "./audit/middleware.js";
 import { readCatalogFile, CatalogStore } from "./catalog/loader.js";
@@ -134,6 +137,20 @@ function emitBypassEvent(
     correlationId: ctx.correlationId,
     ...(event === "redaction_bypass_denied" ? { reason: "credential_not_in_OMCP_KEY_BYPASS_REDACTION" } : {}),
   }));
+}
+
+/** Bridge from the new PolicyEngine to the existing
+ *  hasPermission/buildRequirePermission signatures (which still take
+ *  a plain {role: Permission[]} map). Built-in engine exposes the
+ *  raw map directly; engines that don't (slice 4's OPA) will fall
+ *  back to a synthesized one via .list(). */
+function policyEngineToMap(engine: PolicyEngine): Record<string, Permission[]> {
+  if (engine instanceof BuiltinPolicyEngine) return engine.raw();
+  const out: Record<string, Permission[]> = {};
+  for (const role of engine.roles()) {
+    out[role] = engine.list([role]);
+  }
+  return out;
 }
 
 function applyConfigToRuntime(config: Config, registry: ConnectorRegistry) {
@@ -434,15 +451,27 @@ async function main() {
       const allowed = ctx.allowBypassRedaction === true;
       const bypass = wantsBypass && allowed;
       if (bypass || (wantsBypass && !allowed)) {
-        // Forensic breadcrumb. We log a short SHA-256 prefix of the
-        // principal id rather than the id itself so the log line
-        // (a) doesn't carry the operator-chosen credential name into
-        // log aggregators that don't share the same trust boundary,
-        // and (b) doesn't trip static-analysis taint trackers that
-        // can't tell the credential `name` apart from its `token`
-        // (OMCP_API_KEYS is the shared source). The hash is
-        // deterministic per principal so SIEM correlations still work.
+        // Forensic trail:
+        //   1. stderr breadcrumb for SIEM tail-and-forward setups (the
+        //      log channel keeps no identifying credential reference
+        //      to avoid CodeQL taint findings — correlation goes via
+        //      the audit chain entry below).
+        //   2. management-plane audit chain entry so the bypass
+        //      invocation is tamper-evident alongside the rest of
+        //      /api/*. Persists if OMCP_MGMT_AUDIT_FILE is set.
         emitBypassEvent(bypass ? "redaction_bypass_engaged" : "redaction_bypass_denied", ctx, args);
+        void mgmtAudit.record({
+          actor: { sub: ctx.principalId },
+          resource: "redaction",
+          action: "bypass",
+          method: "MCP",
+          path: "/mcp/query_logs",
+          status: bypass ? 200 : 403,
+          target: (args as { service?: string })?.service ?? undefined,
+        }).catch(() => {
+          // Audit record is best-effort — losing one entry must not
+          // crash the tool call. The chain itself remains intact.
+        });
       }
       return redactToolText(result, { bypass });
     }
@@ -733,8 +762,31 @@ async function main() {
   // there is no string-match-based "is this public?" branch anywhere.
   app.use(buildSessionAttacher(authRuntime));
   const requireSession = buildRequireSession(authRuntime);
+
+  // Active policy engine — built-in DEFAULT_POLICY by default. When
+  // OMCP_RBAC_POLICY_FILE is set we load it and ALWAYS abort on
+  // failure: OMCP_AUTH_ALLOW_FALLBACK is for *auth-mode* fallback
+  // (basic → anonymous), not for the policy file. An operator who
+  // deployed a restrictive policy to TIGHTEN the default would be
+  // worse off silently inheriting the broader built-in
+  // (DEFAULT_POLICY grants admin → redaction:bypass) than crashing
+  // with a clear error. Policy file errors are unconditionally
+  // fatal so the configured intent always wins.
+  let policyEngine: PolicyEngine = new BuiltinPolicyEngine(DEFAULT_POLICY);
+  const policyFile = process.env.OMCP_RBAC_POLICY_FILE?.trim();
+  if (policyFile) {
+    try {
+      policyEngine = loadPolicyFromFile(policyFile);
+      console.log(`[auth] RBAC policy loaded from ${policyFile} (${policyEngine.roles().join(", ")})`);
+    } catch (e) {
+      const reason = e instanceof PolicyLoadError ? e.message : String(e);
+      console.error(`[auth] OMCP_RBAC_POLICY_FILE=${policyFile}: ${reason} — refusing to start (a malformed policy file would silently revert to the more permissive built-in default, defeating the point of the override)`);
+      process.exit(1);
+    }
+  }
+
   const need = (resource: Resource, action: Action) =>
-    buildRequirePermission(authRuntime, resource, action);
+    buildRequirePermission(authRuntime, resource, action, policyEngineToMap(policyEngine));
 
   // Management-plane audit log. Records one entry per mutating /api/*
   // request. Writes JSONL to disk when OMCP_MGMT_AUDIT_FILE is set;
@@ -907,7 +959,7 @@ async function main() {
         email: sess.email,
         roles: sess.roles ?? [],
       },
-      permissions: listGrantedPermissions(sess.roles),
+      permissions: listGrantedPermissions(sess.roles, policyEngineToMap(policyEngine)),
       exp: sess.exp,
       // When the user signed in via OIDC, surface the IdP issuer
       // URL so the UI can render an appropriate badge or link to
@@ -921,11 +973,36 @@ async function main() {
   // doesn't have a checkout to read DEFAULT_POLICY from source. Gated
   // by admin-only delete-on-users so the policy schema isn't visible
   // to non-admin sessions.
-  app.get("/api/policy", need("users", "delete"), (_req, res) => {
+  app.get("/api/policy", need("users", "delete"), (req, res) => {
+    const map = policyEngineToMap(policyEngine);
+    // Optional dry-run: ?roles=admin,operator&resource=sources&action=delete
+    // returns { allowed, reason } so operators can probe the active
+    // engine without writing tests against a checkout.
+    const q = req.query as Record<string, string | undefined>;
+    if (q.resource && q.action) {
+      const dryRoles = typeof q.roles === "string" ? q.roles.split(",").map((r) => r.trim()).filter(Boolean) : undefined;
+      // Validate the probe values against the active vocabulary so
+      // an operator typo doesn't get a misleading "allowed:false
+      // reason: roles do not grant <typo>" reply.
+      if (!VALID_RESOURCES.has(q.resource as Resource)) {
+        res.json({ dryRun: { roles: dryRoles ?? [], resource: q.resource, action: q.action, allowed: false, reason: `unknown resource '${q.resource}' (valid: ${[...VALID_RESOURCES].join(", ")})` } });
+        return;
+      }
+      if (!VALID_ACTIONS.has(q.action as Action)) {
+        res.json({ dryRun: { roles: dryRoles ?? [], resource: q.resource, action: q.action, allowed: false, reason: `unknown action '${q.action}' (valid: ${[...VALID_ACTIONS].join(", ")})` } });
+        return;
+      }
+      const result = policyEngine.evaluate(dryRoles, q.resource as Resource, q.action as Action);
+      res.json({ dryRun: { roles: dryRoles ?? [], resource: q.resource, action: q.action, ...result } });
+      return;
+    }
     res.json({
-      policy: DEFAULT_POLICY,
-      roles: Object.keys(DEFAULT_POLICY),
-      note: "DEFAULT_POLICY shipped with this build. Custom policies are not yet hot-reloadable.",
+      engine: policyEngine.kind(),
+      policy: map,
+      roles: policyEngine.roles(),
+      note: policyEngine.kind() === "builtin"
+        ? "DEFAULT_POLICY shipped with this build. Set OMCP_RBAC_POLICY_FILE to override."
+        : `policy loaded from ${policyEngine.kind()}; restart to reload.`,
     });
   });
 

--- a/mcp-server/src/openapi.ts
+++ b/mcp-server/src/openapi.ts
@@ -298,6 +298,9 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
                           properties: {
                             resource: { type: "string" },
                             action: { type: "string", enum: ["read", "write", "delete", "bypass"] },
+                            // Resource enum is unconstrained at the OpenAPI level so
+                            // custom policies loaded via OMCP_RBAC_POLICY_FILE that
+                            // (correctly) include all built-in resources still validate.
                           },
                         },
                       },
@@ -463,18 +466,34 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
       "/api/policy": {
         get: {
           tags: ["auth"],
-          summary: "Read-only view of the active RBAC DEFAULT_POLICY (admin-only).",
+          summary: "Read-only view of the active RBAC policy (admin-only). Dry-run probe with ?resource=&action=&roles=.",
+          parameters: [
+            { name: "roles", in: "query", required: false, schema: { type: "string" }, description: "Comma-separated role names to probe. Defaults to none (treated as anonymous → always denied)." },
+            { name: "resource", in: "query", required: false, schema: { type: "string" }, description: "Resource to probe. Pair with `action` to enter dry-run mode." },
+            { name: "action", in: "query", required: false, schema: { type: "string" }, description: "Action to probe. Pair with `resource` to enter dry-run mode." },
+          ],
           responses: {
             "200": {
-              description: "Policy map keyed by role.",
+              description: "Either the full policy map (no probe params) or a dry-run decision (with `resource` + `action`).",
               content: {
                 "application/json": {
                   schema: {
                     type: "object",
                     properties: {
+                      engine: { type: "string", description: "Identifier of the active engine: 'builtin', 'file:<path>', 'opa:<url>'." },
                       policy: { type: "object", additionalProperties: true },
                       roles: { type: "array", items: { type: "string" } },
                       note: { type: "string" },
+                      dryRun: {
+                        type: "object",
+                        properties: {
+                          roles: { type: "array", items: { type: "string" } },
+                          resource: { type: "string" },
+                          action: { type: "string" },
+                          allowed: { type: "boolean" },
+                          reason: { type: "string" },
+                        },
+                      },
                     },
                   },
                 },


### PR DESCRIPTION
## Summary

Phase **E5 slice 2 of 5** — stands up the policy-engine abstraction the rest of E5 hooks into, plus the audit-chain integration for redaction-bypass that was deferred from slice 1.

### What changed
- **\`src/auth/policy/engine.ts\`** — \`PolicyEngine\` interface (\`evaluate\` / \`list\` / \`roles\` / \`kind\`) + \`BuiltinPolicyEngine\` wrapping the existing map. Slice 4's OPA engine drops in here.
- **\`src/auth/policy/loader.ts\`** — YAML/JSON → \`PolicyEngine\` with strict validation (unknown resource/action AND **unexpected object keys** all reject — catches \`tesource:\` typos).
- **\`index.ts\`** — \`OMCP_RBAC_POLICY_FILE\` loads at boot; **errors are unconditionally fatal** (does not reuse \`OMCP_AUTH_ALLOW_FALLBACK\`, which would silently revert to the broader built-in default). \`/api/policy\` gains engine kind + dry-run mode (\`?roles=&resource=&action=\` → \`{allowed, reason}\`).
- **\`index.ts\`** — Redaction-bypass tool invocations now record() into the management-plane audit chain (tamper-evident) in addition to the existing stderr breadcrumb. Best-effort.
- **OpenAPI + CI** updated.

### Reviewer pass
- ✅ Real concern fixed: policy-file fail-closed made unconditional. An operator deploying a restrictive policy now gets a clear crash on typo, not a silent revert to the more permissive default.
- ✅ Polish: dry-run validates resource/action against the active vocabulary.
- ✅ Audit-chain hookup uses the separate audit channel — no CodeQL re-flag.

### Tests
- 13 new policy tests (every reject path + replace-not-merge regression)
- Engine tests added to CI glob

### Remaining E5
- Slice 3: UI Policy tab + diff view + dry-run UI
- Slice 4: External OPA engine (HTTP eval)
- Slice 5: Docs + demo

## Test plan
- [ ] CI green
- [ ] No new dependencies, no release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)