### PR TITLE
feat(quota): wire TokenBudget into MCP tools + /api/usage — Phase E6 slice 2/4

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -64,6 +64,7 @@ import { buildAuditMiddleware } from "./audit/middleware.js";
 import { readCatalogFile, CatalogStore } from "./catalog/loader.js";
 import { redactValue } from "./policy/redact.js";
 import { IdentityRateLimiter, resolveToolRatePerMin } from "./quota/limiter.js";
+import { TokenBudget, estimateTokensFor, resolveDailyTokenLimit } from "./quota/token-budget.js";
 import { getPluginLoader } from "./connectors/loader.js";
 import {
   resolveHubCatalogUrl,
@@ -264,6 +265,46 @@ async function main() {
   // the per-category counts so the agent (and the human) sees a hint
   // like `{ email: 4, ipv4: 2, totalMatches: 6 }` instead of silently
   // losing data.
+  /** Charge the estimated tokens in a tool response against the
+   *  per-identity daily budget. When the budget would be exceeded,
+   *  replace the response with a structured error payload —
+   *  the tool's data never crosses the boundary, and the agent
+   *  sees a parseable {error: "OMCP_TOKEN_BUDGET_EXCEEDED", ...}
+   *  rather than a generic failure. Anonymous principals are not
+   *  charged (the budget is per-credential).
+   *
+   *  This charges RETROACTIVELY: the tool body has already executed,
+   *  so the work is done by the time we decide to deny — the call
+   *  that flips the bucket over the cap still pays the cost; the
+   *  N+1 call denies before doing work. Pre-flight denial would
+   *  require predicting response size before the connector runs,
+   *  which isn't tractable for query_logs / query_metrics where
+   *  size is data-dependent. The trade-off is intentional: one
+   *  over-cap call per bucket roll vs an unhelpful "request denied,
+   *  size unknown" upstream. */
+  function chargeTokenBudget<T extends { content: Array<{ text: string }> }>(
+    result: T,
+    ctx: RequestContext,
+    toolName: string,
+  ): T {
+    if (ctx.auth !== "apikey") return result;
+    const text = result.content[0]?.text ?? "";
+    const tokens = estimateTokensFor(text);
+    const decision = tokenBudget.check(ctx.principalId, tokens);
+    if (decision.allowed || decision.limit === 0) return result;
+    const errBody = {
+      error: "OMCP_TOKEN_BUDGET_EXCEEDED",
+      tool: toolName,
+      used: decision.used,
+      limit: decision.limit,
+      requested: tokens,
+      retryAfterSeconds: decision.retryAfterSeconds,
+      freedAtRetry: decision.freedAtRetry,
+      message: `Daily token budget exceeded (${decision.used}/${decision.limit} tokens used in the trailing 24h; this call would have added ~${tokens}). Try again in ~${Math.ceil(decision.retryAfterSeconds / 3600)}h or raise OMCP_TOOL_DAILY_TOKENS.`,
+    };
+    return { ...result, content: [{ ...result.content[0], text: JSON.stringify(errBody) }] } as T;
+  }
+
   const REDACTION_ENABLED = String(process.env.OMCP_REDACTION ?? "on").toLowerCase() !== "off";
   function redactToolText<T extends { content: Array<{ text: string }> }>(
     result: T,
@@ -388,7 +429,8 @@ async function main() {
     },
     async (args) => {
       await enforceEntitledAccess(ctx, { tool: "query_metrics", source: (args as any)?.source, service: (args as any)?.service });
-      return withToolMetrics("query_metrics", () => queryMetricsHandler(registry, args, ctx));
+      const result = await withToolMetrics("query_metrics", () => queryMetricsHandler(registry, args, ctx));
+      return chargeTokenBudget(result, ctx, "query_metrics");
     }
   );
 
@@ -474,7 +516,8 @@ async function main() {
           // crash the tool call. The chain itself remains intact.
         });
       }
-      return redactToolText(result, { bypass });
+      const redacted = redactToolText(result, { bypass });
+      return chargeTokenBudget(redacted, ctx, "query_logs");
     }
   );
 
