### PR TITLE
feat(quota): TokenBudget snapshot persistence + bootstrap-race + corrupt-snapshot warn — Phase E6 slice 3/4

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -34,6 +34,7 @@ Two adjacent controls fall under the same umbrella:
 |---|---|---|---|
 | **PII / secret redaction** of `query_logs` output | `OMCP_REDACTION` | `on` | [redaction.md](redaction.md) |
 | **Per-identity rate limit** on the `/mcp` transport | `OMCP_TOOL_RATE_PER_MIN` | 60 | (in this doc, "Rate limits") |
+| **Per-identity daily token budget** on the MCP tool layer | `OMCP_TOOL_DAILY_TOKENS` (+ optional `OMCP_TOKEN_BUDGET_FILE` for restart survival) | 0 (uncapped) | (in this doc, "Token budget") |
 
 ## Minimal production-ready setup
 
@@ -204,6 +205,66 @@ current windowed count per identity:
 
 Pass `?actor=<name>` to inspect a single identity (count is 0 for
 identities the server has never seen).
+
+## Token budget
+
+`OMCP_TOOL_DAILY_TOKENS=<positive integer>` enables a per-identity
+rolling 24-hour token cap. Tokens are estimated post-tool-execution
+(over-count by ~5% vs cl100k_base, so the gate errs on the strict
+side) and charged against the calling bearer-token credential. When
+the bucket would exceed the cap, the tool returns
+
+```json
+{
+  "error": "OMCP_TOKEN_BUDGET_EXCEEDED",
+  "tool": "query_logs",
+  "used": 49800,
+  "limit": 50000,
+  "requested": 1200,
+  "retryAfterSeconds": 73400,
+  "freedAtRetry": 14000,
+  "message": "Daily token budget exceeded (49800/50000 ...)."
+}
+```
+
+instead of the data. The agent sees a parseable refusal, not a
+generic failure.
+
+Anonymous `/mcp` traffic is not charged (the budget is per
+credential; an operator running without `OMCP_API_KEYS` has no
+identity-keyed bucket to charge). Three tools currently honour the
+gate: `query_logs`, `query_metrics`, `get_service_health`. Adding
+new high-token tools is a one-line `chargeTokenBudget(result, ctx,
+"new_tool")` wrap.
+
+The `retryAfterSeconds` walks bucket history oldest-first until
+enough capacity has dropped to fit the denied request; `freedAtRetry`
+reports how many tokens that frees so a well-behaved agent can
+decide whether to back off or retry sooner with a smaller request.
+
+`OMCP_TOKEN_BUDGET_FILE=<path>` enables snapshot persistence —
+buckets reload at boot, so a server restart mid-day doesn't reset
+quotas. Writes are debounced (1s default) and atomic (write-rename).
+Unset → in-memory only, which is fine for demo / single-operator
+setups where a restart-on-each-deploy effectively rolls budgets.
+
+Live snapshot at `GET /api/usage` (same gate as the rate-limit view)
+returns:
+
+```json
+{
+  "identities": [
+    {
+      "actor": "agent-prod",
+      "count": 14,
+      "limit": 60,
+      "windowMs": 60000,
+      "tokens": { "used": 42100, "limit": 50000, "windowMs": 86400000 }
+    }
+  ],
+  "tokens": { "defaultLimit": 50000, "windowMs": 86400000 }
+}
+```
 
 ## Service catalog enrichment
 

--- a/helm/observability-mcp/values.yaml
+++ b/helm/observability-mcp/values.yaml
@@ -73,6 +73,15 @@ sources:
 #   - OMCP_MGMT_AUDIT_FILE         JSONL audit log; in-memory ring (500) when unset
 #   - OMCP_SERVICE_CATALOG_FILE    owner / tier / on-call / SLO metadata
 #   - OMCP_TOOL_RATE_PER_MIN       per-identity /mcp cap; default 60
