### PR TITLE
feat(ui+quota): Dashboard usage strip + OMCP_TOKEN_REQUEST_EXCEEDS_BUDGET — Phase E6 slice 4/4 (FINAL)

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -266,6 +266,19 @@ returns:
 }
 ```
 
+The Web UI's **Overview** page shows the same data as a "Today's
+MCP usage" strip — top 5 identities sorted by token consumption,
+with a coloured progress bar that turns amber at 70% of the daily
+cap and red at 90%. The strip is hidden when no identity has any
+traffic yet, or the viewer lacks the `audit:read` permission.
+
+### Error codes
+
+| Code | Meaning | Caller response |
+|---|---|---|
+| `OMCP_TOKEN_BUDGET_EXCEEDED` | Identity is at the cap; this call would push over. | Wait `retryAfterSeconds`; `freedAtRetry` tells how much will be available. |
+| `OMCP_TOKEN_REQUEST_EXCEEDS_BUDGET` | Single response alone larger than the entire daily cap. | Retrying won't help — narrow the query (smaller window / lower limit / more selective filter) or raise the cap. |
+
 ## Service catalog enrichment
 
 When `OMCP_SERVICE_CATALOG_FILE` points at a JSON catalog (schema in

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -292,17 +292,35 @@ async function main() {
     const tokens = estimateTokensFor(text);
     const decision = tokenBudget.check(ctx.principalId, tokens);
     if (decision.allowed || decision.limit === 0) return result;
+    // A single request larger than the entire daily cap can never
+    // succeed by waiting — surface a distinct error code so the
+    // agent doesn't loop. Otherwise the wait-then-retry path is the
+    // right answer (and freedAtRetry tells the agent how much they
+    // can request after the wait).
+    const requestExceedsCap = tokens > decision.limit;
     const errBody = {
-      error: "OMCP_TOKEN_BUDGET_EXCEEDED",
+      error: requestExceedsCap ? "OMCP_TOKEN_REQUEST_EXCEEDS_BUDGET" : "OMCP_TOKEN_BUDGET_EXCEEDED",
       tool: toolName,
       used: decision.used,
       limit: decision.limit,
       requested: tokens,
-      retryAfterSeconds: decision.retryAfterSeconds,
+      retryAfterSeconds: requestExceedsCap ? 0 : decision.retryAfterSeconds,
       freedAtRetry: decision.freedAtRetry,
-      message: `Daily token budget exceeded (${decision.used}/${decision.limit} tokens used in the trailing 24h; this call would have added ~${tokens}). Try again in ~${Math.ceil(decision.retryAfterSeconds / 3600)}h or raise OMCP_TOOL_DAILY_TOKENS.`,
+      message: requestExceedsCap
+        ? `This single response (~${tokens} tokens) is larger than the entire daily budget (${decision.limit}). Retrying won't help — narrow the query (smaller window / lower limit / more selective filter) or raise OMCP_TOOL_DAILY_TOKENS.`
+        : `Daily token budget exceeded (${decision.used}/${decision.limit} tokens used in the trailing 24h; this call would have added ~${tokens}). Try again in ~${Math.ceil(decision.retryAfterSeconds / 3600)}h or raise OMCP_TOOL_DAILY_TOKENS.`,
     };
-    return { ...result, content: [{ ...result.content[0], text: JSON.stringify(errBody) }] } as T;
+    // Preserve any additional content entries (e.g. a future
+    // tool returning [text, image]) — only the text payload of the
+    // first entry is replaced with the error JSON; everything after
+    // it passes through.
+    return {
+      ...result,
+      content: [
+        { ...result.content[0], text: JSON.stringify(errBody) },
+        ...result.content.slice(1),
+      ],
+    } as T;
   }
 
   const REDACTION_ENABLED = String(process.env.OMCP_REDACTION ?? "on").toLowerCase() !== "off";

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -1368,6 +1368,19 @@
           <div class="flow-node"><span class="fn-ic">✦</span><span class="fn-t">Analysis</span><span class="fn-s">scored health</span></div>
         </div>
       </div>
