### PR TITLE
feat(docs+badges): cosign + SBOM + SLSA README badges + Helm cosign roadmap — Phase E9 slice 2/2 (FINAL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ question instead of juggling N vendor servers and their query languages.*
 [![Helm chart](https://img.shields.io/badge/helm-observability--mcp-0F1689?logo=helm&logoColor=white)](./helm/observability-mcp)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/observability-mcp)](https://artifacthub.io/packages/search?repo=observability-mcp)
 [![Provenance](https://img.shields.io/badge/npm-provenance-success?logo=npm)](https://docs.npmjs.com/generating-provenance-statements)
+[![Cosign signed](https://img.shields.io/badge/image-cosign_signed-2E7D32?logo=sigstore&logoColor=white)](SECURITY.md#container-image--ghcr--scanned--cosign-signed--syft-sbom)
+[![SBOM CycloneDX](https://img.shields.io/badge/SBOM-CycloneDX-AB47BC?logo=cyclonedx&logoColor=white)](SECURITY.md#container-image--ghcr--scanned--cosign-signed--syft-sbom)
+[![SBOM SPDX](https://img.shields.io/badge/SBOM-SPDX-1976D2?logo=spdx&logoColor=white)](SECURITY.md#container-image--ghcr--scanned--cosign-signed--syft-sbom)
+[![SLSA provenance](https://img.shields.io/badge/SLSA-build_provenance-455A64?logo=slsa&logoColor=white)](SECURITY.md#container-image--ghcr--scanned--cosign-signed--syft-sbom)
 [![Connector Hub](https://img.shields.io/badge/connector-hub-38bdf8?logo=googlechrome&logoColor=white)](https://thotischner.github.io/observability-mcp/hub/)
 
 ![observability-mcp — guided tour of the web UI](docs/demo.gif)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -165,6 +165,12 @@ curl -sS https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/do
 helm verify ./observability-mcp-<version>.tgz
 ```
 
+> **Roadmap.** A cosign-signed OCI chart variant is on the deferred
+> list — once the chart is also pushed as an OCI artifact to GHCR
+> via `helm push`, the same `cosign verify --certificate-identity-…`
+> pattern that covers the image will apply to the chart. Until then,
+> the GPG signature above is the authoritative verification path.
+
 ### MCP tool surface — `tools/list` is the contract
 
 The server only advertises tools it actually implements. The integration


### PR DESCRIPTION
## Summary

**Phase E9 slice 2/2 — FINAL.** Closes Phase E9 (Full SBOM/Cosign/SLSA).

### What ships
- **README.md** — four new header badges (Cosign signed · SBOM CycloneDX · SBOM SPDX · SLSA build provenance), each linking to the SECURITY.md section with the cosign verify command.
- **SECURITY.md** — roadmap note on the Helm section noting that cosign-signed OCI chart variant is deferred; GPG + \`helm verify\` is the authoritative path today.

### Deferred (documented as roadmap items, not silent gaps)
- Per-platform Syft SBOM (arm64 covered by buildx embedded only)
- Helm chart cosign signing of an OCI variant (needs \`helm push\` to GHCR first)
- SLSA L3 generator workflow (the buildx mode=max provenance already gives SLSA-level attestation — the dedicated L3 generator workflow is a separate hardening pass via the trusted-builder reusable workflow)

### Phase E9 status after merge
**Complete.** 2 PRs (#306 + this):
1. Cosign keyless sign + Syft SBOM attestations + SECURITY.md verify commands
2. README badges + Helm cosign roadmap note

Next per the plan: **MCP Products + RBAC** (the final phase).

## Test plan
- [ ] CI green (docs-only)
- [ ] No new dependencies, no release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)