### PR TITLE
feat(products): PUT + DELETE /api/products/:id + atomic file write — MCP Products slice 2/4

### DIFF
--- a/mcp-server/src/audit/middleware.ts
+++ b/mcp-server/src/audit/middleware.ts
@@ -32,7 +32,13 @@ export function buildAuditMiddleware(cfg: AuditMiddlewareConfig): RequestHandler
     }
     res.on("finish", () => {
       const sess = (req as AuthedRequest).session;
-      const target = typeof req.params?.name === "string" ? req.params.name : undefined;
+      // Pick the most-likely identifier from the route params so the
+      // audit entry's `target` lines up with what the operator
+      // typed. Most routes use `:name`; products use `:id`; fall
+      // through if neither (the entry still records method+path).
+      const target = typeof req.params?.name === "string"
+        ? req.params.name
+        : typeof req.params?.id === "string" ? req.params.id : undefined;
       cfg.audit
         .record({
           actor: sess

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -63,7 +63,7 @@ import { OpaPolicyEngine } from "./auth/policy/opa.js";
 import { AuditLog } from "./audit/log.js";
 import { buildAuditMiddleware } from "./audit/middleware.js";
 import { readCatalogFile, CatalogStore } from "./catalog/loader.js";
-import { readProductsFile, ProductsStore } from "./products/loader.js";
+import { readProductsFile, ProductsStore, validateProduct, writeProductsFile, ProductsLoadError } from "./products/loader.js";
 import { redactValue } from "./policy/redact.js";
 import { IdentityRateLimiter, resolveToolRatePerMin } from "./quota/limiter.js";
 import { TokenBudget, estimateTokensFor, resolveDailyTokenLimit } from "./quota/token-budget.js";
@@ -1660,6 +1660,77 @@ async function main() {
       scopedTo: tenantFilter || (isAdmin ? null : callerTenant),
       includesStaging: includeStaging,
     });
+  });
+  // Upsert a product. Body is the same shape as a single entry
+  // in OMCP_PRODUCTS_FILE. The URL-path id must match the body id
+  // (defence-in-depth: the gate keys on body, the path keys the
+  // audit entry). When OMCP_PRODUCTS_FILE is set we also write the
+  // updated catalogue back to disk so the change survives a
+  // restart; without the file, the upsert is in-memory only.
+  app.put("/api/products/:id", need("products", "write"), audit("products", "write"), async (req, res) => {
+    const id = String(req.params.id);
+    const sess = (req as AuthedRequest).session;
+    const isAdmin = hasPermission(sess?.roles, "users", "delete");
+    const callerTenant = sess?.tenant || "default";
+    const body = req.body as Record<string, unknown> | undefined;
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      res.status(400).json({ error: "body must be a product object" });
+      return;
+    }
+    if (typeof body.id === "string" && body.id !== id) {
+      res.status(400).json({ error: `body.id '${body.id}' does not match URL path '${id}'` });
+      return;
+    }
+    // Force the id from the URL so the audit entry's target matches
+    // the persisted record even if the operator omitted it from the
+    // body.
+    const payload = { ...body, id };
+    let validated;
+    try { validated = validateProduct(payload, `PUT /api/products/${id}`); }
+    catch (e) {
+      if (e instanceof ProductsLoadError) { res.status(400).json({ error: e.message }); return; }
+      throw e;
+    }
+    // Tenant gate: non-admins can only write into their own tenant.
+    if (!isAdmin && (validated.tenant || "default") !== callerTenant) {
+      res.status(403).json({ error: "cannot write product into another tenant" });
+      return;
+    }
+    // If an existing product belongs to a different tenant, a non-
+    // admin overwrite would re-parent it — same 404-not-403 posture
+    // as cross-tenant gets.
+    const existing = products.get(id);
+    if (existing && !isAdmin && (existing.tenant || "default") !== callerTenant) {
+      res.status(404).json({ error: "not found" });
+      return;
+    }
+    const next = products.upsert(validated);
+    if (process.env.OMCP_PRODUCTS_FILE) {
+      try { await writeProductsFile(process.env.OMCP_PRODUCTS_FILE, next); }
+      catch (e) {
+        console.warn(`[products] PUT ${id}: failed to persist to ${process.env.OMCP_PRODUCTS_FILE}: ${(e as Error).message} — in-memory state is still updated`);
+      }
+    }
+    res.json({ product: validated, persisted: !!process.env.OMCP_PRODUCTS_FILE });
+  });
+  app.delete("/api/products/:id", need("products", "delete"), audit("products", "delete"), async (req, res) => {
+    const id = String(req.params.id);
+    const sess = (req as AuthedRequest).session;
+    const isAdmin = hasPermission(sess?.roles, "users", "delete");
+    const callerTenant = sess?.tenant || "default";
+    const existing = products.get(id);
+    if (!existing) { res.status(404).json({ error: "not found" }); return; }
+    if (!isAdmin && (existing.tenant || "default") !== callerTenant) {
+      res.status(404).json({ error: "not found" }); return;
+    }
+    const { file: next } = products.delete(id);
+    if (process.env.OMCP_PRODUCTS_FILE) {
+      try { await writeProductsFile(process.env.OMCP_PRODUCTS_FILE, next); }
+      catch (e) {
+        console.warn(`[products] DELETE ${id}: failed to persist to ${process.env.OMCP_PRODUCTS_FILE}: ${(e as Error).message} — in-memory state is still updated`);
+      }
+    }
+    res.status(204).end();
   });
   // Single product by id. Non-admins get a 404 (not 403) on a
   // cross-tenant probe so the existence of the product isn't leaked

