### PR TITLE
feat(ci): cosign keyless sign + Syft CycloneDX/SPDX SBOM attestations — Phase E9 slice 1

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -159,6 +159,13 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # Keyless cosign sign + SBOM attach: id-token allows OIDC
+      # exchange with sigstore's Fulcio for a short-lived signing
+      # cert. Cosign OCI attestations push to the same registry
+      # repo as the image (covered by packages: write above) — no
+      # separate `attestations: write` needed (that's for GitHub's
+      # native attest-* action family, which we don't use here).
+      id-token: write
     steps:
       - name: Lowercase image name
         id: image
@@ -201,5 +208,61 @@ jobs:
             $(printf '${{ env.REGISTRY }}/${{ steps.image.outputs.lower }}@sha256:%s ' *)
 
       - name: Inspect image
+        id: inspect
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ steps.image.outputs.lower }}:${{ steps.meta.outputs.version }}
+          DIGEST="$(docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ steps.image.outputs.lower }}:${{ steps.meta.outputs.version }} --format '{{.Manifest.Digest}}')"
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      # ---- Phase E9: keyless cosign signing ----
+      # Sigstore OIDC + Fulcio: no key management. The signature is
+      # pushed to the OCI registry alongside the manifest digest;
+      # `cosign verify` (with the workflow identity + Fulcio root)
+      # is enough for downstream operators to confirm provenance.
+      - name: Install cosign
+        # Pin hash + label corrected by reviewer: this SHA is the
+        # sigstore/cosign-installer v3.9.2 release. We let the
+        # action's default cosign version (currently v2.5.3) ride
+        # rather than pinning a downgrade — keyless behaviour is
+        # default since cosign 2.x, no operator-visible change.
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+      - name: Sign the image (keyless)
+        run: |
+          cosign sign --yes \
+            "${{ env.REGISTRY }}/${{ steps.image.outputs.lower }}@${{ steps.inspect.outputs.digest }}"
+
+      # ---- Phase E9: Syft SBOM (CycloneDX + SPDX) + cosign attach ----
+      # The buildx-side SBOM is OCI-attached; this extra Syft pass
+      # produces standalone CycloneDX-JSON + SPDX-JSON files the
+      # release uploads (and cosign attests against the image
+      # digest with type=cyclonedx) so an air-gapped operator can
+      # download + verify the SBOM without pulling the image.
+      - name: Install Syft
+        # Pin label corrected by reviewer: this SHA is the
+        # anchore/sbom-action v0.20.4 release.
+        uses: anchore/sbom-action/download-syft@7b36ad622f042cab6f59a75c2ac24ccb256e9b45 # v0.20.4
+      - name: Generate SBOMs (Syft)
+        # Note: Syft handed a manifest-list digest defaults to the
+        # host runner's platform (linux/amd64 on GitHub-hosted
+        # runners). The arm64 variant of the image is covered by
+        # the buildx-embedded SBOM only; doing a second per-platform
+        # Syft pass is tracked as an E9 follow-up.
+        run: |
+          syft "${{ env.REGISTRY }}/${{ steps.image.outputs.lower }}@${{ steps.inspect.outputs.digest }}" \
+            -o cyclonedx-json=image-sbom.cdx.json \
+            -o spdx-json=image-sbom.spdx.json
+      - name: Attest SBOM to the image (cosign attestation)
+        run: |
+          cosign attest --yes --predicate image-sbom.cdx.json --type cyclonedx \
+            "${{ env.REGISTRY }}/${{ steps.image.outputs.lower }}@${{ steps.inspect.outputs.digest }}"
+          cosign attest --yes --predicate image-sbom.spdx.json --type spdxjson \
+            "${{ env.REGISTRY }}/${{ steps.image.outputs.lower }}@${{ steps.inspect.outputs.digest }}"
+      - name: Upload SBOM as workflow artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
+        with:
+          name: image-sbom-${{ steps.meta.outputs.version }}
+          path: |
+            image-sbom.cdx.json
+            image-sbom.spdx.json
+          if-no-files-found: error
+          retention-days: 90

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -84,7 +84,7 @@ Provenance is also visible on the
 [npm package page](https://www.npmjs.com/package/@thotischner/observability-mcp)
 under the "Provenance" tab.
 
-### Container image — GHCR + scanned
+### Container image — GHCR + scanned + cosign-signed + Syft SBOM
 
 ```bash
 # Pull and inspect the source-commit label
@@ -95,6 +95,60 @@ docker image inspect ghcr.io/thotischner/observability-mcp:latest \
 
 CI scans every image with Trivy before publishing; high-severity CVEs block
 the release.
+
+**Keyless cosign signing.** Every image is signed via Sigstore keyless OIDC
+(no operator-managed key material). Verify against the GitHub Actions
+workflow identity:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp "^https://github\.com/ThoTischner/observability-mcp/\.github/workflows/docker-publish\.yml@refs/" \
+  --certificate-oidc-issuer    "https://token.actions.githubusercontent.com" \
+  ghcr.io/thotischner/observability-mcp:latest
+```
+
+**SBOM attestations.** CycloneDX-JSON + SPDX-JSON SBOMs (Syft-generated, in
+addition to the buildx-embedded SBOM) are attached as cosign attestations.
+Fetch + verify either format:
+
+```bash
+# CycloneDX
+cosign verify-attestation \
+  --type cyclonedx \
+  --certificate-identity-regexp "^https://github\.com/ThoTischner/observability-mcp/\.github/workflows/docker-publish\.yml@refs/" \
+  --certificate-oidc-issuer    "https://token.actions.githubusercontent.com" \
+  ghcr.io/thotischner/observability-mcp:latest \
+  | jq -r '.payload | @base64d | fromjson | .predicate' > image-sbom.cdx.json
+
+# SPDX
+cosign verify-attestation \
+  --type spdxjson \
+  --certificate-identity-regexp "^https://github\.com/ThoTischner/observability-mcp/\.github/workflows/docker-publish\.yml@refs/" \
+  --certificate-oidc-issuer    "https://token.actions.githubusercontent.com" \
+  ghcr.io/thotischner/observability-mcp:latest \
+  | jq -r '.payload | @base64d | fromjson | .predicate' > image-sbom.spdx.json
+```
+
+> The Syft SBOMs cover the `linux/amd64` variant (GitHub-runner host
+> platform). The `linux/arm64` variant is covered by buildx's
+> embedded SBOM only; a second per-platform Syft attestation is a
+> tracked E9 follow-up.
+
+The raw SBOM files are also uploaded as workflow artifacts on each release
+(90-day retention), so an air-gapped operator can pull them from the
+[GitHub Actions run](https://github.com/ThoTischner/observability-mcp/actions)
+page without round-tripping cosign.
+
+**SLSA provenance attestation.** buildx attaches SLSA-level provenance
+(`mode=max`) to the OCI image; cosign also verifies that:
+
+```bash
+cosign verify-attestation \
+  --type slsaprovenance \
+  --certificate-identity-regexp "^https://github\.com/ThoTischner/observability-mcp/\.github/workflows/docker-publish\.yml@refs/" \
+  --certificate-oidc-issuer    "https://token.actions.githubusercontent.com" \
+  ghcr.io/thotischner/observability-mcp:latest
+```
 
 ### Helm chart — GPG-signed
 


### PR DESCRIPTION
## Summary

Phase **E9 slice 1** — keyless cosign signing + Syft-generated SBOMs as cosign attestations + workflow artifacts.

### What changed
- **\`.github/workflows/docker-publish.yml\`** merge job adds:
  - keyless cosign sign of the multi-arch manifest list
  - Syft → CycloneDX-JSON + SPDX-JSON SBOMs
  - cosign attest (type=cyclonedx, type=spdxjson) attached to the image digest
  - SBOMs uploaded as workflow artifacts (90-day retention)
- **\`SECURITY.md\`** gains cosign verify commands for image signature, SBOMs (both types), and SLSA provenance, with a tightened cert-identity regex anchored at the exact workflow path.

### Reviewer pre-push (4 real defects fixed)
- ✅ Dropped \`attestations: write\` (unused — cosign uses \`packages: write\`)
- ✅ Two pin labels corrected (cosign-installer v3.9.0→v3.9.2; sbom-action v0.20.0→v0.20.4) — SHAs were right, labels wrong
- ✅ Dropped \`COSIGN_EXPERIMENTAL=1\` (deprecated since cosign 2.0)
- ✅ Tightened \`--certificate-identity-regexp\` to the exact workflow path with proper dot-escaping
- 🟡 Deferred: per-platform Syft pass for arm64 (currently amd64-only; documented in SECURITY.md)

### Remaining E9 (likely slice 2)
- SLSA L3 generator workflow (`slsa-framework/slsa-github-generator`)
- Helm chart cosign signing alongside the existing GPG
- README badges (signed + SBOM)

## Test plan
- [ ] CI green: docker-publish doesn't run on PRs by default (only push to main + workflow_dispatch), so the cosign/Syft path won't exercise here. Manual smoke after merge: trigger docker-publish via workflow_dispatch on a non-prod tag and verify `cosign verify` against the published digest.
- [ ] No new dependencies in the application; CI tooling only

🤖 Generated with [Claude Code](https://claude.com/claude-code)