### PR TITLE
feat(tenancy): catalog tenant scoping across /api/catalog + /api/services + /api/health + tools — Phase E7 slice 3/5

### DIFF
--- a/mcp-server/src/catalog/loader.test.ts
+++ b/mcp-server/src/catalog/loader.test.ts
@@ -97,3 +97,28 @@ test("CatalogStore — get / list / count / replace", () => {
   assert.equal(store.count(), 1);
   assert.equal(store.get("x")?.owner, "team-x");
 });
+
+test("CatalogStore — tenant filter scopes get / list / count", () => {
+  const store = new CatalogStore({
+    services: {
+      "acme-payments": { owner: "team-a", tenant: "acme" },
+      "bigco-payments": { owner: "team-b", tenant: "bigco" },
+      "shared-cdn": { owner: "team-c" }, // no tenant → "default"
+    },
+  });
+  // No tenant filter → see everything (admin-style read)
+  assert.equal(store.count(), 3);
+
+  // Tenant-scoped: each sees its own entries + nothing else
+  assert.equal(store.count("acme"), 1);
+  assert.equal(store.get("acme-payments", "acme")?.owner, "team-a");
+  assert.equal(store.get("bigco-payments", "acme"), undefined, "cross-tenant get must return undefined");
+  assert.equal(Object.keys(store.list("acme"))[0], "acme-payments");
+
+  // Default tenant includes entries with no tenant field
+  assert.equal(store.count("default"), 1);
+  assert.equal(store.get("shared-cdn", "default")?.owner, "team-c");
+
+  // Unknown tenant → empty
+  assert.equal(store.count("unknown"), 0);
+});

