### PR TITLE
feat(tenancy): TenantContext core + identity → tenant resolution — Phase E7 slice 1/5

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,7 +52,7 @@ jobs:
         run: npm ci
       - name: Run tests
         working-directory: ./mcp-server
-        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/auth/oidc/*.test.ts src/auth/policy/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/quota/*.test.ts src/connectors/verify.test.ts src/connectors/hub.test.ts src/connectors/install.test.ts src/cli/*.test.ts src/tools/*.test.ts src/net/*.test.ts src/openapi.test.ts src/enterprise-gate.test.ts
+        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/auth/oidc/*.test.ts src/auth/policy/*.test.ts src/tenancy/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/quota/*.test.ts src/connectors/verify.test.ts src/connectors/hub.test.ts src/connectors/install.test.ts src/cli/*.test.ts src/tools/*.test.ts src/net/*.test.ts src/openapi.test.ts src/enterprise-gate.test.ts
       - name: Connector hub catalog (validate + in-sync)
         run: |
           node hub/build-catalog.mjs --check

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ doctor: ## Quick health check — is the mcp-server reachable on $$OMCP_HOST:$$O
 test: ## Run mcp-server unit tests in Docker
 	docker run --rm -w /app -v "$(PWD)/mcp-server:/app" node:20-alpine \
 	  sh -c "npm install --silent --no-audit --no-fund && \
-	         npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/auth/oidc/*.test.ts src/auth/policy/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/quota/*.test.ts src/tools/*.test.ts src/net/*.test.ts src/openapi.test.ts src/enterprise-gate.test.ts"
+	         npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/auth/oidc/*.test.ts src/auth/policy/*.test.ts src/tenancy/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/quota/*.test.ts src/tools/*.test.ts src/net/*.test.ts src/openapi.test.ts src/enterprise-gate.test.ts"
 
 lint: ## helm lint + tsc --noEmit
 	docker run --rm -v "$(PWD)/helm:/apps" alpine/helm:3.16.2 lint /apps/observability-mcp

--- a/mcp-server/src/auth/credentials.test.ts
+++ b/mcp-server/src/auth/credentials.test.ts
@@ -20,7 +20,7 @@ describe("single-tenant auth primitive", () => {
     assert.equal(creds.length, 2);
     assert.deepEqual(
       creds[0],
-      { name: "ci", token: "tok_abc", allowedSources: undefined, bypassRedaction: undefined }
+      { name: "ci", token: "tok_abc", allowedSources: undefined, bypassRedaction: undefined, tenant: undefined }
     );
     assert.equal(creds[1].name, "key");
     assert.equal(creds[1].token, "tok_bare");
@@ -50,6 +50,16 @@ describe("single-tenant auth primitive", () => {
   it("OMCP_KEY_BYPASS_REDACTION absent → no key bypasses (least privilege default)", () => {
     const creds = loadCredentials({ OMCP_API_KEYS: "agent:tok1,ci:tok2" });
     for (const c of creds) assert.equal(c.bypassRedaction, undefined);
+  });
+
+  it("parses OMCP_KEY_TENANTS → assigns tenant to named keys; unlisted stays undefined (default)", () => {
+    const creds = loadCredentials({
+      OMCP_API_KEYS: "agent:tok1,ci:tok2,nobody:tok3",
+      OMCP_KEY_TENANTS: "agent=acme;ci=BigCorp",
+    });
+    assert.equal(creds.find((c) => c.name === "agent")?.tenant, "acme");
+    assert.equal(creds.find((c) => c.name === "ci")?.tenant, "bigcorp", "lowercased");
+    assert.equal(creds.find((c) => c.name === "nobody")?.tenant, undefined);
   });
 
   it("extractToken handles Bearer and X-API-Key", () => {

--- a/mcp-server/src/auth/credentials.ts
+++ b/mcp-server/src/auth/credentials.ts
@@ -16,11 +16,18 @@
  *                  # via the bypass_redaction tool arg. Off by default
  *                  # for every key — pair with the redaction:bypass
  *                  # RBAC permission for the management-plane angle.
+ *   OMCP_KEY_TENANTS="agent=acme;ci=bigco"
+ *                  # optional per-key tenant assignment. Unlisted keys
+ *                  # land in the "default" tenant — identical to the
+ *                  # pre-E7 single-namespace world. See docs/tenancy.md
+ *                  # (slice 5) for the cross-cutting model.
  *
  * Rich role-based access control (tools/services/lookback/read-only, the
  * full governance object) is intentionally NOT here — this is only the
  * authentication + identity + coarse source-scoping primitive.
  */