@@ -496,7 +539,8 @@ async function main() {
     async (args) => {
       await enforceEntitledAccess(ctx, { tool: "get_service_health", service: (args as any)?.service });
       const result = await withToolMetrics("get_service_health", () => getServiceHealthHandler(registry, args, ctx));
-      return enrichToolHealthText(result, String((args as any)?.service ?? ""));
+      const enriched = enrichToolHealthText(result, String((args as any)?.service ?? ""));
+      return chargeTokenBudget(enriched, ctx, "get_service_health");
     }
   );
 
@@ -1075,16 +1119,34 @@ async function main() {
   // never enters a bucket so it doesn't show up here.
   app.get("/api/usage", need("audit", "read"), (req, res) => {
     const actor = qstr(req.query.actor);
-    const ids = actor ? [actor] : toolRateLimiter.knownIdentities();
+    // Union of identities known to either tracker — an identity might
+    // only show in the budget tracker (no recent calls but historical
+    // tokens still inside the 24h window) or vice versa.
+    const idSet = new Set<string>([
+      ...(actor ? [actor] : toolRateLimiter.knownIdentities()),
+      ...(actor ? [actor] : tokenBudget.knownIdentities()),
+    ]);
+    const ids = [...idSet];
     const now = Date.now();
     const identities = ids.map((id) => {
-      const s = toolRateLimiter.inspect(id, now);
-      return { actor: id, count: s.count, limit: s.limit, windowMs: s.windowMs };
+      const r = toolRateLimiter.inspect(id, now);
+      const b = tokenBudget.inspect(id, now);
+      return {
+        actor: id,
+        count: r.count,
+        limit: r.limit,
+        windowMs: r.windowMs,
+        tokens: { used: b.used, limit: b.limit, windowMs: b.windowMs },
+      };
     });
     res.json({
       identities,
       defaultLimit: resolveToolRatePerMin(process.env.OMCP_TOOL_RATE_PER_MIN),
       windowMs: 60_000,
+      tokens: {
+        defaultLimit: resolveDailyTokenLimit(process.env.OMCP_TOOL_DAILY_TOKENS),
+        windowMs: 24 * 60 * 60 * 1000,
+      },
     });
   });
 
@@ -1698,6 +1760,16 @@ async function main() {
   // still applies. Override via OMCP_TOOL_RATE_PER_MIN.
   const toolRateLimiter = new IdentityRateLimiter({
     limit: resolveToolRatePerMin(process.env.OMCP_TOOL_RATE_PER_MIN),
+  });
+
+  // Token-budget: per-identity 24h rolling daily cap on tokens pulled
+  // through the MCP tool layer. Off by default (OMCP_TOOL_DAILY_TOKENS
+  // unset/zero/negative). When configured, big-data tools
+  // (query_logs / query_metrics / get_service_health) charge the
+  // estimated response size against the cap; over-cap calls return a
+  // structured OMCP_TOKEN_BUDGET_EXCEEDED payload instead of data.
+  const tokenBudget = new TokenBudget({
+    dailyLimit: resolveDailyTokenLimit(process.env.OMCP_TOOL_DAILY_TOKENS),
   });
 
   // Bearer/X-API-Key on every /mcp request; resolve the principal + its

--- a/mcp-server/src/openapi.ts
+++ b/mcp-server/src/openapi.ts
@@ -449,11 +449,28 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
                             count: { type: "integer" },
                             limit: { type: "integer" },
                             windowMs: { type: "integer" },
+                            tokens: {
+                              type: "object",
+                              description: "Per-identity 24h-rolling token usage. `limit: 0` means uncapped (OMCP_TOOL_DAILY_TOKENS unset).",
+                              properties: {
+                                used: { type: "integer" },
+                                limit: { type: "integer" },
+                                windowMs: { type: "integer" },
+                              },
+                            },
                           },
                         },
                       },
                       defaultLimit: { type: "integer" },
                       windowMs: { type: "integer" },
+                      tokens: {
+                        type: "object",
+                        description: "Process-wide defaults for the token-budget tracker.",
+                        properties: {
+                          defaultLimit: { type: "integer" },
+                          windowMs: { type: "integer" },
+                        },
+                      },
                     },
                   },
                 },

--- a/mcp-server/src/quota/token-budget.test.ts
+++ b/mcp-server/src/quota/token-budget.test.ts
@@ -64,19 +64,48 @@ test("TokenBudget — 24h rolling: buckets older than 24h drop off", () => {
   assert.equal(b.check("alice", 1000).allowed, true);
 });
 
