### PR TITLE
feat(tenancy): tracker + audit storage scoped by tenant — Phase E7 slice 2/5

### DIFF
--- a/mcp-server/src/audit/log.test.ts
+++ b/mcp-server/src/audit/log.test.ts
@@ -63,6 +63,20 @@ test("AuditLog — list filters by actor + action + window", async () => {
   assert.equal(log.list({ from: "2099-01-01", to: "2099-12-31" }).length, 0);
 });
 
+test("AuditLog — tenant filter scopes results; entries with no tenant treated as 'default'", async () => {
+  const log = new AuditLog();
+  await log.record({ actor: { sub: "alice" }, tenant: "acme", resource: "sources", action: "write", method: "POST", path: "/api/sources", status: 200 });
+  await log.record({ actor: { sub: "bob" },   tenant: "bigco", resource: "sources", action: "write", method: "POST", path: "/api/sources", status: 200 });
+  // No tenant on this entry → treated as "default" when filtering
+  await log.record({ actor: { sub: "carol" }, resource: "sources", action: "write", method: "POST", path: "/api/sources", status: 200 });
+
+  assert.equal(log.list({ tenant: "acme" }).length, 1);
+  assert.equal(log.list({ tenant: "bigco" }).length, 1);
+  assert.equal(log.list({ tenant: "default" }).length, 1);
+  // No tenant filter → all three visible
+  assert.equal(log.list({}).length, 3);
+});
+
 test("AuditLog — in-memory ring honours cap", async () => {
   const log = new AuditLog({ inMemoryCap: 3 });
   for (let i = 0; i < 10; i++) {

--- a/mcp-server/src/audit/log.ts
+++ b/mcp-server/src/audit/log.ts
@@ -27,6 +27,9 @@ export interface AuditEntry {
   seq: number;
   /** Identity that triggered the change. "anonymous" when auth is off. */
   actor: { sub: string; name?: string };
+  /** Tenant the actor belonged to at the time of the action.
+   *  Omitted on pre-E7 entries; readers default to "default". */
+  tenant?: string;
   /** Logical resource + action, mirrors the RBAC vocabulary. */
   resource: string;
   action: string;
@@ -129,7 +132,7 @@ export class AuditLog {
   }
 
   /** Snapshot of the in-memory ring (most recent last). */
-  list(opts: { from?: string; to?: string; actor?: string; action?: string; limit?: number } = {}): AuditEntry[] {
+  list(opts: { from?: string; to?: string; actor?: string; action?: string; limit?: number; tenant?: string } = {}): AuditEntry[] {
     // Coerce non-finite / non-positive limits (NaN from a bad query
     // string, negative, undefined) to the 100 default. Previously
     // NaN propagated through Math.min / Math.max and the comparison
@@ -146,6 +149,10 @@ export class AuditLog {
       if (opts.to && e.ts > opts.to) continue;
       if (opts.actor && e.actor.sub !== opts.actor) continue;
       if (opts.action && e.action !== opts.action) continue;
+      if (opts.tenant) {
+        const entryTenant = e.tenant || "default";
+        if (entryTenant !== opts.tenant) continue;
+      }
       out.push(e);
     }
     return out;

--- a/mcp-server/src/audit/middleware.ts
+++ b/mcp-server/src/audit/middleware.ts
@@ -38,6 +38,7 @@ export function buildAuditMiddleware(cfg: AuditMiddlewareConfig): RequestHandler
           actor: sess
             ? { sub: sess.sub, name: sess.name }
             : { sub: "anonymous" },
+          tenant: sess?.tenant || "default",
           resource: cfg.resource,
           action: cfg.action,
           method: req.method,
@@ -45,7 +46,7 @@ export function buildAuditMiddleware(cfg: AuditMiddlewareConfig): RequestHandler
           status: res.statusCode,
           ip: req.ip || undefined,
           target,
-        })
+        } as Parameters<typeof cfg.audit.record>[0])
         .catch(() => {
           // record() already swallows file errors — this catch only
           // covers the synchronous Promise wiring.

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -48,6 +48,7 @@ import {
 } from "./auth/middleware.js";
 import {
   buildRequirePermission,
+  hasPermission,
   listGrantedPermissions,
   DEFAULT_POLICY,
   type Permission,
@@ -290,7 +291,7 @@ async function main() {
     if (ctx.auth !== "apikey") return result;
     const text = result.content[0]?.text ?? "";
     const tokens = estimateTokensFor(text);
-    const decision = tokenBudget.check(ctx.principalId, tokens);
+    const decision = tokenBudget.check(identityKey(ctx), tokens);
     if (decision.allowed || decision.limit === 0) return result;
     // A single request larger than the entire daily cap can never
     // succeed by waiting — surface a distinct error code so the
@@ -523,6 +524,7 @@ async function main() {
         emitBypassEvent(bypass ? "redaction_bypass_engaged" : "redaction_bypass_denied", ctx, args);
         void mgmtAudit.record({
           actor: { sub: ctx.principalId },
+          tenant: ctx.tenant,
           resource: "redaction",
           action: "bypass",
           method: "MCP",
@@ -1120,14 +1122,33 @@ async function main() {
   // policy) can pull it. Supports optional ?from, ?to (RFC-3339), ?actor,
   // ?action, ?limit (default 100, capped to ring size).
   app.get("/api/audit", need("audit", "read"), (req, res) => {
+    // Tenant scoping: a non-admin caller (no `users:delete`) sees
+    // only their own tenant's entries. Admins see everything by
+    // default but can ?tenant=acme to filter. This avoids leaking
+    // other tenants' actor / target / path bytes through the audit
+    // surface — the chain-hash protected ground truth is still
+    // process-wide; the API view is per-tenant.
+    const sess = (req as AuthedRequest).session;
+    const isAdmin = hasPermission(sess?.roles, "users", "delete");
+    const callerTenant = sess?.tenant || "default";
+    const requestedTenant = qstr(req.query.tenant);
+    const tenantFilter = isAdmin ? requestedTenant : callerTenant;
     const entries = mgmtAudit.list({
       from: qstr(req.query.from),
       to: qstr(req.query.to),
       actor: qstr(req.query.actor),
       action: qstr(req.query.action),
+      tenant: tenantFilter || undefined,
       limit: qstr(req.query.limit) ? parseInt(qstr(req.query.limit)!, 10) : undefined,
     });
-    res.json({ entries, tipHash: mgmtAudit.tipHash, persisted: !!process.env.OMCP_MGMT_AUDIT_FILE });
+    res.json({
+      entries,
+      tipHash: mgmtAudit.tipHash,
+      persisted: !!process.env.OMCP_MGMT_AUDIT_FILE,
+      // Tell the UI which tenant scope the view is currently showing
+      // so a cross-tenant admin sees an explicit "(all tenants)" hint.
+      scopedTo: tenantFilter || (isAdmin ? null : callerTenant),
+    });
   });
 
   // --- /api/usage — per-identity MCP rate-limit snapshot -----------------
@@ -1136,27 +1157,37 @@ async function main() {
   // audit log can see who is calling what. Anonymous /mcp traffic
   // never enters a bucket so it doesn't show up here.
   app.get("/api/usage", need("audit", "read"), (req, res) => {
-    const actor = qstr(req.query.actor);
-    // Union of identities known to either tracker — an identity might
-    // only show in the budget tracker (no recent calls but historical
-    // tokens still inside the 24h window) or vice versa.
+    const sess = (req as AuthedRequest).session;
+    const isAdmin = hasPermission(sess?.roles, "users", "delete");
+    const callerTenant = sess?.tenant || "default";
+    const requestedTenant = qstr(req.query.tenant);
+    const tenantFilter = isAdmin ? requestedTenant : callerTenant;
+    const actorFilter = qstr(req.query.actor);
+    // Union of identities known to either tracker. The tracker keys
+    // are composite "<tenant> <name>"; we split them back out for the
+    // response shape so the UI sees clean tenant + actor columns.
     const idSet = new Set<string>([
-      ...(actor ? [actor] : toolRateLimiter.knownIdentities()),
-      ...(actor ? [actor] : tokenBudget.knownIdentities()),
+      ...toolRateLimiter.knownIdentities(),
+      ...tokenBudget.knownIdentities(),
     ]);
-    const ids = [...idSet];
     const now = Date.now();
-    const identities = ids.map((id) => {
-      const r = toolRateLimiter.inspect(id, now);
-      const b = tokenBudget.inspect(id, now);
-      return {
-        actor: id,
-        count: r.count,
-        limit: r.limit,
-        windowMs: r.windowMs,
-        tokens: { used: b.used, limit: b.limit, windowMs: b.windowMs },
-      };
-    });
+    const identities = [...idSet]
+      .map((id) => {
+        const split = splitIdentityKey(id);
+        if (tenantFilter && split.tenant !== tenantFilter) return null;
+        if (actorFilter && split.actor !== actorFilter) return null;
+        const r = toolRateLimiter.inspect(id, now);
+        const b = tokenBudget.inspect(id, now);
+        return {
+          actor: split.actor,
+          tenant: split.tenant,
+          count: r.count,
+          limit: r.limit,
+          windowMs: r.windowMs,
+          tokens: { used: b.used, limit: b.limit, windowMs: b.windowMs },
+        };
+      })
+      .filter((x): x is NonNullable<typeof x> => x !== null);
     res.json({
       identities,
       defaultLimit: resolveToolRatePerMin(process.env.OMCP_TOOL_RATE_PER_MIN),
@@ -1165,6 +1196,9 @@ async function main() {
         defaultLimit: resolveDailyTokenLimit(process.env.OMCP_TOOL_DAILY_TOKENS),
         windowMs: 24 * 60 * 60 * 1000,
       },
+      // Same scoping breadcrumb /api/audit returns: which tenant
+      // window the response is showing. null = "all tenants" (admin).
+      scopedTo: tenantFilter || (isAdmin ? null : callerTenant),
     });
   });
 
@@ -1779,6 +1813,18 @@ async function main() {
   const toolRateLimiter = new IdentityRateLimiter({
     limit: resolveToolRatePerMin(process.env.OMCP_TOOL_RATE_PER_MIN),
   });
+  // Per-identity tracker key. Composes tenant + principalId so two
+  // credentials of the same name in different tenants don't share
+  // a bucket. Surface-level fields in /api/usage are still split
+  // back out (see the row builder there) so the UI shows clean
+  // actor + tenant columns.
+  const identityKey = (ctx: RequestContext): string =>
+    `${ctx.tenant} ${ctx.principalId}`;
+  function splitIdentityKey(key: string): { tenant: string; actor: string } {
+    const i = key.indexOf(" ");
+    if (i < 0) return { tenant: "default", actor: key };
+    return { tenant: key.slice(0, i), actor: key.slice(i + 1) };
+  }
 
   // Token-budget: per-identity 24h rolling daily cap on tokens pulled
   // through the MCP tool layer. Off by default (OMCP_TOOL_DAILY_TOKENS
@@ -1822,7 +1868,10 @@ async function main() {
         .json({ error: "unauthorized: valid Bearer token or X-API-Key required" });
       return null;
     }
-    const decision = toolRateLimiter.check(cred.name);
+    // Composite tenant:cred-name key so two creds with the same
+    // name in different tenants don't share a bucket.
+    const credTenant = (cred.tenant || "default");
+    const decision = toolRateLimiter.check(`${credTenant} ${cred.name}`);
     // Standard RateLimit response headers — let well-behaved clients
     // self-pace before they hit a 429. Emitted on BOTH allowed and
     // denied paths so the caller always sees the live state.

--- a/mcp-server/src/openapi.ts
+++ b/mcp-server/src/openapi.ts
@@ -402,6 +402,7 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
             { name: "to", in: "query", schema: { type: "string", format: "date-time" } },
             { name: "actor", in: "query", schema: { type: "string" } },
             { name: "action", in: "query", schema: { type: "string" } },
+            { name: "tenant", in: "query", schema: { type: "string" }, description: "Tenant scope. Non-admins are silently scoped to their own tenant; admins can pass any value (omit → all tenants)." },
             { name: "limit", in: "query", schema: { type: "integer", minimum: 1, maximum: 500, default: 100 } },
           ],
           responses: {
@@ -415,6 +416,7 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
                       entries: { type: "array", items: { type: "object", additionalProperties: true } },
                       tipHash: { type: "string" },
                       persisted: { type: "boolean" },
+                      scopedTo: { type: ["string", "null"], description: "Tenant name this view is scoped to; null = all tenants (admin)." },
                     },
                   },
                 },
@@ -431,6 +433,7 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
           summary: "Per-identity windowed call count for /mcp callers.",
           parameters: [
             { name: "actor", in: "query", schema: { type: "string" }, description: "Narrow to a single identity." },
+            { name: "tenant", in: "query", schema: { type: "string" }, description: "Tenant scope. Non-admins silently scoped to their own; admins can pick any (omit → all)." },
           ],
           responses: {
             "200": {
@@ -446,6 +449,7 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
                           type: "object",
                           properties: {
                             actor: { type: "string" },
+                            tenant: { type: "string", description: "Tenant the identity belongs to. 'default' when single-tenant." },
                             count: { type: "integer" },
                             limit: { type: "integer" },
                             windowMs: { type: "integer" },


### PR DESCRIPTION
## Summary

Phase **E7 slice 2 of 5** — storage scoping for per-identity surfaces.

### What changed
- **Audit** entries gain optional \`tenant\`; \`list()\` takes a tenant filter (entries without one default to "default" — pre-E7 entries surface cleanly).
- **Rate limiter + token budget** now keyed by \`<tenant> <principalId>\` composite — two credentials with the same name in different tenants no longer share buckets.
- **/api/audit + /api/usage** scope responses to the caller's tenant. Admins (\`users:delete\`) see all by default; can \`?tenant=X\` to filter. Both responses gain \`scopedTo\` for UI display.
- **OpenAPI** + 1 new regression test.

### Reviewer pre-push
- ✅ Isolation verified — non-admin's \`?tenant=\` silently overridden by callerTenant; actor filter applied after tenant filter; pre-E7 entries default to "default".
- ✅ Backwards-compat — existing consumers of \`/api/usage\` and \`/api/audit\` see only additive fields.

### Remaining E7
- Slice 3: cross-tenant 404 enforcement on remaining /api/* surfaces + MCP tool scoping
- Slice 4: UI tenant switcher
- Slice 5: docs + demo + migration test

## Test plan
- [ ] CI green: 1 new audit-tenant-filter test + existing suite unaffected
- [ ] No new dependencies, no release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)