+
+import { parseKeyTenants } from "../tenancy/context.js";
 
 export interface Credential {
   name: string;
@@ -31,6 +38,8 @@ export interface Credential {
    *  to explicitly set `bypass_redaction: true` in the tool args —
    *  this flag only authorises it; it never auto-disables redaction. */
   bypassRedaction?: boolean;
+  /** Tenant this credential belongs to. Omitted → DEFAULT_TENANT. */
+  tenant?: string;
 }
 
 function parseKeySources(raw: string | undefined): Map<string, string[]> {
@@ -58,6 +67,7 @@ export function loadCredentials(env: NodeJS.ProcessEnv = process.env): Credentia
   if (!raw) return [];
   const keySources = parseKeySources(env.OMCP_KEY_SOURCES);
   const bypassNames = parseBypassSet(env.OMCP_KEY_BYPASS_REDACTION);
+  const keyTenants = parseKeyTenants(env.OMCP_KEY_TENANTS);
   const creds: Credential[] = [];
   for (const part of raw.split(",").map((s) => s.trim()).filter(Boolean)) {
     const idx = part.indexOf(":");
@@ -69,6 +79,7 @@ export function loadCredentials(env: NodeJS.ProcessEnv = process.env): Credentia
       token,
       allowedSources: keySources.get(name),
       bypassRedaction: bypassNames.has(name) || undefined,
+      tenant: keyTenants.get(name) || undefined,
     });
   }
   return creds;

--- a/mcp-server/src/auth/local-users.ts
+++ b/mcp-server/src/auth/local-users.ts
@@ -30,6 +30,8 @@ export interface LocalUser {
   username: string;
   name: string;
   roles?: string[];
+  /** Optional tenant assignment. Missing → DEFAULT_TENANT. */
+  tenant?: string;
   passwordHash: string;
 }
 
@@ -126,6 +128,7 @@ function isUsersFile(v: unknown): v is LocalUsersFile {
     if (typeof r.name !== "string") return false;
     if (typeof r.passwordHash !== "string") return false;
     if (r.roles !== undefined && !(Array.isArray(r.roles) && r.roles.every((x) => typeof x === "string"))) return false;
+    if (r.tenant !== undefined && typeof r.tenant !== "string") return false;
     return true;
   });
 }

--- a/mcp-server/src/auth/oidc/endpoints.test.ts
+++ b/mcp-server/src/auth/oidc/endpoints.test.ts
@@ -77,6 +77,7 @@ function configForTest(): OidcRuntimeConfig {
     rolesClaim: "groups",
     roleMap: { "omcp-admin": "admin", "omcp-ops": "operator" },
     logoutRedirect: "/",
+    tenantClaim: "",
   };
 }
 

--- a/mcp-server/src/auth/oidc/endpoints.ts
+++ b/mcp-server/src/auth/oidc/endpoints.ts
@@ -105,7 +105,8 @@ export function registerOidcRoutes(app: Application, deps: OidcEndpointDeps): vo
     const emailVerified = claims.email_verified === undefined || claims.email_verified === true;
     const email = emailVerified ? sanitiseClaim(claims.email) : undefined;
     const roles = oidc.resolveRoles(claims);