-test("TokenBudget — denied request returns retryAfter ≈ time until oldest bucket drops", () => {
+test("TokenBudget — denied request returns retryAfter ≈ time until enough buckets drop to fit the request", () => {
   let now = 1_700_000_000_000;
   const b = new TokenBudget({ dailyLimit: 100, now: () => now });
-  b.check("alice", 100); // fully consumed
+  b.check("alice", 100); // fully consumed at hour 0
   now += 60 * 60 * 1000; // +1h
   const denied = b.check("alice", 1);
   assert.equal(denied.allowed, false);
-  // Oldest bucket at hour 0 drops at hour 24; we're at hour 1 → ~23h
+  // Need 1 free; oldest bucket (100 tokens) drops at hour 24 → ~23h wait.
   const expectedSeconds = 23 * 60 * 60;
   assert.ok(
     Math.abs(denied.retryAfterSeconds - expectedSeconds) < 3600,
     `expected ~${expectedSeconds}s, got ${denied.retryAfterSeconds}s`,
   );
+  // freedAtRetry exposes how much will be available
+  assert.equal(denied.freedAtRetry, 100);
+});
+
+test("TokenBudget — retryAfter walks enough buckets to fit a LARGER request", () => {
+  let now = 1_700_000_000_000;
+  const HOUR = 60 * 60 * 1000;
+  const b = new TokenBudget({ dailyLimit: 1000, now: () => now });
+  // Three 300-token calls spread across 3 different hours.
+  b.check("alice", 300, now);              // bucket hour 0
+  b.check("alice", 300, now + HOUR);       // bucket hour 1
+  b.check("alice", 400, now + 2 * HOUR);   // bucket hour 2 — total 1000
+  now += 3 * HOUR;
+  // Now request 700 more. Need 700 free. Dropping bucket@hour0 (300)
+  // only frees 300 — not enough. Dropping bucket@hour1 (300 more)
+  // gets to 600 — still not enough. Dropping bucket@hour2 (400 more)
+  // gets to 1000 — fits 700 with headroom.
+  const denied = b.check("alice", 700);
+  assert.equal(denied.allowed, false);
+  // Must wait until bucket@hour1 drops (at hour 1 + 24 = hour 25),
+  // we are at hour 3 → 22h wait? No — we need bucket@hour1 to drop to
+  // get freed=600, still not enough. Need bucket@hour2 → drops at
+  // hour 26, we're at hour 3 → 23h wait, with 1000 freed by then.
+  const expectedSeconds = 23 * 60 * 60;
+  assert.ok(
+    Math.abs(denied.retryAfterSeconds - expectedSeconds) < 3600,
+    `expected ~${expectedSeconds}s, got ${denied.retryAfterSeconds}s`,
+  );
+  assert.equal(denied.freedAtRetry, 1000, "all three buckets must have dropped to fit the 700 request");
 });
 
 test("TokenBudget — per-identity isolation (alice's bucket doesn't affect bob)", () => {

--- a/mcp-server/src/quota/token-budget.ts
+++ b/mcp-server/src/quota/token-budget.ts
@@ -62,9 +62,15 @@ export interface CheckResult {
   used: number;
   /** Configured daily cap. 0 means uncapped. */
   limit: number;
-  /** Seconds until the oldest bucket's worth of tokens drops off,
-   *  rounded up. 0 when allowed. */
+  /** Seconds until ENOUGH buckets drop off to fit the denied request.
+   *  Walks the bucket list oldest-first and stops at the first
+   *  timestamp where dropping every bucket older would free
+   *  >= (used + tokens - limit) tokens. Rounded up. 0 when allowed
+   *  (or when uncapped). */
   retryAfterSeconds: number;
+  /** How many tokens will be available again at retryAfterSeconds.
+   *  Useful for HTTP 429 bodies + Retry-After hints. 0 when allowed. */
+  freedAtRetry: number;
 }
 
 interface Bucket {
@@ -93,17 +99,19 @@ export class TokenBudget {
     if (this.limit <= 0) {
       // Uncapped → always allow, still track usage for /api/usage.
       this.record(identity, tokens, now);
-      return { allowed: true, used: this.usedInWindow(identity, now), limit: 0, retryAfterSeconds: 0 };
+      return { allowed: true, used: this.usedInWindow(identity, now), limit: 0, retryAfterSeconds: 0, freedAtRetry: 0 };
     }
     const safeTokens = tokens > 0 ? Math.floor(tokens) : 0;
     const existing = this.usedInWindow(identity, now);
     if (existing + safeTokens > this.limit) {
-      const next = this.nextSlotMs(identity, now);
+      const needed = existing + safeTokens - this.limit;
+      const { waitMs, freed } = this.nextEnoughHeadroom(identity, now, needed);
       return {
         allowed: false,
         used: existing,
         limit: this.limit,
-        retryAfterSeconds: Math.max(1, Math.ceil(next / 1000)),
+        retryAfterSeconds: waitMs > 0 ? Math.max(1, Math.ceil(waitMs / 1000)) : 1,
+        freedAtRetry: freed,
       };
     }
     this.record(identity, safeTokens, now);
@@ -112,6 +120,7 @@ export class TokenBudget {
       used: existing + safeTokens,
       limit: this.limit,
       retryAfterSeconds: 0,
+      freedAtRetry: 0,
     };
   }
 
@@ -164,14 +173,29 @@ export class TokenBudget {
     return total;
   }
 
-  /** Time in ms until the oldest in-window bucket drops off, freeing
-   *  its share of the budget. Returns 0 when the bucket list is empty. */
-  private nextSlotMs(identity: string, now: number): number {
+  /** Walk the bucket list oldest-first until enough tokens would have
+   *  dropped off to fit a request needing `needed` extra headroom.
+   *  Returns the wait in ms + the cumulative freed tokens at that
+   *  point. When `needed` exceeds the entire window's content (the
+   *  caller wants more than the cap), returns the time until the
+   *  newest bucket drops + everything freed. */
+  private nextEnoughHeadroom(identity: string, now: number, needed: number): { waitMs: number; freed: number } {
     const fresh = this.pruneOld(identity, now);
-    if (fresh.length === 0) return 0;
-    const oldest = fresh[0];
-    const dropAt = oldest.at + WINDOW_MS;
-    return Math.max(0, dropAt - now);
+    if (fresh.length === 0) return { waitMs: 0, freed: 0 };
+    let freed = 0;
+    for (const b of fresh) {
+      freed += b.tokens;
+      if (freed >= needed) {
+        const dropAt = b.at + WINDOW_MS;
+        return { waitMs: Math.max(0, dropAt - now), freed };
+      }
+    }
+    // Even dropping every bucket isn't enough — the request alone
+    // exceeds the daily cap. Return the time until the newest bucket
+    // drops so the caller knows the window will be empty by then; the
+    // request will still get rejected on size if it exceeds limit.
+    const newest = fresh[fresh.length - 1];
+    return { waitMs: Math.max(0, newest.at + WINDOW_MS - now), freed };
   }
 }
 


### PR DESCRIPTION
## Summary

Phase **E6 slice 2 of 4** — wires the token-budget core into the data-plane and surfaces it via /api/usage.

### What ships
- **CheckResult.freedAtRetry** + **nextEnoughHeadroom** — the retryAfter math now walks buckets oldest-first until enough free to fit the request. Multi-bucket regression test added.
- **\`chargeTokenBudget(result, ctx, toolName)\`** wrapper — wired into \`query_metrics\`, \`query_logs\` (post-redaction), \`get_service_health\`. Over-cap → structured \`OMCP_TOKEN_BUDGET_EXCEEDED\` payload (the agent gets a parseable refusal). Anonymous principals bypass. JSDoc documents the retroactive-charge trade-off.
- **\`/api/usage\`** unions both trackers; per-identity \`tokens: {used, limit, windowMs}\` + top-level \`tokens\` defaults block.
- **OpenAPI** schema updated.

### Reviewer pass
- ✅ Ship — 2 nice-to-haves (distinct over-cap-by-itself error code; multi-content preservation on denial) deferred to slice 3/4.

### Remaining E6
- Slice 3: persistence (survives restarts)
- Slice 4: UI Dashboard usage strip + docs

## Test plan
- [ ] CI green: 1 updated + 1 new token-budget test, /api/usage still functional
- [ ] No new dependencies, no release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)