### PR TITLE
feat(quota): per-identity 24h token-budget tracker — Phase E6 slice 1/4

### DIFF
--- a/mcp-server/src/quota/token-budget.test.ts
+++ b/mcp-server/src/quota/token-budget.test.ts
@@ -1,0 +1,130 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { TokenBudget, estimateTokens, estimateTokensFor, resolveDailyTokenLimit } from "./token-budget.js";
+
+test("estimateTokens — empty/null/undefined → 0", () => {
+  assert.equal(estimateTokens(""), 0);
+});
+
+test("estimateTokens — over-counts by design (~5% above chars/4)", () => {
+  // 100 chars → cl100k actual is ~22-25; our estimate is ceil(100/4 * 1.05) = 27.
+  // We want > chars/4 so quota enforcement errs on the strict side.
+  const t = estimateTokens("x".repeat(100));
+  assert.ok(t >= 26, `expected ≥26, got ${t}`);
+  assert.ok(t <= 30, `expected ≤30, got ${t}`);
+});
+
+test("estimateTokensFor — handles non-string values via JSON serialisation", () => {
+  assert.equal(estimateTokensFor(null), 0);
+  assert.equal(estimateTokensFor(undefined), 0);
+  assert.ok(estimateTokensFor({ a: 1, b: "hello" }) > 0);
+  assert.ok(estimateTokensFor([1, 2, 3]) > 0);
+});
+
+test("estimateTokensFor — circular / non-serialisable returns 0 (don't crash)", () => {
+  const a: Record<string, unknown> = {};
+  a.self = a;
+  assert.equal(estimateTokensFor(a), 0);
+});
+
+test("TokenBudget — uncapped allows everything but still tracks usage", () => {
+  const t = 1_700_000_000_000;
+  const b = new TokenBudget({ dailyLimit: 0, now: () => t });
+  const r = b.check("alice", 999_999);
+  assert.equal(r.allowed, true);
+  assert.equal(r.limit, 0);
+  assert.equal(b.inspect("alice").used, 999_999);
+});
+
+test("TokenBudget — allows up to the daily cap, denies the request that would exceed", () => {
+  const t = 1_700_000_000_000;
+  const b = new TokenBudget({ dailyLimit: 1000, now: () => t });
+  assert.equal(b.check("alice", 600).allowed, true);
+  assert.equal(b.check("alice", 300).allowed, true);
+  // 600 + 300 = 900; +200 would push to 1100 → deny
+  const denied = b.check("alice", 200);
+  assert.equal(denied.allowed, false);
+  assert.equal(denied.used, 900, "denied request must NOT have been recorded");
+  assert.equal(denied.limit, 1000);
+  assert.ok(denied.retryAfterSeconds > 0);
+  // Subsequent small request within remaining headroom still works
+  assert.equal(b.check("alice", 50).allowed, true);
+});
+
+test("TokenBudget — 24h rolling: buckets older than 24h drop off", () => {
+  let now = 1_700_000_000_000;
+  const b = new TokenBudget({ dailyLimit: 1000, now: () => now });
+  b.check("alice", 800); // bucket at hour 0
+  now += 23 * 60 * 60 * 1000; // +23h: still in window
+  assert.equal(b.inspect("alice").used, 800);
+  now += 2 * 60 * 60 * 1000; // +25h total: bucket from hour 0 drops
+  assert.equal(b.inspect("alice").used, 0);
+  // Full daily budget available again
+  assert.equal(b.check("alice", 1000).allowed, true);
+});
+
+test("TokenBudget — denied request returns retryAfter ≈ time until oldest bucket drops", () => {
+  let now = 1_700_000_000_000;
+  const b = new TokenBudget({ dailyLimit: 100, now: () => now });
+  b.check("alice", 100); // fully consumed
+  now += 60 * 60 * 1000; // +1h
+  const denied = b.check("alice", 1);
+  assert.equal(denied.allowed, false);
+  // Oldest bucket at hour 0 drops at hour 24; we're at hour 1 → ~23h
+  const expectedSeconds = 23 * 60 * 60;
+  assert.ok(
+    Math.abs(denied.retryAfterSeconds - expectedSeconds) < 3600,
+    `expected ~${expectedSeconds}s, got ${denied.retryAfterSeconds}s`,
+  );
+});
+
+test("TokenBudget — per-identity isolation (alice's bucket doesn't affect bob)", () => {
+  const t = 1_700_000_000_000;
+  const b = new TokenBudget({ dailyLimit: 1000, now: () => t });
+  b.check("alice", 1000); // fully consumed
+  assert.equal(b.check("alice", 1).allowed, false);
+  assert.equal(b.check("bob", 500).allowed, true);
+  assert.equal(b.inspect("bob").used, 500);
+});
+
+test("TokenBudget — hour bucket aggregation: 3 calls in the same hour share one bucket", () => {
+  let now = 1_700_000_000_000;
+  const b = new TokenBudget({ dailyLimit: 10000, now: () => now });
+  b.check("alice", 100, now);
+  b.check("alice", 200, now + 5_000);
+  b.check("alice", 50, now + 10_000);
+  assert.equal(b.inspect("alice").used, 350);
+});
+
+test("TokenBudget — knownIdentities surfaces every identity seen", () => {
+  const t = 1_700_000_000_000;
+  const b = new TokenBudget({ dailyLimit: 0, now: () => t });
+  b.check("a", 1);
+  b.check("b", 1);
+  b.check("a", 1);
+  assert.deepEqual(b.knownIdentities().sort(), ["a", "b"]);
+});
+
+test("TokenBudget — zero/negative tokens silently dropped", () => {
+  const t = 1_700_000_000_000;
+  const b = new TokenBudget({ dailyLimit: 1000, now: () => t });
+  b.check("alice", 0);
+  b.check("alice", -10);
+  assert.equal(b.inspect("alice").used, 0);
+});
+
+test("resolveDailyTokenLimit — unset/empty/zero/negative/non-numeric → 0 (uncapped)", () => {
+  assert.equal(resolveDailyTokenLimit(undefined), 0);
+  assert.equal(resolveDailyTokenLimit(""), 0);
+  assert.equal(resolveDailyTokenLimit("0"), 0);
+  assert.equal(resolveDailyTokenLimit("-100"), 0);
+  assert.equal(resolveDailyTokenLimit("not-a-number"), 0);
+  assert.equal(resolveDailyTokenLimit("NaN"), 0);
+});
+
+test("resolveDailyTokenLimit — positive integers pass through; decimals floored", () => {
+  assert.equal(resolveDailyTokenLimit("50000"), 50000);
+  assert.equal(resolveDailyTokenLimit("1"), 1);
+  assert.equal(resolveDailyTokenLimit("1234.7"), 1234);
+});