-    const { cookie } = issueSession({ sub, name, email, roles }, sessionCfg);
+    const tenant = oidc.resolveTenant(claims);
+    const { cookie } = issueSession({ sub, name, email, roles, tenant }, sessionCfg);
     // Two cookies: clear the now-spent flow cookie, set the long-lived
     // session cookie. The browser accepts both in a single response.
     res.setHeader("Set-Cookie", [

--- a/mcp-server/src/auth/oidc/runtime.test.ts
+++ b/mcp-server/src/auth/oidc/runtime.test.ts
@@ -23,7 +23,38 @@ test("resolveOidcConfig — happy path with required vars only", () => {
     rolesClaim: "groups",
     roleMap: {},
     logoutRedirect: "/",
+    tenantClaim: "",
   });
+});
+
+test("resolveOidcConfig — honours OMCP_OIDC_TENANT_CLAIM", () => {
+  const r = resolveOidcConfig(envOf({
+    OMCP_OIDC_ISSUER: "https://idp.test",
+    OMCP_OIDC_CLIENT_ID: "c-1",
+    OMCP_OIDC_REDIRECT_URI: "https://app.test/cb",
+    OMCP_OIDC_TENANT_CLAIM: "app.tenant_id",
+  }));
+  assert.equal(r.config?.tenantClaim, "app.tenant_id");
+});
+
+test("buildOidcRuntime.resolveTenant — empty claim path → default", () => {
+  const r = resolveOidcConfig(envOf({
+    OMCP_OIDC_ISSUER: "https://idp.test", OMCP_OIDC_CLIENT_ID: "c",
+    OMCP_OIDC_REDIRECT_URI: "https://app.test/cb",
+  }));
+  const rt = buildOidcRuntime(r.config!);
+  assert.equal(rt.resolveTenant({ tenant: "acme" }), "default");
+});
+
+test("buildOidcRuntime.resolveTenant — dotted path", () => {
+  const r = resolveOidcConfig(envOf({
+    OMCP_OIDC_ISSUER: "https://idp.test", OMCP_OIDC_CLIENT_ID: "c",
+    OMCP_OIDC_REDIRECT_URI: "https://app.test/cb",
+    OMCP_OIDC_TENANT_CLAIM: "app.tenant_id",
+  }));
+  const rt = buildOidcRuntime(r.config!);
+  assert.equal(rt.resolveTenant({ app: { tenant_id: "acme" } }), "acme");
+  assert.equal(rt.resolveTenant({ app: { other: "x" } }), "default");
 });
 
 test("resolveOidcConfig — surfaces ALL missing required vars in one message", () => {

--- a/mcp-server/src/auth/oidc/runtime.ts
+++ b/mcp-server/src/auth/oidc/runtime.ts
@@ -23,6 +23,7 @@
  */
 
 import { OidcClient, type OidcConfig } from "./client.js";
+import { DEFAULT_TENANT, tenantFromClaim } from "../../tenancy/context.js";
 
 export interface OidcRuntimeConfig {
   issuer: string;
@@ -33,6 +34,9 @@ export interface OidcRuntimeConfig {
   rolesClaim: string;
   roleMap: Record<string, string>;
   logoutRedirect: string;
+  /** Dotted claim path to read the tenant from. Empty / missing → all
+   *  OIDC sessions land in the "default" tenant. */
+  tenantClaim: string;
 }
 
 export interface ResolveOidcResult {
@@ -92,6 +96,7 @@ export function resolveOidcConfig(env: NodeJS.ProcessEnv = process.env): Resolve
       rolesClaim: nonEmpty(env.OMCP_OIDC_ROLES_CLAIM) ?? "groups",
       roleMap,
       logoutRedirect: nonEmpty(env.OMCP_OIDC_LOGOUT_REDIRECT) ?? "/",
+      tenantClaim: nonEmpty(env.OMCP_OIDC_TENANT_CLAIM) ?? "",
     },
   };
 }
@@ -105,6 +110,10 @@ export interface OidcRuntime {
    *  return the OMCP role names the user inherits via roleMap.
    *  Unknown claim values are silently dropped (least-privilege). */
   resolveRoles(claims: Record<string, unknown>): string[];
+  /** Walk a JWT claim set, follow the configured tenant claim path,
+   *  and return a normalised tenant id. Empty / missing / invalid →
+   *  DEFAULT_TENANT. */
+  resolveTenant(claims: Record<string, unknown>): string;
 }
 
 export function buildOidcRuntime(cfg: OidcRuntimeConfig, opts: { client?: OidcClient } = {}): OidcRuntime {
@@ -131,6 +140,9 @@ export function buildOidcRuntime(cfg: OidcRuntimeConfig, opts: { client?: OidcCl
         if (mapped) roles.add(mapped);
       }
       return [...roles];
+    },
+    resolveTenant(claims) {
+      return cfg.tenantClaim ? tenantFromClaim(claims, cfg.tenantClaim) : DEFAULT_TENANT;
     },
   };
 }