+      <!-- Today's usage strip (top-5 identities by activity in the trailing
+           24h window). Reads /api/usage; hidden when no identity has any
+           traffic yet OR the viewer lacks audit:read (silently — non-admin
+           sessions just don't see it). -->
+      <div class="card" id="dash-usage-card" style="display:none">
+        <div class="card-header"><h2>Today's MCP usage
+          <button class="info" aria-label="About the usage strip"
+            data-title="Usage strip"
+            data-info="Per-identity totals across the trailing 24h window: requests counted by the rate-limiter (1-minute resolution) and tokens estimated post-tool-execution. The token bucket is the same one OMCP_TOOL_DAILY_TOKENS gates against — when it fills, the corresponding identity gets OMCP_TOKEN_BUDGET_EXCEEDED on the next call. Anonymous /mcp traffic isn't shown (no per-identity bucket to charge)."
+            onclick="infoPop(this)">?</button>
+        </h2></div>
+        <div id="dash-usage" class="content"><div class="empty">Loading…</div></div>
+      </div>
       <div style="display:grid; grid-template-columns: 1fr 1fr; gap: 16px;">
         <div class="card"><div class="card-header"><h2>Sources</h2><button class="btn btn-primary btn-sm" data-rbac="sources:write" onclick="showPage('sources');openAddModal()">+ Add Source</button></div><div id="dash-sources"><div class="empty">Loading...</div></div></div>
         <div class="card"><div class="card-header"><h2>Services</h2></div><div id="dash-services"><div class="empty">Loading...</div></div></div>
@@ -3013,6 +3026,40 @@ function closeModal(id) { document.getElementById(id).classList.remove('open'); 
 
 // --- Data Loading ---
 async function loadSources() { try { sourcesData=await(await fetch('/api/sources')).json(); renderSources(); updateStats(); } catch(e){} }
+async function loadDashUsage() {
+  const card = document.getElementById('dash-usage-card');
+  const box = document.getElementById('dash-usage');
+  if (!card || !box) return;
+  try {
+    const r = await fetch('/api/usage');
+    if (!r.ok) { card.style.display = 'none'; return; }
+    const j = await r.json();
+    const ids = (j.identities || [])
+      .map((i) => ({
+        actor: i.actor,
+        calls: i.count || 0,
+        rateLimit: i.limit || 0,
+        tokensUsed: (i.tokens && i.tokens.used) || 0,
+        tokenLimit: (i.tokens && i.tokens.limit) || 0,
+      }))
+      .filter((i) => i.calls > 0 || i.tokensUsed > 0)
+      .sort((a, b) => (b.tokensUsed - a.tokensUsed) || (b.calls - a.calls))
+      .slice(0, 5);
+    if (ids.length === 0) { card.style.display = 'none'; return; }
+    card.style.display = '';
+    const rows = ids.map((i) => {
+      const pct = i.tokenLimit > 0 ? Math.min(100, Math.round((i.tokensUsed / i.tokenLimit) * 100)) : null;
+      const tokenCell = i.tokenLimit > 0
+        ? `${i.tokensUsed.toLocaleString()} / ${i.tokenLimit.toLocaleString()} <span class="t-sm" style="opacity:.7">(${pct}%)</span>`
+        : `${i.tokensUsed.toLocaleString()} <span class="t-sm" style="opacity:.7">(uncapped)</span>`;
+      const bar = pct !== null
+        ? `<div style="background: var(--surface-2); height: 6px; border-radius: 3px; overflow:hidden; margin-top: 2px;"><div style="width:${pct}%; height:100%; background: ${pct >= 90 ? 'var(--danger)' : pct >= 70 ? 'var(--warning)' : 'var(--success)'};"></div></div>`
+        : '';
+      return `<tr><td><code>${escHtml(i.actor)}</code></td><td>${i.calls.toLocaleString()} / ${i.rateLimit.toLocaleString()}</td><td>${tokenCell}${bar}</td></tr>`;
+    }).join('');
+    box.innerHTML = `<table class="data-table" style="width:100%"><thead><tr><th>Identity</th><th>Calls (rate-limit/min)</th><th>Tokens (24h)</th></tr></thead><tbody>${rows}</tbody></table>`;
+  } catch (e) { card.style.display = 'none'; }
+}
 async function loadServices() { try { const d=await(await fetch('/api/services')).json(); servicesData=d.services||[]; renderServices(); updateStats(); } catch(e){} }
 async function loadTypes() { try { supportedTypes=await(await fetch('/api/source-types')).json(); } catch(e){ supportedTypes=['prometheus','loki']; } }
 async function loadSettingsData() {
@@ -4639,7 +4686,7 @@ function richEmpty(opts) {
 function loadingBlock(label) {
   return `<div class="state is-loading" role="status" aria-live="polite"><div class="state-ico">${STATE_ICONS.spinner}</div><div class="state-title">${esc(label||'Loading…')}</div></div>`;
 }
-async function refresh(){await Promise.all([loadSources(),loadServices()]);}
+async function refresh(){await Promise.all([loadSources(),loadServices(),loadDashUsage()]);}
 
 async function loadInfo(){
   try{


### PR DESCRIPTION
## Summary

**Phase E6 slice 4/4 — FINAL.** Closes Phase E6 (Token-Budget + Quotas + Usage UI).

### UI
- New **"Today's MCP usage"** card on the Overview page: top-5 identities sorted by tokens used (desc), with coloured progress bar (green <70%, amber ≥70%, red ≥90%).
- Hidden silently for non-admins or when no identity has traffic yet.
- Auto-refreshes via the existing 15s dashboard tick.

### Deferred slice-2 polish landed
- **\`OMCP_TOKEN_REQUEST_EXCEEDS_BUDGET\`** — distinct code when a single response is larger than the entire daily cap (retry can't help; narrow query or raise cap). Avoids agent retry loops.
- **\`content[1..]\` preservation** on denial — forward-compat for future multi-content tools.

### Docs
- New error-code table in \`docs/access-control.md\`.

### Phase E6 status after merge
**Complete.** 4 PRs (#297, #298, #299, this): zero-dep token tracker → wiring + /api/usage → persistence with bootstrap+shutdown handling → UI surface + distinct error codes.

Next per the plan: **E7 (Multi-Tenancy)**.

## Test plan
- [ ] CI green: existing 20 token-budget tests still pass; UI smoke covers the new card
- [ ] No new dependencies, no release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)