--- a/mcp-server/src/quota/token-budget.ts
+++ b/mcp-server/src/quota/token-budget.ts
@@ -1,0 +1,186 @@
+/**
+ * Per-identity token-budget tracker.
+ *
+ * The MCP transport gets per-call sliding-window cap from
+ * `IdentityRateLimiter`. Operators with paid-tier LLM agents want a
+ * second axis: a daily token quota that limits the number of tokens
+ * a credential can pull through the tool layer in a 24-hour rolling
+ * window. This module is the data-plane half of that knob.
+ *
+ * Token estimation:
+ *   The MCP tool response (and the agent's request args) cross the
+ *   boundary as JSON text. We don't tokenize with a real tokenizer
+ *   here — pulling in tiktoken / gpt-tokenizer would add a non-trivial
+ *   wasm/dep that the airgapped-friendly posture wants to avoid. The
+ *   estimate uses a deliberate over-approximation:
+ *       tokens ≈ ceil(chars / 4) * 1.05
+ *   which tends to over-count by ~5% vs. cl100k_base on prose payloads
+ *   and ~15% on dense code/JSON. Under-counting is the worse error
+ *   mode for budget control, so the rounding direction is intentional.
+ *
+ * Window:
+ *   24h rolling, bucketed at 1-hour resolution to keep memory bounded.
+ *   Each bucket records (hour-aligned timestamp, tokens). On every
+ *   `check()` we drop buckets older than 24h and sum the rest.
+ *
+ * Persistence is OUT OF SCOPE for this slice (planned for E6/3). The
+ * in-memory tracker is constructed fresh at boot; restart-survival
+ * requires the persistence layer.
+ */
+
+const HOUR_MS = 60 * 60 * 1000;
+const WINDOW_MS = 24 * HOUR_MS;
+
+/** Estimate tokens from a string. Intentionally over-counts. */
+export function estimateTokens(text: string): number {
+  if (!text) return 0;
+  // Chars/4 is the cl100k rule-of-thumb. Multiplied by 1.05 to push
+  // the estimate slightly above the real value — quota enforcement
+  // wants false-positives over false-negatives.
+  return Math.ceil((text.length / 4) * 1.05);
+}
+
+/** Estimate tokens for an arbitrary JSON-serialisable value. */
+export function estimateTokensFor(v: unknown): number {
+  if (v === undefined || v === null) return 0;
+  if (typeof v === "string") return estimateTokens(v);
+  try { return estimateTokens(JSON.stringify(v)); } catch { return 0; }
+}
+
+export interface TokenBudgetConfig {
+  /** Daily cap in tokens per identity. 0 / undefined / negative
+   *  disables the cap (the limiter never denies). */
+  dailyLimit?: number;
+  /** Override Date.now for tests. */
+  now?: () => number;
+}
+
+export interface CheckResult {
+  allowed: boolean;
+  /** Tokens used in the trailing 24h window AFTER this call was
+   *  counted (when allowed) — or as of now (when denied). */
+  used: number;
+  /** Configured daily cap. 0 means uncapped. */
+  limit: number;
+  /** Seconds until the oldest bucket's worth of tokens drops off,
+   *  rounded up. 0 when allowed. */
+  retryAfterSeconds: number;
+}
+
+interface Bucket {
+  /** Hour-aligned epoch ms. */
+  at: number;
+  tokens: number;
+}
+
+/** Per-identity 24h-rolling token budget with 1h buckets. */
+export class TokenBudget {
+  private readonly limit: number;
+  private readonly now: () => number;
+  private readonly buckets = new Map<string, Bucket[]>();
+
+  constructor(cfg: TokenBudgetConfig = {}) {
+    this.limit = cfg.dailyLimit && cfg.dailyLimit > 0 ? Math.floor(cfg.dailyLimit) : 0;
+    this.now = cfg.now ?? Date.now;
+  }
+
+  /** Record-and-test: does adding `tokens` keep `identity` under the
+   *  daily cap? When `allowed`, the tokens are persisted into the
+   *  bucket; when denied, they are NOT recorded (so a single huge
+   *  request can't push the bucket arbitrarily over the cap and
+   *  starve the rest of the window). */
+  check(identity: string, tokens: number, now: number = this.now()): CheckResult {
+    if (this.limit <= 0) {
+      // Uncapped → always allow, still track usage for /api/usage.
+      this.record(identity, tokens, now);
+      return { allowed: true, used: this.usedInWindow(identity, now), limit: 0, retryAfterSeconds: 0 };
+    }
+    const safeTokens = tokens > 0 ? Math.floor(tokens) : 0;
+    const existing = this.usedInWindow(identity, now);
+    if (existing + safeTokens > this.limit) {
+      const next = this.nextSlotMs(identity, now);
+      return {
+        allowed: false,
+        used: existing,
+        limit: this.limit,
+        retryAfterSeconds: Math.max(1, Math.ceil(next / 1000)),
+      };
+    }
+    this.record(identity, safeTokens, now);
+    return {
+      allowed: true,
+      used: existing + safeTokens,
+      limit: this.limit,
+      retryAfterSeconds: 0,
+    };
+  }
+
+  /** Read-only snapshot for /api/usage. */
+  inspect(identity: string, now: number = this.now()): { used: number; limit: number; windowMs: number } {
+    return { used: this.usedInWindow(identity, now), limit: this.limit, windowMs: WINDOW_MS };
+  }
+
+  /** All identities the tracker has ever seen — for /api/usage aggregation. */
+  knownIdentities(): string[] {
+    return Array.from(this.buckets.keys());
+  }
+
+  /** For tests — clear everything. */
+  reset(): void {
+    this.buckets.clear();
+  }
+
+  /** Internal: append `tokens` to the current hour's bucket for
+   *  `identity`. Creates a new bucket when the hour boundary rolls. */
+  private record(identity: string, tokens: number, now: number): void {
+    if (tokens <= 0) return;
+    const hourAt = Math.floor(now / HOUR_MS) * HOUR_MS;
+    const fresh = this.pruneOld(identity, now);
+    const last = fresh[fresh.length - 1];
+    if (last && last.at === hourAt) {
+      last.tokens += tokens;
+    } else {
+      fresh.push({ at: hourAt, tokens });
+    }
+    this.buckets.set(identity, fresh);
+  }
+
+  /** Internal: drop buckets older than 24h and return the remainder. */
+  private pruneOld(identity: string, now: number): Bucket[] {
+    const cutoff = now - WINDOW_MS;
+    const buckets = this.buckets.get(identity) ?? [];
+    let i = 0;
+    while (i < buckets.length && buckets[i].at < cutoff) i++;
+    if (i === 0) return buckets;
+    const kept = buckets.slice(i);
+    this.buckets.set(identity, kept);
+    return kept;
+  }
+
+  private usedInWindow(identity: string, now: number): number {
+    const fresh = this.pruneOld(identity, now);
+    let total = 0;
+    for (const b of fresh) total += b.tokens;
+    return total;
+  }
+
+  /** Time in ms until the oldest in-window bucket drops off, freeing
+   *  its share of the budget. Returns 0 when the bucket list is empty. */
+  private nextSlotMs(identity: string, now: number): number {
+    const fresh = this.pruneOld(identity, now);
+    if (fresh.length === 0) return 0;
+    const oldest = fresh[0];
+    const dropAt = oldest.at + WINDOW_MS;
+    return Math.max(0, dropAt - now);
+  }
+}
+
+/** Parse OMCP_TOOL_DAILY_TOKENS into a daily limit. Mirrors the
+ *  resolveToolRatePerMin pattern: unset / empty / non-numeric /
+ *  zero / negative → uncapped (0). Positive integers pass through. */
+export function resolveDailyTokenLimit(raw: string | undefined): number {
+  if (raw === undefined || raw === "") return 0;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  return Math.floor(n);
+}


