### PR TITLE
feat(products): mtime-poll hot-reload for OMCP_PRODUCTS_FILE

### DIFF
--- a/docs/products.md
+++ b/docs/products.md
@@ -138,9 +138,11 @@ the recommended path is:
 2. Open a PR for any change.
 3. CI runs `parseProductsText` validation (via the loader test
    harness) and fails loudly on typos / unknown keys / duplicates.
-4. Merge → server reads the updated file at next boot (hot-reload
-   on file change is a roadmap item; today the standard restart
-   covers it).
+4. Merge → server picks up the updated file on the next
+   `/api/products*` request (mtime-poll hot-reload). No restart
+   required. Parse errors keep the previous good catalogue in
+   memory and log loudly, so a broken edit on disk never takes
+   the running server down.
 
 This keeps the catalog in the same review loop as code: every
 product change has an author, a reason in the PR body, and a

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -916,7 +916,16 @@ async function main() {
   // No file ⇒ empty catalog, enrichment is a no-op (anonymous demos
   // see no behaviour change).
   const catalog = new CatalogStore(await readCatalogFile(process.env.OMCP_SERVICE_CATALOG_FILE));
-  const products = new ProductsStore(await readProductsFile(process.env.OMCP_PRODUCTS_FILE));
+  // Hot-reload aware: passing the path lets `products.maybeReload()`
+  // pick up out-of-band edits to OMCP_PRODUCTS_FILE without a restart.
+  // Each /api/products* handler awaits maybeReload() before reading,
+  // so a `kubectl apply` of an updated ConfigMap or a git-ops edit is
+  // visible on the very next request.
+  const productsPath = process.env.OMCP_PRODUCTS_FILE;
+  const products = new ProductsStore(await readProductsFile(productsPath), { path: productsPath });
+  // Seed the mtime cursor from the file we just loaded so the first
+  // maybeReload() call doesn't redundantly re-parse the boot state.
+  await products.pinMtimeAfterWrite();
   // Protected route prefixes. /api/me, /api/auth/*, /api/info,
   // /api/openapi.json deliberately don't appear here — they stay public.
   for (const prefix of [
@@ -1647,7 +1656,9 @@ async function main() {
   // Same scoping / staging-visibility pattern as /api/catalog. Non-admins
   // see only their own tenant's PUBLISHED products; admins see all
   // tenants by default + staging.
-  app.get("/api/products", need("products", "read"), (req, res) => {
+  app.get("/api/products", need("products", "read"), async (req, res) => {
+    // Pick up out-of-band edits before serving — see ProductsStore docs.
+    await products.maybeReload();
     const sess = (req as AuthedRequest).session;
     const isAdmin = hasPermission(sess?.roles, "users", "delete");
     const callerTenant = sess?.tenant || "default";
@@ -1668,6 +1679,9 @@ async function main() {
   // updated catalogue back to disk so the change survives a
   // restart; without the file, the upsert is in-memory only.
   app.put("/api/products/:id", need("products", "write"), audit("products", "write"), async (req, res) => {
+    // Hot-reload before mutating so a concurrent on-disk edit isn't
+    // silently clobbered by our in-memory snapshot.
+    await products.maybeReload();
     const id = String(req.params.id);
     const sess = (req as AuthedRequest).session;
     const isAdmin = hasPermission(sess?.roles, "users", "delete");
@@ -1706,7 +1720,13 @@ async function main() {
     }
     const next = products.upsert(validated);
     if (process.env.OMCP_PRODUCTS_FILE) {
-      try { await writeProductsFile(process.env.OMCP_PRODUCTS_FILE, next); }
+      try {
+        await writeProductsFile(process.env.OMCP_PRODUCTS_FILE, next);
+        // Advance our mtime cursor past this write so the next
+        // maybeReload() doesn't treat our own change as an external
+        // edit and re-read what we just persisted.
+        await products.pinMtimeAfterWrite();
+      }
       catch (e) {
         console.warn(`[products] PUT ${id}: failed to persist to ${process.env.OMCP_PRODUCTS_FILE}: ${(e as Error).message} — in-memory state is still updated`);
       }
@@ -1714,6 +1734,7 @@ async function main() {
     res.json({ product: validated, persisted: !!process.env.OMCP_PRODUCTS_FILE });
   });
   app.delete("/api/products/:id", need("products", "delete"), audit("products", "delete"), async (req, res) => {
+    await products.maybeReload();
     const id = String(req.params.id);
     const sess = (req as AuthedRequest).session;
     const isAdmin = hasPermission(sess?.roles, "users", "delete");
@@ -1725,7 +1746,10 @@ async function main() {
     }
     const { file: next } = products.delete(id);
     if (process.env.OMCP_PRODUCTS_FILE) {
-      try { await writeProductsFile(process.env.OMCP_PRODUCTS_FILE, next); }
+      try {
+        await writeProductsFile(process.env.OMCP_PRODUCTS_FILE, next);
+        await products.pinMtimeAfterWrite();
+      }
       catch (e) {
         console.warn(`[products] DELETE ${id}: failed to persist to ${process.env.OMCP_PRODUCTS_FILE}: ${(e as Error).message} — in-memory state is still updated`);
       }
@@ -1735,7 +1759,8 @@ async function main() {
   // Single product by id. Non-admins get a 404 (not 403) on a
   // cross-tenant probe so the existence of the product isn't leaked
   // — same posture as the rest of the tenancy layer.
-  app.get("/api/products/:id", need("products", "read"), (req, res) => {
+  app.get("/api/products/:id", need("products", "read"), async (req, res) => {
+    await products.maybeReload();
     const sess = (req as AuthedRequest).session;
     const isAdmin = hasPermission(sess?.roles, "users", "delete");
     const callerTenant = sess?.tenant || "default";

--- a/mcp-server/src/products/loader.test.ts
+++ b/mcp-server/src/products/loader.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { parseProductsText, ProductsStore, ProductsLoadError } from "./loader.js";
+import { parseProductsText, ProductsStore, ProductsLoadError, readProductsFile } from "./loader.js";
 
 test("parseProductsText — empty/minimal products array", () => {
   const f = parseProductsText("products: []", "test");
@@ -190,4 +190,94 @@ test("ProductsLoadError is the throw class", () => {
     return;
   }
   assert.fail("expected throw");
+});
+
+test("ProductsStore.maybeReload — picks up out-of-band edits on next call", async () => {
+  const { mkdtemp, rm, writeFile, utimes } = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const dir = await mkdtemp(join(tmpdir(), "omcp-products-reload-"));
+  try {
+    const file = join(dir, "products.yaml");
+    await writeFile(file, "products:\n  - id: a\n    name: A\n", "utf8");
+    const initial = await readProductsFile(file);
+    const store = new ProductsStore(initial, { path: file });
+    await store.pinMtimeAfterWrite();
+    assert.equal(store.list().length, 1);
+    assert.equal(store.list()[0].id, "a");
+    // Simulate an out-of-band edit. Bump mtime explicitly because
+    // some filesystems (WSL → 9P) round mtime to the second, so a
+    // back-to-back write can land in the same second and look
+    // unchanged to stat().
+    await writeFile(file, "products:\n  - id: a\n    name: A\n  - id: b\n    name: B\n", "utf8");
+    const future = new Date(Date.now() + 5_000);
+    await utimes(file, future, future);
+    const { reloaded } = await store.maybeReload();
+    assert.equal(reloaded, true);
+    assert.equal(store.list().length, 2);
+    // A second call with no further edit is a no-op.
+    const r2 = await store.maybeReload();
+    assert.equal(r2.reloaded, false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("ProductsStore.maybeReload — broken YAML on disk keeps previous good state", async () => {
+  const { mkdtemp, rm, writeFile, utimes } = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const dir = await mkdtemp(join(tmpdir(), "omcp-products-broken-"));
+  try {
+    const file = join(dir, "products.yaml");
+    await writeFile(file, "products:\n  - id: a\n    name: A\n", "utf8");
+    const store = new ProductsStore(await readProductsFile(file), { path: file });
+    await store.pinMtimeAfterWrite();
+    // Corrupt the file with an unknown top-level key — fails the
+    // strict typo guard inside parseProductsText.
+    await writeFile(file, "products:\n  - id: a\n    name: A\n    junk: true\n", "utf8");
+    const future = new Date(Date.now() + 5_000);
+    await utimes(file, future, future);
+    const { reloaded } = await store.maybeReload();
+    // We did NOT swap state — caller sees the previous good catalogue.
+    assert.equal(reloaded, false);
+    assert.equal(store.list().length, 1);
+    assert.equal(store.list()[0].name, "A");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("ProductsStore.maybeReload — no path = no-op", async () => {
+  const store = new ProductsStore({ products: [{ id: "a", name: "A" }] });
+  const r = await store.maybeReload();
+  assert.equal(r.reloaded, false);
+  assert.equal(store.list().length, 1);
+});
+
+test("ProductsStore.pinMtimeAfterWrite — own writes do not trigger a redundant reload", async () => {
+  const { mkdtemp, rm, writeFile, utimes } = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const { writeProductsFile } = await import("./loader.js");
+  const dir = await mkdtemp(join(tmpdir(), "omcp-products-pin-"));
+  try {
+    const file = join(dir, "products.yaml");
+    await writeFile(file, "products:\n  - id: a\n    name: A\n", "utf8");
+    const store = new ProductsStore(await readProductsFile(file), { path: file });
+    await store.pinMtimeAfterWrite();
+    // Simulate the server-side mutate-then-persist path.
+    store.upsert({ id: "b", name: "B" });
+    // Move mtime forward so writeProductsFile genuinely advances it
+    // past our cursor (1-second-resolution FS guard).
+    const future = new Date(Date.now() + 5_000);
+    await writeProductsFile(file, store.snapshot());
+    await utimes(file, future, future);
+    await store.pinMtimeAfterWrite();
+    const { reloaded } = await store.maybeReload();
+    assert.equal(reloaded, false, "own write must not re-trigger maybeReload");
+    assert.equal(store.list().length, 2);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });

--- a/mcp-server/src/products/loader.ts
+++ b/mcp-server/src/products/loader.ts
@@ -12,11 +12,16 @@
  *     (YAML or JSON). Missing/empty file → empty catalog.
  *   - Strict validation: unknown action / unknown resource /
  *     unexpected keys reject loudly.
- *   - Hot-reload on next /api/products call (slice 2 wires the
- *     reload trigger; for now the file is read once at boot).
+ *   - Mtime-poll hot-reload: callers (e.g. each /api/products
+ *     handler) `await store.maybeReload()` before reading. If the
+ *     file mtime advanced since the last load, the store re-parses
+ *     and atomically swaps the in-memory file; parse errors keep
+ *     the previous good state and log loudly. One `stat()` call per
+ *     reload-aware request — too cheap to matter vs. the network
+ *     round-trip, no FSWatcher platform fragility (WSL / NFS).
  */
 
-import { readFile, writeFile, rename } from "node:fs/promises";
+import { readFile, writeFile, rename, stat } from "node:fs/promises";
 import yaml from "js-yaml";
 
 export interface Product {
@@ -152,7 +157,73 @@ export function parseProductsText(text: string, origin: string): ProductsFile {
 
 /** In-memory store with tenant- and status-aware queries. */
 export class ProductsStore {
-  constructor(private file: ProductsFile = EMPTY) {}
+  /** Optional source file path. When set, `maybeReload()` polls its
+   *  mtime and re-parses on change. Mutations via upsert/delete update
+   *  `lastMtimeMs` after the caller persists, so the store does not
+   *  reload its own writes. */
+  private path?: string;
+  private lastMtimeMs = 0;
+
+  constructor(private file: ProductsFile = EMPTY, opts: { path?: string; initialMtimeMs?: number } = {}) {
+    this.path = opts.path;
+    this.lastMtimeMs = opts.initialMtimeMs ?? 0;
+  }
+
+  /** Re-read the source file if its mtime has advanced since the last
+   *  load. No-op when no path was supplied at construction. Parse or
+   *  IO errors are logged and the previous good state is kept — the
+   *  invariant is "the store always reflects a valid catalogue", so a
+   *  broken edit on disk never takes the running server down. */
+  async maybeReload(): Promise<{ reloaded: boolean }> {
+    if (!this.path) return { reloaded: false };
+    let mtimeMs: number;
+    try {
+      const s = await stat(this.path);
+      mtimeMs = s.mtimeMs;
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException).code;
+      // File gone (ENOENT) — keep last good state. Re-creating the
+      // file will land in this branch's else on the next call when
+      // stat succeeds again with a fresh mtime.
+      if (code !== "ENOENT") {
+        console.warn(`[products] hot-reload stat(${this.path}) failed: ${(e as Error).message} — keeping previous catalogue`);
+      }
+      return { reloaded: false };
+    }
+    if (mtimeMs <= this.lastMtimeMs) return { reloaded: false };
+    let next: ProductsFile;
+    try {
+      next = await readProductsFile(this.path);
+    } catch (e) {
+      // readProductsFile downgrades IO errors to EMPTY but lets
+      // parse errors (ProductsLoadError) propagate — so a broken
+      // YAML edit lands here, and we explicitly do NOT swap state.
+      console.warn(`[products] hot-reload of ${this.path} failed: ${(e as Error).message} — keeping previous catalogue`);
+      // Bump the mtime cursor anyway so we don't re-log the same
+      // failure on every subsequent request until the operator fixes
+      // the file (next save advances mtime past this value).
+      this.lastMtimeMs = mtimeMs;
+      return { reloaded: false };
+    }
+    this.file = next;
+    this.lastMtimeMs = mtimeMs;
+    return { reloaded: true };
+  }
+
+  /** Re-stat the source file and pin the mtime cursor to its current
+   *  value. Call this after a successful write so the store does not
+   *  treat its own change as an external reload trigger. Best-effort:
+   *  if the stat fails, the next maybeReload() will simply reload the
+   *  file once and find it identical. */
+  async pinMtimeAfterWrite(): Promise<void> {
+    if (!this.path) return;
+    try {
+      const s = await stat(this.path);
+      this.lastMtimeMs = s.mtimeMs;
+    } catch {
+      // Silent — see method JSDoc.
+    }
+  }
 
   /** Return the product list. When `tenant` is set, filters to that
    *  tenant (entries without a tenant field treated as "default").


### PR DESCRIPTION
## Summary

- \`ProductsStore\` optionally takes a \`path\`; \`maybeReload()\` stats it and re-parses if mtime advanced
- Each \`/api/products*\` handler \`await\`s \`maybeReload()\` before reading
- Parse errors keep previous good state + log loudly — broken edit can't take the server down
- PUT/DELETE pin mtime after their own writes so the store doesn't reload itself
- Closes the \"hot-reload roadmap item\" gap documented in docs/products.md

## Why

Operators were forced to restart the server to pick up out-of-band edits to \`OMCP_PRODUCTS_FILE\` (e.g. a GitOps ConfigMap apply). Now a \`kubectl apply\` or a \`git pull\` is visible on the very next request.

## Why mtime-poll, not fs.watch?

One \`stat()\` per request (~50µs on Linux, negligible vs. network) — robust on WSL / NFS / containerised ConfigMap mounts where \`fs.watch\` is platform-flaky.

## Test plan

- [x] 4 new tests: edit pickup, broken-YAML keeps state, no-path no-op, own-write doesn't loop
- [x] 19/19 product tests pass
- [x] tsc clean
- [x] Reviewer-agent: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)