### PR TITLE
feat(tenancy): docs/tenancy.md + OpenAPI scopedTo + 7 migration tests — Phase E7 slice 5/5 (FINAL)

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -26,6 +26,7 @@ the README quickstart promises.
 | **Web UI SSO via OIDC** | `OMCP_AUTH=oidc` + `OMCP_OIDC_*` | anonymous | [auth-oidc.md](auth-oidc.md) |
 | **Role-based permissions** on the management API | (built-in `viewer` / `operator` / `admin`; role assigned via the user file's `roles` field) | only meaningful in basic mode | this doc, "Roles & permissions" |
 | **Policy engine** for RBAC decisions | `OMCP_RBAC_POLICY_FILE` (YAML) or `OMCP_OPA_URL` (OPA HTTP) | built-in | [policy-engines.md](policy-engines.md) |
+| **Multi-tenancy** (per-identity scope across audit / quotas / catalog) | `OMCP_KEY_TENANTS` + `OMCP_OIDC_TENANT_CLAIM` + user-file `tenant` field | single-tenant (`default`) | [tenancy.md](tenancy.md) |
 | **Audit log** of mutating `/api/*` requests | `OMCP_MGMT_AUDIT_FILE` | in-memory ring (500 entries) | this doc, "Audit log" |
 
 Two adjacent controls fall under the same umbrella:

--- a/docs/auth-basic.md
+++ b/docs/auth-basic.md
@@ -144,3 +144,5 @@ The session cookie (`omcp_session`) is:
   reverse-proxy setup, and the investigation playbook.
 - [auth-oidc.md](auth-oidc.md) — the third auth mode, for teams that
   already run an IdP (Keycloak, Authentik, Auth0, Azure AD, ...).
+- [tenancy.md](tenancy.md) — the `tenant` field on user entries
+  drives multi-tenant scoping of audit, quotas, and the catalog.

--- a/docs/auth-oidc.md
+++ b/docs/auth-oidc.md
@@ -234,3 +234,5 @@ issue: ensure the OMCP redirect URI and the UI URL share an origin
 - [auth-basic.md](auth-basic.md) — local-users-file alternative.
 - [auth-and-tls.md](auth-and-tls.md) — TLS termination + the `/mcp`
   bearer-token gate.
+- [tenancy.md](tenancy.md) — multi-tenant deployments (`OMCP_OIDC_TENANT_CLAIM`
+  is the OIDC-side wiring).

--- a/docs/tenancy.md
+++ b/docs/tenancy.md
@@ -1,0 +1,185 @@
+# Multi-tenancy
+
+Single-tenant by default — every existing OMCP deployment continues to
+work without setting any `OMCP_*TENANT*` env vars. Anonymous principals,
+local users without a `tenant` field, OIDC sessions without
+`OMCP_OIDC_TENANT_CLAIM`, and MCP credentials without
+`OMCP_KEY_TENANTS` all land in the universal `default` tenant. That's
+the pre-E7 world.
+
+Once an operator opts in via any of those knobs, OMCP becomes
+multi-tenant: per-identity rate-limiter buckets, token-budget buckets,
+audit entries, and catalog enrichments all scope by tenant. Cross-
+tenant data is invisible to non-admins through both the `/api/*`
+surface and the MCP tool layer.
+
+## How identities resolve to a tenant
+
+| Identity path | Tenant comes from | Default when unset |
+|---|---|---|
+| Anonymous | n/a | `default` |
+| Basic-mode local user | `tenant` field on the user file entry | `default` |
+| OIDC session | `OMCP_OIDC_TENANT_CLAIM` dotted-path claim | `default` |
+| MCP bearer credential | `OMCP_KEY_TENANTS="name=tenant;..."` env | `default` |
+
+The tenant identifier is normalised to `[A-Za-z0-9][A-Za-z0-9._-]{0,63}` —
+strictly lowercased, trimmed, traversal-safe. Invalid claims silently
+fall back to `default` (the audit chain still records the actual
+identity, but the tenant is sanitised). The regex is a strict superset
+of RFC 1123 k8s namespace identifiers — any valid k8s namespace passes.
+
+## Per-identity storage
+
+Both per-identity surfaces use a composite `<tenant> <principalId>`
+key internally:
+
+- **Rate limiter** (`OMCP_TOOL_RATE_PER_MIN`): two credentials named
+  `agent` in tenants `acme` and `bigco` get independent per-minute
+  buckets.
+- **Token budget** (`OMCP_TOOL_DAILY_TOKENS`): same.
+
+The surface field stays unchanged: `/api/usage` continues to return
+`actor: "agent"` (split out from the composite) plus a new
+`tenant: "acme"` column. Existing tooling reading `actor`/`count`/
+`limit`/`windowMs`/`tokens` is unaffected.
+
+## Audit chain
+
+Every recorded entry carries a `tenant` field. Pre-E7 entries default
+to `"default"` when filtered. `/api/audit?tenant=acme` filters; non-
+admins (without `users:delete`) are silently scoped to their own
+tenant — they cannot read another tenant's audit history.
+
+## Service catalog
+
+`ServiceCatalogEntry.tenant` is optional. When set, the entry is only
+surfaced to callers in that tenant — through `/api/catalog`,
+`/api/services`, `/api/health{,/:service}`, and the `list_services` /
+`get_service_health` MCP tool enrichers. Pre-E7 catalog files without
+a `tenant` field on entries continue to enrich `default`-tenant
+callers (i.e., pre-E7 deployments).
+
+```yaml
+# config/catalog.yaml — multi-tenant example
+services:
+  acme-payments:
+    owner: team-payments
+    tier: tier-1
+    onCall: https://acme.pagerduty/team-payments
+    tenant: acme
+  bigco-payments:
+    owner: bigco-platform
+    tier: tier-2
+    tenant: bigco
+  shared-cdn:
+    owner: infra
+    # no tenant → default → visible to anonymous / single-tenant callers
+```
+
+## Cross-tenant API model
+
+| Endpoint | Non-admin behaviour | Admin (`users:delete`) behaviour |
+|---|---|---|
+| `/api/audit` | scoped to own tenant | all tenants by default; `?tenant=X` to drill down |
+| `/api/usage` | scoped to own tenant | all tenants by default; `?tenant=X` to drill down |
+| `/api/catalog` | scoped to own tenant | all tenants by default; `?tenant=X` to drill down |
+| `/api/services` | catalog enrichment scoped to own tenant | (same — admins don't get a special tool here yet) |
+| `/api/health{,/:service}` | catalog enrichment scoped to own tenant | (same) |
+
+All four endpoints return a `scopedTo` field — `null` for an admin
+viewing all tenants, the tenant string otherwise. The UI uses this
+to render a "scope: acme" / "scope: all tenants" hint above the
+relevant data block.
+
+## UI surface
+
+- **User badge** (top-right) gains a tag chip when the user's tenant
+  is non-default. Tooltip combines IdP issuer (OIDC) + tenant.
+- **\<body data-tenant=…>** attribute is set on every identity sync
+  so per-tenant CSS theming (brand colour bar, banner) drops in
+  without per-tenant builds.
+- **Dashboard usage strip** gains a "scope: …" hint and a Tenant
+  column when an admin views all tenants unscoped.
+
+## Migration from single-tenant
+
+No migration is required. The smallest opt-in is one user gaining a
+`tenant` field:
+
+```diff
+ // OMCP_USERS_FILE
+ {
+   "users": [
+-    { "username": "alice", "name": "Alice", "passwordHash": "..." }
++    { "username": "alice", "name": "Alice", "tenant": "acme", "passwordHash": "..." }
+   ]
+ }
+```
+
+Alice's session now writes audit entries tagged `tenant: acme`. Other
+users without the field stay in `default`. Pre-E7 audit entries
+continue to surface under `?tenant=default`. No data migration step,
+no schema change, no replay.
+
+## OIDC integration
+
+```yaml
+env:
+  OMCP_OIDC_TENANT_CLAIM: "app.tenant_id"   # dotted path; default ""
+```
+
+When the claim is absent / empty / non-string in a given session, the
+session lands in `default` (least-privilege fallback). Array-valued
+claims take the first string entry — multi-tenant per-session
+identities aren't supported; an operator wanting per-call switching
+should mint distinct tokens.
+
+## MCP credentials
+
+```yaml
+env:
+  OMCP_API_KEYS: "agent:tok_acme,agent:tok_bigco"
+  OMCP_KEY_TENANTS: "agent-acme=acme;agent-bigco=bigco"
+  # Note: the credential NAME has to be unique per tenant for the
+  # tracker buckets to map cleanly. Use distinct names.
+```
+
+Unlisted keys default to `default`. The same OMCP server can serve
+multiple tenants over the same `/mcp` endpoint as long as each
+credential has a unique name.
+
+## What's not (yet) tenant-scoped
+
+- **Connector configurations** (`config/sources.yaml`) are still
+  process-global. A Prometheus instance configured at boot is
+  reachable by every tenant. Per-tenant connector pools are a
+  follow-up — track via the [tenancy roadmap].
+- **Helm chart** doesn't yet split deployments per tenant. The
+  documented model is "one Helm release per tenant" if you need full
+  network-level isolation; in-process multi-tenancy is for the
+  policy / audit / quota / catalog surfaces.
+- **OPA policy package** runs process-wide. The current query
+  input shape is `{ roles, resource, action }` — tenant is NOT
+  passed in. Per-tenant authorisation rules need either a custom
+  package per tenant (one OPA instance per tenant) or an upcoming
+  slice that extends the OPA input shape. Track the gap in the
+  tenancy roadmap before authoring tenant-conditional Rego.
+- **Per-process self-metrics** (`/metrics`) are not labelled by
+  tenant. Anyone scraping the Prometheus endpoint sees aggregate
+  counts across every tenant. Operators that need per-tenant
+  Prometheus dashboards should currently run one OMCP per tenant
+  and let upstream Prometheus do the labelling.
+- **MCP credential bucket-key uniqueness** — the rate-limiter and
+  token-budget tracker key on `<tenant> <credential-name>`. Two
+  credentials sharing a name across tenants get isolated buckets,
+  but operators are still advised to use distinct names per tenant
+  for log clarity (see the MCP credentials section above).
+
+## See also
+
+- [access-control.md](access-control.md) — RBAC + audit + redaction
+  + quotas; the layers tenant-scoping plugs into.
+- [auth-oidc.md](auth-oidc.md) — OIDC session bootstrap, claim
+  mapping, the `OMCP_OIDC_TENANT_CLAIM` env var.
+- [auth-basic.md](auth-basic.md) — local-user file, the `tenant`
+  field on user entries.

--- a/mcp-server/src/openapi.ts
+++ b/mcp-server/src/openapi.ts
@@ -528,6 +528,9 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
         get: {
           tags: ["catalog"],
           summary: "Loaded service catalog (owner / tier / on-call / SLO).",
+          parameters: [
+            { name: "tenant", in: "query", schema: { type: "string" }, description: "Tenant scope. Non-admins silently scoped to their own; admins can pick any (omit → all)." },
+          ],
           responses: {
             "200": {
               description: "Catalog map keyed by service name.",
@@ -539,6 +542,7 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
                       services: { type: "object", additionalProperties: true },
                       count: { type: "integer" },
                       configured: { type: "boolean", description: "true when OMCP_SERVICE_CATALOG_FILE is set." },
+                      scopedTo: { type: ["string", "null"], description: "Tenant name this view is scoped to; null = all tenants (admin)." },
                     },
                   },
                 },

--- a/mcp-server/src/tenancy/migration.test.ts
+++ b/mcp-server/src/tenancy/migration.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Migration regression suite — pre-E7 single-tenant deployments must
+ * continue to work without any config change. These tests pin the
+ * "everything defaults to `default`" contract by simulating the
+ * exact data shapes a pre-E7 server / file / token would carry.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { defaultContext, principalContext } from "../context.js";
+import { issueSession, verifySession } from "../auth/session.js";
+import { loadCredentials } from "../auth/credentials.js";
+import { CatalogStore } from "../catalog/loader.js";
+import { AuditLog } from "../audit/log.js";
+import { DEFAULT_TENANT } from "./context.js";
+
+const SECRET = "x".repeat(32);
+
+test("migration — anonymous context lands in DEFAULT_TENANT", () => {
+  const ctx = defaultContext();
+  assert.equal(ctx.tenant, DEFAULT_TENANT);
+});
+
+test("migration — principalContext without tenant opt → DEFAULT_TENANT", () => {
+  const ctx = principalContext("agent", ["prom-prod"]);
+  assert.equal(ctx.tenant, DEFAULT_TENANT);
+});
+
+test("migration — pre-E7 session cookie (no tenant field) verifies + reads back fine", () => {
+  // Session minted as it would have been pre-E7: no tenant.
+  const { cookie } = issueSession({ sub: "alice", name: "Alice", roles: ["operator"] }, { secret: SECRET });
+  const verified = verifySession(cookie, { secret: SECRET });
+  assert.ok(verified, "verifySession should accept a pre-E7 cookie");
+  assert.equal(verified.tenant, undefined, "tenant stays undefined; consumers default to 'default'");
+});
+
+test("migration — pre-E7 OMCP_API_KEYS (no OMCP_KEY_TENANTS) leaves credentials in DEFAULT_TENANT", () => {
+  const creds = loadCredentials({ OMCP_API_KEYS: "agent:tok_abc,ci:tok_def" });
+  assert.equal(creds.length, 2);
+  for (const c of creds) {
+    assert.equal(c.tenant, undefined, "no env → no tenant assignment → consumers default to 'default'");
+  }
+});
+
+test("migration — pre-E7 catalog (entries without tenant field) still enriches DEFAULT_TENANT callers", () => {
+  const store = new CatalogStore({
+    services: {
+      "payments": { owner: "team-payments" }, // pre-E7 shape
+      "shipping": { owner: "team-shipping" },
+    },
+  });
+  // A pre-E7 caller (no session, ctx.tenant = "default") sees both
+  // entries through the tenant-aware get().
+  assert.equal(store.get("payments", DEFAULT_TENANT)?.owner, "team-payments");
+  assert.equal(store.get("shipping", DEFAULT_TENANT)?.owner, "team-shipping");
+  // Same caller via the unfiltered get path also sees them (admins).
+  assert.equal(store.get("payments")?.owner, "team-payments");
+});
+
+test("migration — pre-E7 audit entries (no tenant field) surface under ?tenant=default", async () => {
+  const log = new AuditLog();
+  // Pre-E7 record: no tenant.
+  await log.record({ actor: { sub: "alice" }, resource: "sources", action: "write", method: "POST", path: "/api/sources", status: 200 });
+  const entries = log.list({ tenant: "default" });
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].actor.sub, "alice");
+});
+
+test("migration — opt-in is per-entry: an admin defining `tenant: acme` doesn't break the rest", () => {
+  const store = new CatalogStore({
+    services: {
+      "acme-app": { owner: "acme-team", tenant: "acme" },        // opted in
+      "shared-cdn": { owner: "infra" },                            // pre-E7 shape
+    },
+  });
+  // The acme-tenant caller sees only their entry.
+  assert.equal(store.count("acme"), 1);
+  assert.equal(store.get("shared-cdn", "acme"), undefined);
+  // The default-tenant caller (anonymous / single-tenant) sees only
+  // the pre-E7 entry — the acme entry is correctly hidden.
+  assert.equal(store.count("default"), 1);
+  assert.equal(store.get("acme-app", "default"), undefined);
+  assert.equal(store.get("shared-cdn", "default")?.owner, "infra");
+});