--- a/mcp-server/src/auth/session.ts
+++ b/mcp-server/src/auth/session.ts
@@ -22,6 +22,10 @@ export interface SessionPayload {
    *  local-users-mode sessions usually omit this; OIDC sessions populate
    *  from the `email` claim when present + verified by the IdP. */
   email?: string;
+  /** Tenant the identity belongs to. Omitted when single-tenant — the
+   *  request handler defaults to "default" via normaliseTenant() so
+   *  existing single-tenant deployments need no migration. */
+  tenant?: string;
   /** Optional list of role identifiers — used by later phases for RBAC. */
   roles?: string[];
   /** Issued-at, seconds since epoch. */
@@ -60,7 +64,7 @@ function sign(secret: string, payload: string): string {
 
 /** Create a signed cookie value for the given identity. */
 export function issueSession(
-  identity: Pick<SessionPayload, "sub" | "name" | "roles" | "email">,
+  identity: Pick<SessionPayload, "sub" | "name" | "roles" | "email" | "tenant">,
   cfg: SessionConfig,
   now: number = Math.floor(Date.now() / 1000),
 ): { cookie: string; payload: SessionPayload } {
@@ -70,6 +74,7 @@ export function issueSession(
     sub: identity.sub,
     name: identity.name,
     email: identity.email,
+    tenant: identity.tenant,
     roles: identity.roles,
     iat: now,
     exp: now + ttl,
@@ -123,6 +128,7 @@ function isSessionPayload(v: unknown): v is SessionPayload {
   if (typeof o.iat !== "number" || typeof o.exp !== "number") return false;
   if (o.roles !== undefined && !(Array.isArray(o.roles) && o.roles.every((r) => typeof r === "string"))) return false;
   if (o.email !== undefined && typeof o.email !== "string") return false;
+  if (o.tenant !== undefined && typeof o.tenant !== "string") return false;
   return true;
 }
 

--- a/mcp-server/src/context.ts
+++ b/mcp-server/src/context.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
 
+import { DEFAULT_TENANT, normaliseTenant } from "./tenancy/context.js";
+
 /**
  * Request-scoped context threaded from the transport boundary (HTTP `/mcp`,
  * stdio, and the internal REST/dashboard call sites) into every tool handler.
@@ -25,6 +27,10 @@ export interface RequestContext {
    *  tool call ALSO sets `bypass_redaction: true` in its args. Default
    *  false. Configured via OMCP_KEY_BYPASS_REDACTION. */
   allowBypassRedaction?: boolean;
+  /** Tenant the request operates in. ALWAYS set — defaults to
+   *  "default" for anonymous principals + missing-tenant credentials,
+   *  preserving the single-namespace behaviour of pre-E7 deployments. */
+  tenant: string;
   /** Correlates all tool calls within one transport request/session. */
   correlationId: string;
 }
@@ -34,6 +40,7 @@ export function defaultContext(): RequestContext {
   return {
     principalId: "anonymous",
     auth: "anonymous",
+    tenant: DEFAULT_TENANT,
     correlationId: randomUUID(),
   };
 }
@@ -42,13 +49,14 @@ export function defaultContext(): RequestContext {
 export function principalContext(
   principalId: string,
   allowedSources?: string[],
-  opts: { allowBypassRedaction?: boolean } = {},
+  opts: { allowBypassRedaction?: boolean; tenant?: string } = {},
 ): RequestContext {
   return {
     principalId,
     auth: "apikey",
     allowedSources: allowedSources && allowedSources.length > 0 ? allowedSources : undefined,
     allowBypassRedaction: opts.allowBypassRedaction || undefined,
+    tenant: normaliseTenant(opts.tenant),
     correlationId: randomUUID(),
   };
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1238,7 +1238,7 @@ async function main() {
       return;
     }
     const { cookie } = issueSession(
-      { sub: user.username, name: user.name, roles: user.roles },
+      { sub: user.username, name: user.name, roles: user.roles, tenant: user.tenant },
       sessionCfg,
     );
     const secure = req.secure || (req.headers["x-forwarded-proto"] === "https");
@@ -1842,6 +1842,7 @@ async function main() {
     }
     return principalContext(cred.name, cred.allowedSources, {
       allowBypassRedaction: cred.bypassRedaction,
+      tenant: cred.tenant,
     });
   }
 

--- a/mcp-server/src/tenancy/context.test.ts
+++ b/mcp-server/src/tenancy/context.test.ts
@@ -1,0 +1,91 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  DEFAULT_TENANT,
+  MAX_TENANT_LENGTH,
+  normaliseTenant,
+  tenantFromClaim,
+  parseKeyTenants,
+} from "./context.js";
+
+test("normaliseTenant — happy paths", () => {
+  assert.equal(normaliseTenant("acme"), "acme");
+  assert.equal(normaliseTenant("ACME"), "acme", "lowercases");
+  assert.equal(normaliseTenant("  acme-corp  "), "acme-corp", "trims");
+  assert.equal(normaliseTenant("team_a.us-east"), "team_a.us-east");
+});
+
+test("normaliseTenant — invalid / empty / null falls back to default", () => {
+  assert.equal(normaliseTenant(undefined), DEFAULT_TENANT);
+  assert.equal(normaliseTenant(null), DEFAULT_TENANT);
+  assert.equal(normaliseTenant(""), DEFAULT_TENANT);
+  assert.equal(normaliseTenant("   "), DEFAULT_TENANT);
+  assert.equal(normaliseTenant(123), DEFAULT_TENANT);
+  // Disallowed shapes
+  assert.equal(normaliseTenant("acme/corp"), DEFAULT_TENANT, "slash rejected");
+  assert.equal(normaliseTenant("acme corp"), DEFAULT_TENANT, "space rejected");
+  assert.equal(normaliseTenant("..hidden"), DEFAULT_TENANT, "leading dot rejected");
+  assert.equal(normaliseTenant("-leading"), DEFAULT_TENANT, "leading dash rejected");
+  // Too long
+  assert.equal(normaliseTenant("x".repeat(MAX_TENANT_LENGTH + 1)), DEFAULT_TENANT);
+});
+
+test("normaliseTenant — exactly MAX_TENANT_LENGTH passes", () => {
+  const t = "a" + "x".repeat(MAX_TENANT_LENGTH - 1);
+  assert.equal(t.length, MAX_TENANT_LENGTH);
+  assert.equal(normaliseTenant(t), t);
+});
+
+test("tenantFromClaim — flat claim", () => {
+  assert.equal(tenantFromClaim({ tenant: "acme" }, "tenant"), "acme");
+  assert.equal(tenantFromClaim({ tenant: "ACME" }, "tenant"), "acme");
+  assert.equal(tenantFromClaim({}, "tenant"), DEFAULT_TENANT);
+});
+
+test("tenantFromClaim — dotted claim path", () => {
+  assert.equal(tenantFromClaim({ app: { tenant_id: "acme" } }, "app.tenant_id"), "acme");
+  assert.equal(tenantFromClaim({ app: { tenant_id: "acme" } }, "app.missing"), DEFAULT_TENANT);
+  assert.equal(tenantFromClaim({ app: { tenant_id: "acme" } }, "missing.path"), DEFAULT_TENANT);
+});
+
+test("tenantFromClaim — array claim takes first string entry", () => {
+  assert.equal(tenantFromClaim({ tenants: ["acme", "other"] }, "tenants"), "acme");
+  assert.equal(tenantFromClaim({ tenants: [123, "acme"] }, "tenants"), "acme");
+  assert.equal(tenantFromClaim({ tenants: [123, 456] }, "tenants"), DEFAULT_TENANT);
+});
+
+test("tenantFromClaim — non-string scalar falls back", () => {
+  assert.equal(tenantFromClaim({ tenant: 42 }, "tenant"), DEFAULT_TENANT);
+  assert.equal(tenantFromClaim({ tenant: true }, "tenant"), DEFAULT_TENANT);
+  assert.equal(tenantFromClaim({ tenant: null }, "tenant"), DEFAULT_TENANT);
+});
+
+test("tenantFromClaim — empty claimPath returns default", () => {
+  assert.equal(tenantFromClaim({ tenant: "acme" }, ""), DEFAULT_TENANT);
+});
+
+test("parseKeyTenants — happy path", () => {
+  const m = parseKeyTenants("ci=acme;agent=bigco; dev=team_a.us");
+  assert.equal(m.size, 3);
+  assert.equal(m.get("ci"), "acme");
+  assert.equal(m.get("agent"), "bigco");
+  assert.equal(m.get("dev"), "team_a.us");
+});
+
+test("parseKeyTenants — invalid tenant on the right-hand side normalises to default", () => {
+  const m = parseKeyTenants("ci=acme/corp;agent=BIGCO");
+  assert.equal(m.get("ci"), DEFAULT_TENANT, "slash → default");
+  assert.equal(m.get("agent"), "bigco", "uppercase OK after normalise");
+});
+
+test("parseKeyTenants — malformed entries skipped, doesn't crash", () => {
+  const m = parseKeyTenants("noequal;=novalueeither;valid=acme");
+  assert.equal(m.size, 1);
+  assert.equal(m.get("valid"), "acme");
+});
+
+test("parseKeyTenants — undefined / empty returns empty map", () => {
+  assert.equal(parseKeyTenants(undefined).size, 0);
+  assert.equal(parseKeyTenants("").size, 0);
+});

--- a/mcp-server/src/tenancy/context.ts
+++ b/mcp-server/src/tenancy/context.ts
@@ -1,0 +1,92 @@
+/**
+ * Multi-tenant context primitives.
+ *
+ * Every request lands in EXACTLY ONE tenant. Identities resolve to a
+ * tenant via one of three paths:
+ *
+ *   1. Anonymous (no auth, the demo / single-operator path) → DEFAULT_TENANT.
+ *   2. Basic-mode local user → user file's optional `tenant` field;
+ *      missing → DEFAULT_TENANT (so existing single-tenant deployments
+ *      keep working without any config change).
+ *   3. OIDC session → OMCP_OIDC_TENANT_CLAIM (default `tenant`);
+ *      empty / missing claim → DEFAULT_TENANT.
+ *   4. MCP credential (bearer token) → optional per-credential
+ *      `tenant` field assigned via OMCP_KEY_TENANTS env, mirroring
+ *      OMCP_KEY_SOURCES / OMCP_KEY_BYPASS_REDACTION shape.
+ *
+ * The constant `DEFAULT_TENANT` is the universal escape hatch — any
+ * non-multi-tenant deployment behaves as if everything is in
+ * tenant `default`, identical to the pre-E7 single-namespace world.
+ *
+ * Cross-tenant requests return 404 (not 403) per the plan — leaking
+ * existence by status code defeats half the point of isolation.
+ */
+
+export const DEFAULT_TENANT = "default";
+
+/** Maximum tenant identifier length. Defence-in-depth against a
+ *  hostile claim payload pushing arbitrary KB-sized strings through
+ *  every cookie. Operators with longer names should pick shorter
+ *  ones; the audit chain still hashes the full string but the
+ *  cookie payload + log lines stay bounded. */
+export const MAX_TENANT_LENGTH = 64;
+
+/** Pattern: alphanumeric + `-` + `_` + `.`. Mirrors what most CI
+ *  identifiers accept. Rejects `/`, space, control chars (which
+ *  could break filesystem layouts in slice 2). */
+const VALID_TENANT_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+/** Normalise + validate a tenant identifier. Returns the trimmed,
+ *  lower-cased string when valid; DEFAULT_TENANT for empty or
+ *  invalid input (silent fallback rather than crash — an OIDC claim
+ *  with junk should drop the user into the safe default, not 500
+ *  the whole flow). */
+export function normaliseTenant(raw: unknown): string {
+  if (typeof raw !== "string") return DEFAULT_TENANT;
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed.length === 0) return DEFAULT_TENANT;
+  if (trimmed.length > MAX_TENANT_LENGTH) return DEFAULT_TENANT;
+  if (!VALID_TENANT_RE.test(trimmed)) return DEFAULT_TENANT;
+  return trimmed;
+}
+
+/** Walk a dotted-path claim out of an arbitrary claim set, then
+ *  normalise. Used for OIDC sessions where the tenant lives at e.g.
+ *  `app.tenant_id` rather than the top level. */
+export function tenantFromClaim(claims: Record<string, unknown>, claimPath: string): string {
+  if (!claimPath) return DEFAULT_TENANT;
+  const parts = claimPath.split(".");
+  let cur: unknown = claims;
+  for (const p of parts) {
+    if (cur && typeof cur === "object" && !Array.isArray(cur) && p in (cur as Record<string, unknown>)) {
+      cur = (cur as Record<string, unknown>)[p];
+    } else {
+      return DEFAULT_TENANT;
+    }
+  }
+  // Arrays: take the first string-shaped entry (the same posture as
+  // resolveRoles in auth/oidc/runtime.ts). Operators wanting per-call
+  // multi-tenancy should use one tenant claim per token, not a list.
+  if (Array.isArray(cur)) {
+    for (const v of cur) if (typeof v === "string") return normaliseTenant(v);
+    return DEFAULT_TENANT;
+  }
+  return normaliseTenant(cur);
+}
+
+/** Parse OMCP_KEY_TENANTS="ci=acme;agent=bigco" into a name → tenant
+ *  map. Mirrors parseKeySources in auth/credentials.ts so the operator
+ *  cognitive load stays low. Invalid tenant strings normalise to
+ *  DEFAULT_TENANT silently. */
+export function parseKeyTenants(raw: string | undefined): Map<string, string> {
+  const out = new Map<string, string>();
+  if (!raw) return out;
+  for (const entry of raw.split(";").map((s) => s.trim()).filter(Boolean)) {
+    const eq = entry.indexOf("=");
+    if (eq <= 0) continue;
+    const name = entry.slice(0, eq).trim();
+    const tenant = normaliseTenant(entry.slice(eq + 1).trim());
+    if (name) out.set(name, tenant);
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Phase **E7 slice 1 of 5** — first slice of multi-tenancy. Server-core only; storage scoping, cross-tenant 404, UI, docs+demo follow in slices 2-5.

### What ships
- **\`src/tenancy/context.ts\`** — \`DEFAULT_TENANT\`, \`normaliseTenant\` (hardened regex, path-traversal-safe, RFC 1123 superset), \`tenantFromClaim\` (dotted-path), \`parseKeyTenants\` (\`OMCP_KEY_TENANTS\`).
- **Identity wiring across all four paths**: anonymous, basic-mode local user (\`tenant\` field), OIDC session (\`OMCP_OIDC_TENANT_CLAIM\` claim), MCP credential (\`OMCP_KEY_TENANTS\` env). All default to \`default\` when unconfigured — zero-touch backwards compat.
- **16 new tests** (12 tenancy + 3 OIDC + 1 credentials), plus 2 shape-assertion updates.

### Backwards compat
- Pre-E7 deployments with no \`tenant\` field on any LocalUser, no \`OMCP_KEY_TENANTS\`, no \`OMCP_OIDC_TENANT_CLAIM\`: all identities land in \`default\`. Pre-existing session cookies validate (tenant is optional in isSessionPayload).

### Security
- \`normaliseTenant\` regex rejects \`/\`, \`..\`, leading dot/dash, control chars, oversized strings. Slice 2's filesystem keying can't be path-traversal-attacked via a hostile tenant claim.

### Reviewer pre-push
- ✅ 1 blocker fixed: existing \`runtime.test.ts\` deepEqual was broken by the new \`tenantClaim\` field — expectation updated + 3 new pinning tests added.

### Remaining E7
- Slice 2: storage layers keyed by tenant (sources, catalog, audit, quota)
- Slice 3: cross-tenant 404 enforcement on /api/* + tool scoping
- Slice 4: UI tenant switcher + scoped views
- Slice 5: docs + demo + migration test

## Test plan
- [ ] CI green: 16 new + 1 updated test pass; existing OIDC/credentials suites unaffected
- [ ] No new dependencies, no release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)