--- a/mcp-server/src/openapi.ts
+++ b/mcp-server/src/openapi.ts
@@ -565,6 +565,41 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
             "403": { description: "Missing products:read permission." },
           },
         },
+        put: {
+          tags: ["products"],
+          summary: "Upsert a product (admin + operator). Body must match the OMCP_PRODUCTS_FILE entry shape.",
+          parameters: [
+            { name: "id", in: "path", required: true, schema: { type: "string" } },
+          ],
+          requestBody: {
+            required: true,
+            content: { "application/json": { schema: { type: "object", additionalProperties: true } } },
+          },
+          responses: {
+            "200": {
+              description: "Upsert succeeded; returns the validated product + a persisted flag.",
+              content: { "application/json": { schema: { type: "object", properties: {
+                product: { type: "object", additionalProperties: true },
+                persisted: { type: "boolean", description: "True when OMCP_PRODUCTS_FILE was set and the file was rewritten." },
+              } } } },
+            },
+            "400": { description: "Body shape invalid (validateProduct rejected — typo, unknown key, wrong type, ...)." },
+            "403": { description: "Missing products:write permission, or non-admin attempting to write into another tenant." },
+            "404": { description: "Existing product belongs to a different tenant (non-admin)." },
+          },
+        },
+        delete: {
+          tags: ["products"],
+          summary: "Delete a product by id (admin only).",
+          parameters: [
+            { name: "id", in: "path", required: true, schema: { type: "string" } },
+          ],
+          responses: {
+            "204": { description: "Deleted." },
+            "403": { description: "Missing products:delete permission." },
+            "404": { description: "Not found (or hidden by tenant scope)." },
+          },
+        },
       },
       "/api/catalog": {
         get: {

--- a/mcp-server/src/products/loader.test.ts
+++ b/mcp-server/src/products/loader.test.ts
@@ -117,6 +117,72 @@ test("ProductsStore — staging hidden by default within a tenant filter", () =>
   assert.equal(store.list({ tenant: "acme", includeStaging: true }).length, 2);
 });
 
+test("ProductsStore.upsert — replaces existing, appends new", () => {
+  const store = new ProductsStore({
+    products: [
+      { id: "a", name: "Original" },
+      { id: "b", name: "Second" },
+    ],
+  });
+  // Replace existing
+  store.upsert({ id: "a", name: "Replaced" });
+  assert.equal(store.get("a")?.name, "Replaced");
+  assert.equal(store.count(), 2);
+  // Append new
+  store.upsert({ id: "c", name: "New" });
+  assert.equal(store.count(), 3);
+  assert.equal(store.get("c")?.name, "New");
+});
+
+test("ProductsStore.delete — returns removed flag + survivors", () => {
+  const store = new ProductsStore({
+    products: [{ id: "a", name: "A" }, { id: "b", name: "B" }],
+  });
+  const r1 = store.delete("a");
+  assert.equal(r1.removed, true);
+  assert.equal(store.count(), 1);
+  // Re-delete is a no-op
+  const r2 = store.delete("a");
+  assert.equal(r2.removed, false);
+  // Unknown id
+  const r3 = store.delete("nope");
+  assert.equal(r3.removed, false);
+});
+
+test("validateProduct — accepts a valid entry, rejects bad shape via same parser", async () => {
+  // Happy path
+  const p = await import("./loader.js").then((m) => m.validateProduct({ id: "x", name: "X" }));
+  assert.equal(p.name, "X");
+  // Bad shape uses the loader's strict rules
+  const { validateProduct } = await import("./loader.js");
+  assert.throws(() => validateProduct({ id: "x", name: "X", unknownKey: 1 }), /unexpected key 'unknownKey'/);
+  assert.throws(() => validateProduct({ id: "..bad", name: "X" }), /id must be a string matching/);
+});
+
+test("writeProductsFile + readProductsFile — atomic round-trip", async () => {
+  const { mkdtemp, rm } = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const { writeProductsFile, readProductsFile } = await import("./loader.js");
+  const dir = await mkdtemp(join(tmpdir(), "omcp-products-"));
+  try {
+    const file = join(dir, "products.yaml");
+    await writeProductsFile(file, {
+      products: [
+        { id: "a", name: "A", status: "published" },
+        { id: "b", name: "B", tools: ["query_logs"], tenant: "acme" },
+      ],
+    });
+    const reloaded = await readProductsFile(file);
+    assert.equal(reloaded.products.length, 2);
+    assert.equal(reloaded.products[0].status, "published");
+    assert.equal(reloaded.products[1].tenant, "acme");
+    assert.deepEqual(reloaded.products[1].tools, ["query_logs"]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("ProductsLoadError is the throw class", () => {
   try { parseProductsText("not-json", "t"); }
   catch (e) {

--- a/mcp-server/src/products/loader.ts
+++ b/mcp-server/src/products/loader.ts
@@ -16,7 +16,7 @@
  *     reload trigger; for now the file is read once at boot).
  */
 
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile, rename } from "node:fs/promises";
 import yaml from "js-yaml";
 
 export interface Product {
@@ -184,4 +184,51 @@ export class ProductsStore {
   replace(file: ProductsFile): void {
     this.file = file;
   }
+
+  /** Upsert (replace if id exists, else append). Returns the new
+   *  ProductsFile so the caller can persist it. */
+  upsert(product: Product): ProductsFile {
+    const i = this.file.products.findIndex((p) => p.id === product.id);
+    const next: Product[] = this.file.products.slice();
+    if (i >= 0) next[i] = product;
+    else next.push(product);
+    this.file = { products: next };
+    return this.file;
+  }
+
+  /** Remove by id. Returns true when the product existed, false
+   *  otherwise. Caller persists the resulting file. */
+  delete(id: string): { removed: boolean; file: ProductsFile } {
+    const i = this.file.products.findIndex((p) => p.id === id);
+    if (i < 0) return { removed: false, file: this.file };
+    const next = this.file.products.slice();
+    next.splice(i, 1);
+    this.file = { products: next };
+    return { removed: true, file: this.file };
+  }
+
+  /** Snapshot of the current file (for tests / persistence). */
+  snapshot(): ProductsFile {
+    return { products: this.file.products.slice() };
+  }
+}
+
+/** Validate a single product entry by routing it through the same
+ *  parser as the file format. Throws ProductsLoadError on any
+ *  shape problem. Used by PUT /api/products/:id so a typo / wrong
+ *  type / unknown key gets the same loud rejection a malformed
+ *  file would. */
+export function validateProduct(input: unknown, origin = "input"): Product {
+  const wrapped = parseProductsText(yaml.dump({ products: [input] }), origin);
+  return wrapped.products[0];
+}
+
+/** Atomic write of the products file. Same tmp+rename pattern as
+ *  the audit-chain + token-budget snapshot, so a crash mid-write
+ *  leaves the previous file intact. */
+export async function writeProductsFile(path: string, file: ProductsFile): Promise<void> {
+  const text = yaml.dump(file, { sortKeys: false, lineWidth: 100 });
+  const tmp = path + ".tmp";
+  await writeFile(tmp, text, "utf8");
+  await rename(tmp, path);
 }


### PR DESCRIPTION
## Summary

MCP Products slice 2/4 — write side of the API.

### What changed
- **\`ProductsStore.upsert\` / \`delete\` / \`snapshot\`** — in-memory mutations + a snapshot helper for tests.
- **\`validateProduct\`** — single-entry validator routed through the same parseProductsText pipeline (zero validator drift).
- **\`writeProductsFile\`** — atomic tmp+rename persistence.
- **PUT /api/products/:id** + **DELETE /api/products/:id** with tenant gates (non-admin scoped to own tenant; cross-tenant overwrite → 404 to avoid existence leak), audit middleware, atomic file write when \`OMCP_PRODUCTS_FILE\` set.
- **\`audit/middleware.ts\`** target extractor extended to pick \`:id\` as well as \`:name\` (reviewer-flagged).
- OpenAPI + 4 new tests.

### Reviewer pre-push: 3 cleanups applied
- ✅ Middleware order flipped to \`need(...), audit(...)\` for parity with 11 existing audited routes
- ✅ Redundant per-route \`express.json()\` dropped (global parser is authoritative)
- ✅ Audit target extractor extended to \`:id\`

### Remaining MCP Products phase
- Slice 3: UI Products tab using new /api/products endpoints
- Slice 4: Docs + demo products.yaml + cross-links

## Test plan
- [ ] CI green: 4 new products tests + existing suite unaffected
- [ ] No new dependencies, no release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)