### PR DESCRIPTION
## Summary

**Phase E7 slice 5/5 — FINAL.** Closes Phase E7 (Multi-Tenancy).

### What ships
- **\`docs/tenancy.md\`** (~170 lines) — operator runbook covering identity → tenant resolution, per-identity storage, audit/catalog scoping, cross-tenant API model, UI surface, migration, OIDC + MCP credential wiring, and the honest "what's not yet scoped" gap list (connectors, Helm, OPA input shape, self-metrics).
- **OpenAPI** \`/api/catalog\` spec gains \`?tenant=\` query param + \`scopedTo\` response field.
- **7 migration tests** in \`src/tenancy/migration.test.ts\` pinning pre-E7 behaviour: anonymous, principalContext, pre-E7 session cookie, OMCP_API_KEYS without tenants, pre-E7 catalog entries, pre-E7 audit entries, per-entry opt-in isolation.
- **Cross-links** from \`access-control.md\`, \`auth-oidc.md\`, \`auth-basic.md\`.

### Reviewer pre-push
- ✅ Fixed: 2 doc inaccuracies (OPA input shape didn't actually carry tenant; self-metrics gap was missing from the not-scoped list).

### Phase E7 status after merge
**Complete.** 5 PRs (#301, #302, #303, #304, this):
1. TenantContext core + 4-path identity resolution
2. Tracker (rate limiter + token budget) + audit storage keyed by tenant
3. Catalog tenant scoping across /api/catalog + /api/services + /api/health{,/:service} + tool enrichers
4. UI tenant chip + dashboard scope hint + per-row tenant column
5. Docs + OpenAPI polish + migration tests

Next per the plan: **E9 (Full SBOM / Cosign / SLSA L3)**.

## Test plan
- [ ] CI green: 7 new migration tests + existing suite unaffected
- [ ] No new dependencies, no release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)