+#   - OMCP_TOOL_DAILY_TOKENS       per-identity 24h-rolling token cap;
+#                                  default 0 (uncapped). Charges only
+#                                  named bearer-token callers, never
+#                                  anonymous /mcp traffic. See
+#                                  docs/access-control.md.
+#   - OMCP_TOKEN_BUDGET_FILE       JSON snapshot path so per-identity
+#                                  budgets survive restarts; unset →
+#                                  in-memory only (resets on every
+#                                  boot).
 #   - OMCP_REDACTION               on (default) | off — see docs/redaction.md
 #   - OMCP_TRUST_PROXY             true | loopback | <hops> | <ip,ip,...>
 #   - OMCP_AUTH_ALLOW_FALLBACK     true → degrade to anonymous on basic-mode

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1770,7 +1770,22 @@ async function main() {
   // structured OMCP_TOKEN_BUDGET_EXCEEDED payload instead of data.
   const tokenBudget = new TokenBudget({
     dailyLimit: resolveDailyTokenLimit(process.env.OMCP_TOOL_DAILY_TOKENS),
+    filePath: process.env.OMCP_TOKEN_BUDGET_FILE?.trim() || undefined,
   });
+  // AWAIT bootstrap before any tool call can arrive: a void-fired
+  // bootstrap raced with /mcp requests would silently overwrite
+  // post-boot charges with the on-disk snapshot when it later
+  // resolved. The file is small (KB range) so the wait is
+  // negligible; a missing file returns immediately.
+  await tokenBudget.bootstrap();
+  // Flush on graceful shutdown so the debounce-window of pending
+  // charges isn't dropped on `kubectl rollout restart` etc. The
+  // process keeps running while we wait — the snapshot is small.
+  for (const sig of ["SIGTERM", "SIGINT"] as const) {
+    process.once(sig, () => {
+      void tokenBudget.flushNow().catch(() => { /* best-effort */ });
+    });
+  }
 
   // Bearer/X-API-Key on every /mcp request; resolve the principal + its
   // coarse source allow-list into the RequestContext.

--- a/mcp-server/src/quota/token-budget.test.ts
+++ b/mcp-server/src/quota/token-budget.test.ts
@@ -1,6 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { TokenBudget, estimateTokens, estimateTokensFor, resolveDailyTokenLimit } from "./token-budget.js";
 
 test("estimateTokens — empty/null/undefined → 0", () => {
@@ -156,4 +160,79 @@ test("resolveDailyTokenLimit — positive integers pass through; decimals floore
   assert.equal(resolveDailyTokenLimit("50000"), 50000);
   assert.equal(resolveDailyTokenLimit("1"), 1);
   assert.equal(resolveDailyTokenLimit("1234.7"), 1234);
+});
+
+test("TokenBudget persistence — flushNow writes a snapshot that bootstrap() reads back", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "omcp-token-"));
+  const file = join(dir, "budget.json");
+  try {
+    const t = 1_700_000_000_000;
+    const b1 = new TokenBudget({ dailyLimit: 1000, filePath: file, flushDebounceMs: 0, now: () => t });
+    b1.check("alice", 300);
+    b1.check("bob", 700);
+    await b1.flushNow();
+    const text = await readFile(file, "utf8");
+    const parsed = JSON.parse(text) as Record<string, Array<{ at: number; tokens: number }>>;
+    assert.equal(parsed.alice[0].tokens, 300);
+    assert.equal(parsed.bob[0].tokens, 700);
+    // A fresh tracker pointed at the same file picks up the buckets.
+    const b2 = new TokenBudget({ dailyLimit: 1000, filePath: file, flushDebounceMs: 0, now: () => t });
+    await b2.bootstrap();
+    assert.equal(b2.inspect("alice").used, 300);
+    assert.equal(b2.inspect("bob").used, 700);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("TokenBudget persistence — bootstrap drops entries older than 24h", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "omcp-token-"));
+  const file = join(dir, "budget.json");
+  try {
+    const t0 = 1_700_000_000_000;
+    const b1 = new TokenBudget({ dailyLimit: 1000, filePath: file, flushDebounceMs: 0, now: () => t0 });
+    b1.check("alice", 500);
+    await b1.flushNow();
+    // Restart 30h later — the alice entry should drop on bootstrap.
+    const tLater = t0 + 30 * 60 * 60 * 1000;
+    const b2 = new TokenBudget({ dailyLimit: 1000, filePath: file, flushDebounceMs: 0, now: () => tLater });
+    await b2.bootstrap();
+    assert.equal(b2.inspect("alice").used, 0, "expired buckets must drop on bootstrap");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("TokenBudget persistence — corrupt snapshot is tolerated (start fresh, don't crash)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "omcp-token-"));
+  const file = join(dir, "budget.json");
+  try {
+    // Write something that's not valid JSON.
+    const fs = await import("node:fs/promises");
+    await fs.writeFile(file, "{not: json", "utf8");
+    const b = new TokenBudget({ dailyLimit: 1000, filePath: file, flushDebounceMs: 0 });
+    await b.bootstrap();
+    // Tracker should be empty; subsequent operations should work fine.
+    assert.equal(b.inspect("alice").used, 0);
+    b.check("alice", 100);
+    assert.equal(b.inspect("alice").used, 100);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("TokenBudget persistence — debounced flush eventually writes (default 1s)", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "omcp-token-"));
+  const file = join(dir, "budget.json");
+  try {
+    const b = new TokenBudget({ dailyLimit: 1000, filePath: file, flushDebounceMs: 50 });
+    b.check("alice", 42);
+    // Wait past the debounce window
+    await new Promise((r) => setTimeout(r, 120));
+    const text = await readFile(file, "utf8");
+    const parsed = JSON.parse(text) as Record<string, Array<{ at: number; tokens: number }>>;
+    assert.equal(parsed.alice[0].tokens, 42);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });

--- a/mcp-server/src/quota/token-budget.ts
+++ b/mcp-server/src/quota/token-budget.ts
@@ -28,6 +28,8 @@
  * requires the persistence layer.
  */
 
+import { readFile, writeFile, rename } from "node:fs/promises";
+
 const HOUR_MS = 60 * 60 * 1000;
 const WINDOW_MS = 24 * HOUR_MS;
 
@@ -53,6 +55,15 @@ export interface TokenBudgetConfig {
   dailyLimit?: number;
   /** Override Date.now for tests. */
   now?: () => number;
+  /** Optional path to a JSON snapshot file. When set, the tracker
+   *  loads buckets on bootstrap() and atomically rewrites the
+   *  snapshot on a debounced timer after each charge — so a server
+   *  restart picks up the rolling 24h window where it left off.
+   *  Unset → in-memory only (fine for demo / single-instance). */
+  filePath?: string;
+  /** Debounce window in ms for snapshot writes; default 1000. Tests
+   *  pass 0 to flush synchronously between assertions. */
+  flushDebounceMs?: number;
 }
 
 export interface CheckResult {
@@ -84,10 +95,65 @@ export class TokenBudget {
   private readonly limit: number;
   private readonly now: () => number;
   private readonly buckets = new Map<string, Bucket[]>();
+  private readonly filePath: string | undefined;
+  private readonly debounceMs: number;
+  private flushTimer: NodeJS.Timeout | null = null;
+  private writeQueue: Promise<void> = Promise.resolve();
+  private bootstrapped: Promise<void> | null = null;
 
   constructor(cfg: TokenBudgetConfig = {}) {
     this.limit = cfg.dailyLimit && cfg.dailyLimit > 0 ? Math.floor(cfg.dailyLimit) : 0;
     this.now = cfg.now ?? Date.now;
+    this.filePath = cfg.filePath;
+    this.debounceMs = cfg.flushDebounceMs ?? 1000;
+  }
+
+  /** Load a prior snapshot from disk (when filePath is set).
+   *  Safe to call multiple times — bootstraps once and caches. */
+  async bootstrap(): Promise<void> {
+    if (!this.filePath) return;
+    if (this.bootstrapped) return this.bootstrapped;
+    this.bootstrapped = (async () => {
+      let raw: string;
+      try { raw = await readFile(this.filePath!, "utf8"); }
+      catch (e) {
+        // ENOENT on a first run is fine; everything else is worth a
+        // warning so an operator notices a missing-mount / perms
+        // issue immediately rather than discovering quotas reset
+        // silently on next restart.
+        if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+          console.warn(`[token-budget] could not read snapshot ${this.filePath}: ${(e as Error).message} — starting fresh`);
+        }
+        return;
+      }
+      let parsed: unknown;
+      try { parsed = JSON.parse(raw); }
+      catch (e) {
+        console.warn(`[token-budget] snapshot ${this.filePath} is not valid JSON (${(e as Error).message}) — starting fresh, prior 24h charges are lost`);
+        return;
+      }
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        console.warn(`[token-budget] snapshot ${this.filePath} root is not a JSON object — starting fresh`);
+        return;
+      }
+      const now = this.now();
+      const cutoff = now - WINDOW_MS;
+      for (const [identity, raw] of Object.entries(parsed as Record<string, unknown>)) {
+        if (!Array.isArray(raw)) continue;
+        const kept: Bucket[] = [];
+        for (const b of raw) {
+          if (!b || typeof b !== "object") continue;
+          const at = (b as { at?: unknown }).at;
+          const tokens = (b as { tokens?: unknown }).tokens;
+          if (typeof at !== "number" || typeof tokens !== "number" || tokens <= 0) continue;
+          if (at < cutoff) continue;
+          kept.push({ at, tokens });
+        }
+        kept.sort((a, b) => a.at - b.at);
+        if (kept.length > 0) this.buckets.set(identity, kept);
+      }
+    })();
+    return this.bootstrapped;
   }
 
   /** Record-and-test: does adding `tokens` keep `identity` under the
@@ -152,6 +218,53 @@ export class TokenBudget {
       fresh.push({ at: hourAt, tokens });
     }
     this.buckets.set(identity, fresh);
+    this.scheduleFlush();
+  }
+
+  /** Debounce a snapshot write. No-op when filePath isn't configured. */
+  private scheduleFlush(): void {
+    if (!this.filePath) return;
+    if (this.flushTimer) return;
+    if (this.debounceMs === 0) {
+      // Tests pass 0 so the write happens before the next assertion.
+      void this.flushNow();
+      return;
+    }
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      void this.flushNow();
+    }, this.debounceMs);
+    // Don't keep the event loop alive for the snapshot flush —
+    // the in-memory state is the truth; the file is a recovery
+    // aid. Process shutdown without one final flush loses at
+    // most one debounce window of charge data.
+    if (typeof this.flushTimer.unref === "function") this.flushTimer.unref();
+  }
+
+  /** Write the current bucket state to disk atomically (tmp + rename).
+   *  Public so a graceful shutdown can `await tokenBudget.flushNow()`. */
+  async flushNow(): Promise<void> {
+    if (!this.filePath) return;
+    const path = this.filePath;
+    // Build the snapshot synchronously so we capture a consistent
+    // point-in-time view of the map, then write asynchronously.
+    const snapshot: Record<string, Bucket[]> = {};
+    for (const [id, buckets] of this.buckets) {
+      if (buckets.length > 0) snapshot[id] = buckets;
+    }
+    const body = JSON.stringify(snapshot);
+    this.writeQueue = this.writeQueue.then(async () => {
+      try {
+        const tmp = path + ".tmp";
+        await writeFile(tmp, body, "utf8");
+        await rename(tmp, path);
+      } catch {
+        // Best-effort: persistence is recovery insurance, not the
+        // source of truth. A failed write doesn't poison in-memory
+        // state.
+      }
+    });
+    return this.writeQueue;
   }
 
   /** Internal: drop buckets older than 24h and return the remainder. */