--- a/mcp-server/src/catalog/loader.ts
+++ b/mcp-server/src/catalog/loader.ts
@@ -38,6 +38,10 @@ export interface ServiceCatalogEntry {
   runbooks?: string[];
   /** Optional list of free-form tags. */
   tags?: string[];
+  /** Tenant the entry belongs to. Omitted → "default". Used by
+   *  multi-tenant deployments to scope what /api/catalog and the
+   *  list_services / get_service_health tools surface per session. */
+  tenant?: string;
 }
 
 export interface ServiceCatalog {
@@ -98,6 +102,7 @@ export function validateCatalog(input: unknown): ServiceCatalog {
     if (Array.isArray(e.tags)) {
       entry.tags = e.tags.filter((x): x is string => typeof x === "string");
     }
+    if (typeof e.tenant === "string") entry.tenant = e.tenant;
     out[name] = entry;
   }
   return { services: out };
@@ -106,14 +111,29 @@ export function validateCatalog(input: unknown): ServiceCatalog {
 /** Lookup wrapper used by the enricher / API handlers. */
 export class CatalogStore {
   constructor(private catalog: ServiceCatalog = EMPTY_CATALOG) {}
-  get(serviceName: string): ServiceCatalogEntry | undefined {
-    return this.catalog.services[serviceName];
+  /** Lookup. When `tenant` is set, returns undefined for entries
+   *  belonging to a different tenant — so a cross-tenant
+   *  enrichment never leaks owner / on-call / SLO bytes. Entries
+   *  without a tenant field are treated as `"default"`. */
+  get(serviceName: string, tenant?: string): ServiceCatalogEntry | undefined {
+    const e = this.catalog.services[serviceName];
+    if (!e) return undefined;
+    if (!tenant) return e;
+    const entryTenant = e.tenant || "default";
+    return entryTenant === tenant ? e : undefined;
   }
-  list(): Record<string, ServiceCatalogEntry> {
-    return this.catalog.services;
+  /** Snapshot. When `tenant` is set, filters down to entries in that
+   *  tenant; entries without a tenant field counted as `"default"`. */
+  list(tenant?: string): Record<string, ServiceCatalogEntry> {
+    if (!tenant) return this.catalog.services;
+    const out: Record<string, ServiceCatalogEntry> = {};
+    for (const [k, v] of Object.entries(this.catalog.services)) {
+      if ((v.tenant || "default") === tenant) out[k] = v;
+    }
+    return out;
   }
-  count(): number {
-    return Object.keys(this.catalog.services).length;
+  count(tenant?: string): number {
+    return Object.keys(this.list(tenant)).length;
   }
   replace(catalog: ServiceCatalog): void {
     this.catalog = catalog;

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -246,12 +246,15 @@ async function main() {
   // overload. We pass the value back unchanged when it doesn't parse,
   // and otherwise mutate the parsed JSON before re-stringifying into a
   // fresh wrapper that mirrors the handler's own shape.
-  function enrichToolServicesText<T extends { content: Array<{ text: string }> }>(result: T): T {
+  function enrichToolServicesText<T extends { content: Array<{ text: string }> }>(result: T, ctx: RequestContext): T {
     try {
       const parsed = JSON.parse(result.content[0]?.text ?? "{}");
       if (parsed && Array.isArray(parsed.services)) {
         for (const s of parsed.services) {
-          const entry = typeof s?.name === "string" ? catalog.get(s.name) : undefined;
+          // Scope enrichment to the caller's tenant so we don't
+          // leak owner / on-call / SLO bytes for other tenants'
+          // services that happen to share a name in the catalog.
+          const entry = typeof s?.name === "string" ? catalog.get(s.name, ctx.tenant) : undefined;
           if (entry) s.catalog = entry;
         }
       }
@@ -345,10 +348,10 @@ async function main() {
     }
   }
 
-  function enrichToolHealthText<T extends { content: Array<{ text: string }> }>(result: T, serviceName: string): T {
+  function enrichToolHealthText<T extends { content: Array<{ text: string }> }>(result: T, serviceName: string, ctx: RequestContext): T {
     try {
       const parsed = JSON.parse(result.content[0]?.text ?? "{}");
-      const entry = serviceName ? catalog.get(serviceName) : undefined;
+      const entry = serviceName ? catalog.get(serviceName, ctx.tenant) : undefined;
       if (entry && parsed && typeof parsed === "object") parsed.catalog = entry;
       const clone = { ...result, content: result.content.map((c, i) => i === 0 ? { ...c, text: JSON.stringify(parsed) } : c) };
       return clone as T;
@@ -399,7 +402,7 @@ async function main() {
     async (args) => {
       await enforceEntitledAccess(ctx, { tool: "list_services" });
       const result = await withToolMetrics("list_services", () => listServicesHandler(registry, args, ctx));
-      return enrichToolServicesText(result);
+      return enrichToolServicesText(result, ctx);
     }
   );
 
@@ -559,7 +562,7 @@ async function main() {
     async (args) => {
       await enforceEntitledAccess(ctx, { tool: "get_service_health", service: (args as any)?.service });
       const result = await withToolMetrics("get_service_health", () => getServiceHealthHandler(registry, args, ctx));
-      const enriched = enrichToolHealthText(result, String((args as any)?.service ?? ""));
+      const enriched = enrichToolHealthText(result, String((args as any)?.service ?? ""), ctx);
       return chargeTokenBudget(enriched, ctx, "get_service_health");
     }
   );
@@ -1596,14 +1599,20 @@ async function main() {
   }
 
   // List discovered services
-  app.get("/api/services", async (_req, res) => {
+  app.get("/api/services", async (req, res) => {
     try {
+      const sess = (req as AuthedRequest).session;
+      const callerTenant = sess?.tenant || "default";
       const result = await listServicesHandler(registry, {}, defaultContext());
       const parsed = parseToolResult(result) as { services?: Array<Record<string, unknown> & { name?: string }> };
-      // Enrich each entry with the catalog metadata (no-op when empty).
+      // Tenant-scope catalog enrichment so a viewer in tenant A
+      // doesn't accidentally see acme's owner/SLO metadata on a
+      // service that happens to share a name. Anonymous mode is
+      // session-less so callerTenant is "default" → matches
+      // entries with no tenant field too (pre-E7 behaviour).
       if (parsed?.services) {
         for (const s of parsed.services) {
-          const entry = typeof s.name === "string" ? catalog.get(s.name) : undefined;
+          const entry = typeof s.name === "string" ? catalog.get(s.name, callerTenant) : undefined;
           if (entry) s.catalog = entry;
         }
       }
@@ -1613,21 +1622,32 @@ async function main() {
 
   // Read-only view of the configured catalog. Gated by the same
   // "catalog:read" permission Phase E4 added to DEFAULT_POLICY.
-  app.get("/api/catalog", need("catalog", "read"), (_req, res) => {
+  app.get("/api/catalog", need("catalog", "read"), (req, res) => {
+    // Same scoping shape as /api/audit + /api/usage: non-admins see
+    // only their own tenant's catalog entries; admins see all by
+    // default and can ?tenant=X for an explicit drill-down.
+    const sess = (req as AuthedRequest).session;
+    const isAdmin = hasPermission(sess?.roles, "users", "delete");
+    const callerTenant = sess?.tenant || "default";
+    const requestedTenant = qstr(req.query.tenant);
+    const tenantFilter = isAdmin ? requestedTenant : callerTenant;
+    const services = catalog.list(tenantFilter || undefined);
     res.json({
-      services: catalog.list(),
-      count: catalog.count(),
+      services,
+      count: Object.keys(services).length,
       configured: !!process.env.OMCP_SERVICE_CATALOG_FILE,
+      scopedTo: tenantFilter || (isAdmin ? null : callerTenant),
     });
   });
 
   // Health endpoint for UI dashboard
   app.get("/api/health/:service", async (req, res) => {
     try {
+      const callerTenant = (req as AuthedRequest).session?.tenant || "default";
       const service = String(req.params.service);
       const result = await getServiceHealthHandler(registry, { service }, defaultContext());
       const parsed = parseToolResult(result) as Record<string, unknown>;
-      const entry = catalog.get(service);
+      const entry = catalog.get(service, callerTenant);
       if (entry && parsed && typeof parsed === "object") parsed.catalog = entry;
       res.json(parsed);
     } catch {
@@ -1636,8 +1656,9 @@ async function main() {
   });
 
   // Health for all services
-  app.get("/api/health", async (_req, res) => {
+  app.get("/api/health", async (req, res) => {
     try {
+      const callerTenant = (req as AuthedRequest).session?.tenant || "default";
       const servicesResult = await listServicesHandler(registry, {}, defaultContext());
       const parsed = parseToolResult(servicesResult) as { services?: Array<{ name: string }> };
       const services = parsed?.services || [];
@@ -1646,7 +1667,10 @@ async function main() {
         try {
           const result = await getServiceHealthHandler(registry, { service: svc.name }, defaultContext());
           const h = parseToolResult(result) as Record<string, unknown>;
-          const entry = catalog.get(svc.name);
+          // Same tenant scoping as /api/services to avoid the
+          // dashboard cross-tenant catalog leak the reviewer
+          // caught in slice 3.
+          const entry = catalog.get(svc.name, callerTenant);
           if (entry && h && typeof h === "object") h.catalog = entry;
           health[svc.name] = h;
         } catch { health[svc.name] = { error: "failed to fetch health" }; }


### PR DESCRIPTION
## Summary

Phase **E7 slice 3 of 5** — tenant-scopes the service catalog everywhere it surfaces.

### What changed
- **ServiceCatalogEntry.tenant?** optional field; pre-E7 entries default to \`"default"\`.
- **CatalogStore.get / list / count** take optional tenant arg; cross-tenant gets return \`undefined\`.
- **Tool enrichers** \`enrichToolServicesText\` / \`enrichToolHealthText\` scope catalog lookups by \`ctx.tenant\`.
- **REST endpoints** \`/api/catalog\` + \`/api/services\` + \`/api/health\` + \`/api/health/:service\` scope catalog enrichment by session tenant; \`/api/catalog\` adds \`scopedTo\` and admin \`?tenant=X\` drill-down.
- 1 new CatalogStore tenant-filter regression test.

### Reviewer pre-push
- ✅ Fixed: \`/api/health{,/:service}\` were unscoped — a dashboard viewer of tenant A would have seen catalog metadata from a same-named service in tenant B.
- 🟡 Deferred to slice 4/5: OpenAPI \`/api/catalog\` \`?tenant=\` query param + \`scopedTo\` field documentation (lands with the UI work).

### Remaining E7
- Slice 4: UI tenant switcher + scoped views
- Slice 5: docs + demo + migration test

## Test plan
- [ ] CI green: new catalog tenant test + existing suite unaffected
- [ ] No new dependencies, no release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)