### PR DESCRIPTION
## Summary

Phase **E6 slice 1 of 4** — server-core token-budget tracker. Zero new deps.

### What ships
- **\`estimateTokens\` / \`estimateTokensFor\`** — deliberate over-estimate (\`chars/4 × 1.05\`, ceiled). cl100k rule-of-thumb + 5% fudge so budget enforcement errs strict. No tokenizer dependency — keeps the airgapped posture intact.
- **\`TokenBudget\`** class — per-identity, 24h-rolling, 1h-bucketed accounting. \`check()\` records-and-tests in one step; denied requests are NOT recorded.
- **\`resolveDailyTokenLimit\`** — \`OMCP_TOOL_DAILY_TOKENS\` parser with the same footgun handling as \`resolveToolRatePerMin\`.

### Tests
14 node:test cases.

### Reviewer pass
- ✅ Ship as-is.
- 🕒 Carry-forwards to slice 2: refine retryAfter to fit-the-request, add \`freedAtRetry\` to CheckResult, optional debug log on circular-serialise.

### Remaining E6
- Slice 2: wire into MCP tools + /api/usage extension + OpenAPI
- Slice 3: persistence (JSONL or snapshot)
- Slice 4: UI Dashboard usage strip + docs

## Test plan
- [ ] CI green: 14 new tests
- [ ] No new dependencies, no release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)