### PR DESCRIPTION
## Summary

Phase **E6 slice 3 of 4** — quotas survive server restarts.

### What ships
- **\`OMCP_TOKEN_BUDGET_FILE=path\`** wires snapshot persistence: \`bootstrap()\` at boot loads prior buckets, \`flushNow()\` writes atomically (tmp + rename), \`record()\` triggers a debounced flush (1s default).
- **4 new persistence tests** (round-trip, drop >24h, corrupt tolerated, debounced flush).
- **Docs**: \`docs/access-control.md\` "Token budget" section + Helm values comment.

### Reviewer pre-push: 3 real defects fixed
- **Bootstrap race** — was \`void\` fired; tool calls in the boot window silently lost charges when the async snapshot overwrote post-boot buckets. Now **awaited** before \`app.listen\`.
- **No shutdown flush** — was the whole point of persistence; SIGTERM/SIGINT now call \`flushNow()\` so \`kubectl rollout restart\` doesn't drop the debounce window.
- **Silent corrupt-snapshot loss** — was \`catch { return }\`; now three distinct \`console.warn\` lines (ENOENT stays quiet, parse error / bad shape / read error all surface so the operator notices).

### Remaining E6
- Slice 4: UI Dashboard usage strip + final docs polish

## Test plan
- [ ] CI green: 4 new persistence tests + existing 16 still pass
- [ ] No new dependencies, no release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)