### PR TITLE
feat(products+rbac): Product model + GET /api/products{,/:id} + RBAC — MCP Products slice 1/4

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,7 +52,7 @@ jobs:
         run: npm ci
       - name: Run tests
         working-directory: ./mcp-server
-        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/auth/oidc/*.test.ts src/auth/policy/*.test.ts src/tenancy/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/quota/*.test.ts src/connectors/verify.test.ts src/connectors/hub.test.ts src/connectors/install.test.ts src/cli/*.test.ts src/tools/*.test.ts src/net/*.test.ts src/openapi.test.ts src/enterprise-gate.test.ts
+        run: npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/auth/oidc/*.test.ts src/auth/policy/*.test.ts src/tenancy/*.test.ts src/products/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/quota/*.test.ts src/connectors/verify.test.ts src/connectors/hub.test.ts src/connectors/install.test.ts src/cli/*.test.ts src/tools/*.test.ts src/net/*.test.ts src/openapi.test.ts src/enterprise-gate.test.ts
       - name: Connector hub catalog (validate + in-sync)
         run: |
           node hub/build-catalog.mjs --check

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ doctor: ## Quick health check — is the mcp-server reachable on $$OMCP_HOST:$$O
 test: ## Run mcp-server unit tests in Docker
 	docker run --rm -w /app -v "$(PWD)/mcp-server:/app" node:20-alpine \
 	  sh -c "npm install --silent --no-audit --no-fund && \
-	         npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/auth/oidc/*.test.ts src/auth/policy/*.test.ts src/tenancy/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/quota/*.test.ts src/tools/*.test.ts src/net/*.test.ts src/openapi.test.ts src/enterprise-gate.test.ts"
+	         npx tsx --test src/analysis/*.test.ts src/config/*.test.ts src/sdk/*.test.ts src/auth/*.test.ts src/auth/oidc/*.test.ts src/auth/policy/*.test.ts src/tenancy/*.test.ts src/products/*.test.ts src/audit/*.test.ts src/catalog/*.test.ts src/policy/*.test.ts src/quota/*.test.ts src/tools/*.test.ts src/net/*.test.ts src/openapi.test.ts src/enterprise-gate.test.ts"
 
 lint: ## helm lint + tsc --noEmit
 	docker run --rm -v "$(PWD)/helm:/apps" alpine/helm:3.16.2 lint /apps/observability-mcp

--- a/mcp-server/src/auth/rbac.test.ts
+++ b/mcp-server/src/auth/rbac.test.ts
@@ -41,7 +41,7 @@ test("DEFAULT_POLICY — operator writes sources + settings but never deletes", 
 });
 
 test("DEFAULT_POLICY — admin can do everything across every resource", () => {
-  for (const resource of ["sources", "services", "health", "topology", "settings", "connectors", "audit", "catalog", "users"] as const) {
+  for (const resource of ["sources", "services", "health", "topology", "settings", "connectors", "audit", "catalog", "users", "products"] as const) {
     for (const action of ["read", "write", "delete"] as const) {
       assert.equal(hasPermission(["admin"], resource, action), true, `admin should ${action} ${resource}`);
     }
@@ -130,9 +130,11 @@ test("listGrantedPermissions — deduplicates across overlapping roles", () => {
 
 test("listGrantedPermissions — admin lists every (resource, action) once", () => {
   const p = listGrantedPermissions(["admin"]);
-  // 9 resources * 3 actions = 27, plus the special redaction:bypass entry = 28.
-  assert.equal(p.length, 28);
+  // 10 resources (added 'products' in the products-RBAC phase) * 3 actions
+  // = 30, plus the special redaction:bypass entry = 31.
+  assert.equal(p.length, 31);
   assert.ok(p.some((g) => g.resource === "redaction" && g.action === "bypass"));
+  assert.ok(p.some((g) => g.resource === "products" && g.action === "delete"));
 });
 
 test("DEFAULT_POLICY shape — has the three built-in roles", () => {

--- a/mcp-server/src/auth/rbac.ts
+++ b/mcp-server/src/auth/rbac.ts
@@ -30,7 +30,8 @@ export type Resource =
   | "audit"
   | "catalog"
   | "users"
-  | "redaction";
+  | "redaction"
+  | "products";
 
 export interface Permission {
   resource: Resource;
@@ -48,6 +49,7 @@ export const DEFAULT_POLICY: Record<string, Permission[]> = {
     { resource: "connectors", action: "read" },
     { resource: "audit", action: "read" },
     { resource: "catalog", action: "read" },
+    { resource: "products", action: "read" },
   ],
   operator: [
     // Inherits viewer's read set + write on operational resources.
@@ -62,10 +64,12 @@ export const DEFAULT_POLICY: Record<string, Permission[]> = {
     { resource: "connectors", action: "read" },
     { resource: "audit", action: "read" },
     { resource: "catalog", action: "read" },
+    { resource: "products", action: "read" },
+    { resource: "products", action: "write" },
   ],
   admin: [
     // Full surface — readable + writable + deletable.
-    ...(["sources", "services", "health", "topology", "settings", "connectors", "audit", "catalog", "users"] as Resource[])
+    ...(["sources", "services", "health", "topology", "settings", "connectors", "audit", "catalog", "users", "products"] as Resource[])
       .flatMap((r) =>
         (["read", "write", "delete"] as Action[]).map<Permission>((a) => ({ resource: r, action: a })),
       ),

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -63,6 +63,7 @@ import { OpaPolicyEngine } from "./auth/policy/opa.js";
 import { AuditLog } from "./audit/log.js";
 import { buildAuditMiddleware } from "./audit/middleware.js";
 import { readCatalogFile, CatalogStore } from "./catalog/loader.js";
+import { readProductsFile, ProductsStore } from "./products/loader.js";
 import { redactValue } from "./policy/redact.js";
 import { IdentityRateLimiter, resolveToolRatePerMin } from "./quota/limiter.js";
 import { TokenBudget, estimateTokensFor, resolveDailyTokenLimit } from "./quota/token-budget.js";
@@ -915,6 +916,7 @@ async function main() {
   // No file ⇒ empty catalog, enrichment is a no-op (anonymous demos
   // see no behaviour change).
   const catalog = new CatalogStore(await readCatalogFile(process.env.OMCP_SERVICE_CATALOG_FILE));
+  const products = new ProductsStore(await readProductsFile(process.env.OMCP_PRODUCTS_FILE));
   // Protected route prefixes. /api/me, /api/auth/*, /api/info,
   // /api/openapi.json deliberately don't appear here — they stay public.
   for (const prefix of [
@@ -1639,6 +1641,41 @@ async function main() {
       configured: !!process.env.OMCP_SERVICE_CATALOG_FILE,
       scopedTo: tenantFilter || (isAdmin ? null : callerTenant),
     });
+  });
+
+  // --- /api/products — MCP Products catalogue ---------------------------
+  // Same scoping / staging-visibility pattern as /api/catalog. Non-admins
+  // see only their own tenant's PUBLISHED products; admins see all
+  // tenants by default + staging.
+  app.get("/api/products", need("products", "read"), (req, res) => {
+    const sess = (req as AuthedRequest).session;
+    const isAdmin = hasPermission(sess?.roles, "users", "delete");
+    const callerTenant = sess?.tenant || "default";
+    const requestedTenant = qstr(req.query.tenant);
+    const tenantFilter = isAdmin ? requestedTenant : callerTenant;
+    const includeStaging = isAdmin;
+    res.json({
+      products: products.list({ tenant: tenantFilter || undefined, includeStaging }),
+      configured: !!process.env.OMCP_PRODUCTS_FILE,
+      scopedTo: tenantFilter || (isAdmin ? null : callerTenant),
+      includesStaging: includeStaging,
+    });
+  });
+  // Single product by id. Non-admins get a 404 (not 403) on a
+  // cross-tenant probe so the existence of the product isn't leaked
+  // — same posture as the rest of the tenancy layer.
+  app.get("/api/products/:id", need("products", "read"), (req, res) => {
+    const sess = (req as AuthedRequest).session;
+    const isAdmin = hasPermission(sess?.roles, "users", "delete");
+    const callerTenant = sess?.tenant || "default";
+    const tenantFilter = isAdmin ? undefined : callerTenant;
+    const id = String(req.params.id);
+    const p = products.get(id, tenantFilter);
+    if (!p) { res.status(404).json({ error: "not found" }); return; }
+    // Non-admins also don't see staging products even if they happen
+    // to belong to the same tenant.
+    if (!isAdmin && p.status === "staging") { res.status(404).json({ error: "not found" }); return; }
+    res.json(p);
   });
 
   // Health endpoint for UI dashboard

--- a/mcp-server/src/openapi.test.ts
+++ b/mcp-server/src/openapi.test.ts
@@ -27,6 +27,8 @@ test("openapi — every user-visible /api path is documented", () => {
     "/api/usage",
     "/api/policy",
     "/api/catalog",
+    "/api/products",
+    "/api/products/{id}",
     "/api/info",
     "/api/openapi.json",
   ];

--- a/mcp-server/src/openapi.ts
+++ b/mcp-server/src/openapi.ts
@@ -524,6 +524,48 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
           },
         },
       },
+      "/api/products": {
+        get: {
+          tags: ["products"],
+          summary: "Loaded MCP Products catalogue (curated tool bundles for agents).",
+          parameters: [
+            { name: "tenant", in: "query", schema: { type: "string" }, description: "Tenant scope. Non-admins silently scoped to their own; admins can pick any (omit → all)." },
+          ],
+          responses: {
+            "200": {
+              description: "Products list scoped to caller's tenant; admins see staging entries too.",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      products: { type: "array", items: { type: "object", additionalProperties: true } },
+                      configured: { type: "boolean" },
+                      scopedTo: { type: ["string", "null"] },
+                      includesStaging: { type: "boolean" },
+                    },
+                  },
+                },
+              },
+            },
+            "403": { description: "Missing products:read permission." },
+          },
+        },
+      },
+      "/api/products/{id}": {
+        get: {
+          tags: ["products"],
+          summary: "Single product by id (404 on cross-tenant or staging probe by non-admin).",
+          parameters: [
+            { name: "id", in: "path", required: true, schema: { type: "string" } },
+          ],
+          responses: {
+            "200": { description: "The product entry.", content: { "application/json": { schema: { type: "object", additionalProperties: true } } } },
+            "404": { description: "Not found (or hidden by tenant / staging scope)." },
+            "403": { description: "Missing products:read permission." },
+          },
+        },
+      },
       "/api/catalog": {
         get: {
           tags: ["catalog"],

--- a/mcp-server/src/products/loader.test.ts
+++ b/mcp-server/src/products/loader.test.ts
@@ -1,0 +1,127 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseProductsText, ProductsStore, ProductsLoadError } from "./loader.js";
+
+test("parseProductsText — empty/minimal products array", () => {
+  const f = parseProductsText("products: []", "test");
+  assert.deepEqual(f.products, []);
+});
+
+test("parseProductsText — happy path with full shape", () => {
+  const yaml = `
+products:
+  - id: ops-bundle
+    name: Operations Bundle
+    description: Tools for incident response.
+    tools: [query_logs, query_metrics, get_service_health]
+    version: 1.2.0
+    status: published
+    branding:
+      iconUrl: https://example.test/icon.png
+      color: "#3178c6"
+  - id: dev-bundle
+    name: Developer Bundle
+    tools: [query_logs]
+    status: staging
+`;
+  const f = parseProductsText(yaml, "test");
+  assert.equal(f.products.length, 2);
+  assert.equal(f.products[0].id, "ops-bundle");
+  assert.deepEqual(f.products[0].tools, ["query_logs", "query_metrics", "get_service_health"]);
+  assert.equal(f.products[0].status, "published");
+  assert.equal(f.products[0].branding?.color, "#3178c6");
+  assert.equal(f.products[1].status, "staging");
+});
+
+test("parseProductsText — rejects malformed root / non-array products", () => {
+  assert.throws(() => parseProductsText("[]", "t"), /root must be an object/);
+  assert.throws(() => parseProductsText("products: notalist", "t"), /'products' must be an array/);
+});
+
+test("parseProductsText — rejects bad id / missing name / duplicate id", () => {
+  assert.throws(() => parseProductsText("products:\n  - id: '..bad'\n    name: x", "t"), /id must be a string matching/);
+  assert.throws(() => parseProductsText("products:\n  - id: ok\n    name: ''", "t"), /name must be a non-empty string/);
+  assert.throws(
+    () => parseProductsText("products:\n  - id: dup\n    name: A\n  - id: dup\n    name: B", "t"),
+    /duplicate product id 'dup'/,
+  );
+});
+
+test("parseProductsText — rejects unknown status / wrong types", () => {
+  assert.throws(() => parseProductsText("products:\n  - id: x\n    name: X\n    status: archived", "t"), /status must be one of/);
+  assert.throws(() => parseProductsText("products:\n  - id: x\n    name: X\n    tools: 'string-not-array'", "t"), /tools must be an array/);
+  assert.throws(() => parseProductsText("products:\n  - id: x\n    name: X\n    version: 42", "t"), /version must be a string/);
+});
+
+test("parseProductsText — rejects unexpected top-level keys (typo guard)", () => {
+  assert.throws(
+    () => parseProductsText("products:\n  - id: x\n    name: X\n    toolss: []", "t"),
+    /unexpected key 'toolss'/,
+  );
+});
+
+test("parseProductsText — rejects malformed branding shape", () => {
+  assert.throws(
+    () => parseProductsText("products:\n  - id: x\n    name: X\n    branding: notobject", "t"),
+    /branding must be an object/,
+  );
+  assert.throws(
+    () => parseProductsText("products:\n  - id: x\n    name: X\n    branding:\n      iconUrl: 42", "t"),
+    /branding.iconUrl must be a string/,
+  );
+});
+
+test("ProductsStore — list / get / count happy paths", () => {
+  const store = new ProductsStore({
+    products: [
+      { id: "a", name: "A", status: "published" },
+      { id: "b", name: "B", status: "staging" },
+      { id: "c", name: "C" }, // no explicit status → not "staging" → visible by default
+    ],
+  });
+  // Default: staging hidden
+  assert.equal(store.list().length, 2);
+  // Include staging
+  assert.equal(store.list({ includeStaging: true }).length, 3);
+  // get unfiltered
+  assert.equal(store.get("a")?.name, "A");
+  assert.equal(store.get("missing"), undefined);
+  // count includes everything
+  assert.equal(store.count(), 3);
+});
+
+test("ProductsStore — tenant filter scopes list / get / count", () => {
+  const store = new ProductsStore({
+    products: [
+      { id: "acme-ops", name: "Acme Ops", tenant: "acme" },
+      { id: "bigco-ops", name: "BigCo Ops", tenant: "bigco" },
+      { id: "shared", name: "Shared" }, // no tenant → "default"
+    ],
+  });
+  // Tenant-scoped
+  assert.equal(store.list({ tenant: "acme" }).length, 1);
+  assert.equal(store.get("acme-ops", "acme")?.name, "Acme Ops");
+  assert.equal(store.get("bigco-ops", "acme"), undefined, "cross-tenant get returns undefined");
+  assert.equal(store.count("default"), 1, "no-tenant entry counts under 'default'");
+});
+
+test("ProductsStore — staging hidden by default within a tenant filter", () => {
+  const store = new ProductsStore({
+    products: [
+      { id: "p1", name: "P1", tenant: "acme", status: "published" },
+      { id: "p2", name: "P2", tenant: "acme", status: "staging" },
+    ],
+  });
+  assert.equal(store.list({ tenant: "acme" }).length, 1, "staging is hidden");
+  assert.equal(store.list({ tenant: "acme", includeStaging: true }).length, 2);
+});
+
+test("ProductsLoadError is the throw class", () => {
+  try { parseProductsText("not-json", "t"); }
+  catch (e) {
+    assert.ok(e instanceof ProductsLoadError);
+    return;
+  }
+  assert.fail("expected throw");
+});

--- a/mcp-server/src/products/loader.ts
+++ b/mcp-server/src/products/loader.ts
@@ -1,0 +1,187 @@
+/**
+ * MCP Products — curated, agent-facing collections of tools.
+ *
+ * A Product is a named bundle that ships with branding metadata
+ * (icon, description, version) plus a list of allowed MCP tools.
+ * The agent calling /mcp can be told which Product it belongs to
+ * (via a future header / arg, slice 2+), and the server can filter
+ * tools/list and tools/call responses accordingly.
+ *
+ * Today's surface (slice 1):
+ *   - In-memory ProductsStore loaded from OMCP_PRODUCTS_FILE
+ *     (YAML or JSON). Missing/empty file → empty catalog.
+ *   - Strict validation: unknown action / unknown resource /
+ *     unexpected keys reject loudly.
+ *   - Hot-reload on next /api/products call (slice 2 wires the
+ *     reload trigger; for now the file is read once at boot).
+ */
+
+import { readFile } from "node:fs/promises";
+import yaml from "js-yaml";
+
+export interface Product {
+  /** Stable identifier — used in URLs, audit entries, /api/products/{id}. */
+  id: string;
+  /** Display name shown in the UI / agent dropdown. */
+  name: string;
+  /** One-sentence description. */
+  description?: string;
+  /** Allowed MCP tool names. Empty / undefined → all tools allowed. */
+  tools?: string[];
+  /** Operator-defined version label, e.g. "1.0.0" or "preview". */
+  version?: string;
+  /** Free-form branding metadata for the UI — icon URL, theme colour, etc. */
+  branding?: {
+    iconUrl?: string;
+    color?: string;
+  };
+  /** Lifecycle stage: published = visible to agents; staging = admin-only. */
+  status?: "published" | "staging";
+  /** Tenant this product belongs to. Omitted → "default". */
+  tenant?: string;
+}
+
+export interface ProductsFile {
+  products: Product[];
+}
+
+const EMPTY: ProductsFile = { products: [] };
+const VALID_STATUS = new Set(["published", "staging"]);
+const ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+export class ProductsLoadError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "ProductsLoadError";
+  }
+}
+
+export async function readProductsFile(path: string | undefined): Promise<ProductsFile> {
+  if (!path) return EMPTY;
+  let text: string;
+  try { text = await readFile(path, "utf8"); }
+  catch (e) {
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return EMPTY;
+    console.warn(`[products] could not read ${path}: ${(e as Error).message} — starting with empty catalog`);
+    return EMPTY;
+  }
+  return parseProductsText(text, path);
+}
+
+export function parseProductsText(text: string, origin: string): ProductsFile {
+  let parsed: unknown;
+  try { parsed = yaml.load(text); }
+  catch (e) { throw new ProductsLoadError(`${origin}: not valid YAML/JSON: ${(e as Error).message}`); }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ProductsLoadError(`${origin}: root must be an object with a 'products' array`);
+  }
+  const root = parsed as Record<string, unknown>;
+  const rawProducts = root.products;
+  if (!Array.isArray(rawProducts)) {
+    throw new ProductsLoadError(`${origin}: 'products' must be an array`);
+  }
+  const out: Product[] = [];
+  const seenIds = new Set<string>();
+  for (let i = 0; i < rawProducts.length; i++) {
+    const e = rawProducts[i];
+    if (!e || typeof e !== "object" || Array.isArray(e)) {
+      throw new ProductsLoadError(`${origin}: products[${i}] must be an object`);
+    }
+    const r = e as Record<string, unknown>;
+    if (typeof r.id !== "string" || !ID_RE.test(r.id)) {
+      throw new ProductsLoadError(`${origin}: products[${i}].id must be a string matching ${ID_RE}`);
+    }
+    if (seenIds.has(r.id)) {
+      throw new ProductsLoadError(`${origin}: duplicate product id '${r.id}'`);
+    }
+    seenIds.add(r.id);
+    if (typeof r.name !== "string" || !r.name) {
+      throw new ProductsLoadError(`${origin}: products[${i}].name must be a non-empty string`);
+    }
+    const p: Product = { id: r.id, name: r.name };
+    if (r.description !== undefined) {
+      if (typeof r.description !== "string") throw new ProductsLoadError(`${origin}: products[${i}].description must be a string`);
+      p.description = r.description;
+    }
+    if (r.tools !== undefined) {
+      if (!Array.isArray(r.tools) || !r.tools.every((t) => typeof t === "string")) {
+        throw new ProductsLoadError(`${origin}: products[${i}].tools must be an array of strings`);
+      }
+      p.tools = r.tools as string[];
+    }
+    if (r.version !== undefined) {
+      if (typeof r.version !== "string") throw new ProductsLoadError(`${origin}: products[${i}].version must be a string`);
+      p.version = r.version;
+    }
+    if (r.status !== undefined) {
+      if (typeof r.status !== "string" || !VALID_STATUS.has(r.status)) {
+        throw new ProductsLoadError(`${origin}: products[${i}].status must be one of ${[...VALID_STATUS].join(", ")}`);
+      }
+      p.status = r.status as "published" | "staging";
+    }
+    if (r.tenant !== undefined) {
+      if (typeof r.tenant !== "string") throw new ProductsLoadError(`${origin}: products[${i}].tenant must be a string`);
+      p.tenant = r.tenant;
+    }
+    if (r.branding !== undefined) {
+      if (!r.branding || typeof r.branding !== "object" || Array.isArray(r.branding)) {
+        throw new ProductsLoadError(`${origin}: products[${i}].branding must be an object`);
+      }
+      const b = r.branding as Record<string, unknown>;
+      p.branding = {};
+      if (b.iconUrl !== undefined) {
+        if (typeof b.iconUrl !== "string") throw new ProductsLoadError(`${origin}: products[${i}].branding.iconUrl must be a string`);
+        p.branding.iconUrl = b.iconUrl;
+      }
+      if (b.color !== undefined) {
+        if (typeof b.color !== "string") throw new ProductsLoadError(`${origin}: products[${i}].branding.color must be a string`);
+        p.branding.color = b.color;
+      }
+    }
+    // Reject unexpected top-level keys — operator typo guard
+    for (const k of Object.keys(r)) {
+      if (!["id", "name", "description", "tools", "version", "branding", "status", "tenant"].includes(k)) {
+        throw new ProductsLoadError(`${origin}: products[${i}] has unexpected key '${k}'`);
+      }
+    }
+    out.push(p);
+  }
+  return { products: out };
+}
+
+/** In-memory store with tenant- and status-aware queries. */
+export class ProductsStore {
+  constructor(private file: ProductsFile = EMPTY) {}
+
+  /** Return the product list. When `tenant` is set, filters to that
+   *  tenant (entries without a tenant field treated as "default").
+   *  When `includeStaging` is false (default), staging products are
+   *  hidden from the result — admins should pass true. */
+  list(opts: { tenant?: string; includeStaging?: boolean } = {}): Product[] {
+    return this.file.products.filter((p) => {
+      if (opts.tenant) {
+        const pt = p.tenant || "default";
+        if (pt !== opts.tenant) return false;
+      }
+      if (!opts.includeStaging && p.status === "staging") return false;
+      return true;
+    });
+  }
+
+  /** Lookup by id. Cross-tenant gets return undefined when `tenant` set. */
+  get(id: string, tenant?: string): Product | undefined {
+    const p = this.file.products.find((x) => x.id === id);
+    if (!p) return undefined;
+    if (tenant && (p.tenant || "default") !== tenant) return undefined;
+    return p;
+  }
+
+  count(tenant?: string): number {
+    return this.list({ tenant, includeStaging: true }).length;
+  }
+
+  replace(file: ProductsFile): void {
+    this.file = file;
+  }
+}


### PR DESCRIPTION
## Summary

First slice of the **MCP Products + RBAC** phase (the last phase of the deferred-work plan).

### What ships
- **\`src/products/loader.ts\`** — Product model, strict-validating parser, ProductsStore with tenant + staging awareness
- **\`src/auth/rbac.ts\`** — Resource gains \`products\`; viewer/operator/admin get the appropriate grants
- **\`/api/products\`** + **\`/api/products/:id\`** — tenant-scoped + staging-aware, 404 on cross-tenant probes (no existence leak)
- **OpenAPI** + 10 new loader tests + pinned route list + CI test glob

### Reviewer pre-push: 0 blockers
- ✅ Cross-tenant 404, staging hidden from non-admins, ID regex path-traversal-safe, backwards-compat (no env → empty catalog)
- 🟡 Deferred to slice 2: fail-loud on non-ENOENT read errors at boot

### Remaining MCP Products phase
- Slice 2: PUT/DELETE + audit + hot-reload
- Slice 3: UI Products tab (replaces legacy enterprise-gate stub)
- Slice 4: Docs + demo products.yaml

## Test plan
- [ ] CI green: 10 new products tests, rbac count assertions updated
- [ ] No new deps, no release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)