### PR TITLE
feat(products): /mcp tools/list filter via OMCP_KEY_PRODUCTS binding

### DIFF
--- a/docs/products.md
+++ b/docs/products.md
@@ -65,7 +65,7 @@ Validation rules (the loader rejects loudly, ENOENT silently — see
 |---|---|
 | `id` matches `^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$` | URL-safe, path-traversal safe |
 | `name` non-empty string | UI display |
-| `tools` optional string-array | `tools/list` filter (slice will wire) |
+| `tools` optional string-array | `/mcp` `tools/list` filter — only the named tools register on a credential bound to this Product. Absent / empty list = no restriction. |
 | `status` ∈ `{published, staging}` | Staging hidden from agents + non-admin viewers |
 | `branding.iconUrl` / `branding.color` must be strings | Type guard |
 | Duplicate `id` rejects loudly | Operator typo catch |
@@ -108,6 +108,38 @@ Custom policies (`OMCP_RBAC_POLICY_FILE`) can redefine any of these
 Cross-tenant probes (GET / DELETE on an id that exists in another
 tenant) return **404** — same posture as the rest of the tenancy
 layer, no existence leak.
+
+## Binding an agent's `/mcp` session to a Product
+
+Set `OMCP_KEY_PRODUCTS` to bind a named credential to one Product id:
+
+```bash
+OMCP_API_KEYS="agent:tok_ops,ci:tok_dev"
+OMCP_KEY_PRODUCTS="agent=ops-bundle;ci=dev-bundle"
+# (optionally pin each credential to a tenant)
+OMCP_KEY_TENANTS="agent=acme;ci=acme"
+```
+
+When the `agent` credential opens an `/mcp` session, only the tools
+listed in the `ops-bundle` Product's `tools` field are registered;
+`tools/list` returns exactly that set. Unrecognised tool names are
+silently skipped at registration time, so a typo in the YAML
+narrows the surface rather than crashing the session.
+
+Resolution is tenant-scoped: a credential bound to `ops-bundle` in
+tenant `acme` cannot pick up a `ops-bundle` Product owned by tenant
+`bigco` — the cross-tenant `get()` returns `undefined` and the
+session falls back to the unrestricted set. This is the same posture
+the rest of the tenancy layer enforces.
+
+Anonymous `/mcp` sessions (no `OMCP_API_KEYS` configured) and
+credentials with no `productId` see every registered tool — the
+back-compat path the open-source default relies on.
+
+The catalogue is read with hot-reload semantics: editing the
+Product's `tools` list and re-saving the file takes effect on the
+**next** `/mcp` session, no server restart needed. Live sessions
+keep the snapshot they were created with.
 
 ## UI
 

--- a/helm/observability-mcp/values.yaml
+++ b/helm/observability-mcp/values.yaml
@@ -85,7 +85,15 @@ sources:
 #   - OMCP_PRODUCTS_FILE           YAML catalogue of MCP Products
 #                                  (curated tool bundles per
 #                                  tenant/agent). Empty when unset;
-#                                  see docs/products.md.
+#                                  see docs/products.md. Hot-reload
+#                                  on file change is automatic — no
+#                                  pod restart needed when the
+#                                  mounted ConfigMap is re-applied.
+#   - OMCP_KEY_PRODUCTS            "name=productId;..." binding of
+#                                  named bearer credentials to MCP
+#                                  Products. /mcp tools/list is
+#                                  filtered to the Product's tools
+#                                  allow-list on each new session.
 #   - OMCP_REDACTION               on (default) | off — see docs/redaction.md
 #   - OMCP_TRUST_PROXY             true | loopback | <hops> | <ip,ip,...>
 #   - OMCP_AUTH_ALLOW_FALLBACK     true → degrade to anonymous on basic-mode

--- a/mcp-server/src/auth/credentials.test.ts
+++ b/mcp-server/src/auth/credentials.test.ts
@@ -20,7 +20,7 @@ describe("single-tenant auth primitive", () => {
     assert.equal(creds.length, 2);
     assert.deepEqual(
       creds[0],
-      { name: "ci", token: "tok_abc", allowedSources: undefined, bypassRedaction: undefined, tenant: undefined }
+      { name: "ci", token: "tok_abc", allowedSources: undefined, bypassRedaction: undefined, tenant: undefined, productId: undefined }
     );
     assert.equal(creds[1].name, "key");
     assert.equal(creds[1].token, "tok_bare");
@@ -60,6 +60,28 @@ describe("single-tenant auth primitive", () => {
     assert.equal(creds.find((c) => c.name === "agent")?.tenant, "acme");
     assert.equal(creds.find((c) => c.name === "ci")?.tenant, "bigcorp", "lowercased");
     assert.equal(creds.find((c) => c.name === "nobody")?.tenant, undefined);
+  });
+
+  it("parses OMCP_KEY_PRODUCTS → assigns productId to named keys; unlisted stays undefined", () => {
+    const creds = loadCredentials({
+      OMCP_API_KEYS: "agent:tok1,ci:tok2,nobody:tok3",
+      OMCP_KEY_PRODUCTS: "agent=ops-bundle;ci=dev-bundle",
+    });
+    assert.equal(creds.find((c) => c.name === "agent")?.productId, "ops-bundle");
+    assert.equal(creds.find((c) => c.name === "ci")?.productId, "dev-bundle");
+    assert.equal(creds.find((c) => c.name === "nobody")?.productId, undefined);
+  });
+
+  it("OMCP_KEY_PRODUCTS — malformed entries (no =, empty value) silently skipped", () => {
+    const creds = loadCredentials({
+      OMCP_API_KEYS: "agent:tok1,ci:tok2,x:tok3",
+      // "noeq" lacks "=" → skip; "ci=" has empty value → skip;
+      // "agent=ops" parses cleanly.
+      OMCP_KEY_PRODUCTS: "agent=ops;noeq;ci=;x=dev",
+    });
+    assert.equal(creds.find((c) => c.name === "agent")?.productId, "ops");
+    assert.equal(creds.find((c) => c.name === "ci")?.productId, undefined);
+    assert.equal(creds.find((c) => c.name === "x")?.productId, "dev");
   });
 
   it("extractToken handles Bearer and X-API-Key", () => {

--- a/mcp-server/src/auth/credentials.ts
+++ b/mcp-server/src/auth/credentials.ts
@@ -21,6 +21,13 @@
  *                  # land in the "default" tenant — identical to the
  *                  # pre-E7 single-namespace world. See docs/tenancy.md
  *                  # (slice 5) for the cross-cutting model.
+ *   OMCP_KEY_PRODUCTS="agent=ops-bundle;ci=dev-bundle"
+ *                  # optional per-key Product binding. When set, the
+ *                  # /mcp tools/list response is filtered to the named
+ *                  # Product's `tools` allow-list (Product without a
+ *                  # tools list = no restriction). Unlisted keys see
+ *                  # every registered tool — back-compat with the
+ *                  # pre-Products world. See docs/products.md.
  *
  * Rich role-based access control (tools/services/lookback/read-only, the
  * full governance object) is intentionally NOT here — this is only the
@@ -40,6 +47,10 @@ export interface Credential {
   bypassRedaction?: boolean;
   /** Tenant this credential belongs to. Omitted → DEFAULT_TENANT. */
   tenant?: string;
+  /** Product id this credential is bound to. When set, /mcp tools/list
+   *  is filtered to the Product's `tools` allow-list. Resolved against
+   *  the credential's tenant so cross-tenant Products don't leak. */
+  productId?: string;
 }
 
 function parseKeySources(raw: string | undefined): Map<string, string[]> {
@@ -56,6 +67,22 @@ function parseKeySources(raw: string | undefined): Map<string, string[]> {
   return m;
 }
 
+/** Parse OMCP_KEY_PRODUCTS — `name=productId;name2=productId2`. Same
+ *  shape as parseKeyTenants (single id per credential — Products are
+ *  bundles, not bundles-of-bundles). */
+function parseKeyProducts(raw: string | undefined): Map<string, string> {
+  const m = new Map<string, string>();
+  if (!raw) return m;
+  for (const entry of raw.split(";").map((s) => s.trim()).filter(Boolean)) {
+    const eq = entry.indexOf("=");
+    if (eq <= 0) continue;
+    const name = entry.slice(0, eq).trim();
+    const productId = entry.slice(eq + 1).trim();
+    if (name && productId) m.set(name, productId);
+  }
+  return m;
+}
+
 function parseBypassSet(raw: string | undefined): Set<string> {
   if (!raw) return new Set();
   return new Set(raw.split(",").map((s) => s.trim()).filter(Boolean));
@@ -68,6 +95,7 @@ export function loadCredentials(env: NodeJS.ProcessEnv = process.env): Credentia
   const keySources = parseKeySources(env.OMCP_KEY_SOURCES);
   const bypassNames = parseBypassSet(env.OMCP_KEY_BYPASS_REDACTION);
   const keyTenants = parseKeyTenants(env.OMCP_KEY_TENANTS);
+  const keyProducts = parseKeyProducts(env.OMCP_KEY_PRODUCTS);
   const creds: Credential[] = [];
   for (const part of raw.split(",").map((s) => s.trim()).filter(Boolean)) {
     const idx = part.indexOf(":");
@@ -80,6 +108,7 @@ export function loadCredentials(env: NodeJS.ProcessEnv = process.env): Credentia
       allowedSources: keySources.get(name),
       bypassRedaction: bypassNames.has(name) || undefined,
       tenant: keyTenants.get(name) || undefined,
+      productId: keyProducts.get(name) || undefined,
     });
   }
   return creds;

--- a/mcp-server/src/context.test.ts
+++ b/mcp-server/src/context.test.ts
@@ -1,0 +1,43 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { allowsTool, defaultContext, principalContext } from "./context.js";
+
+test("allowsTool — undefined allow-list = no Product binding = every tool allowed", () => {
+  assert.equal(allowsTool(undefined, "list_sources"), true);
+  assert.equal(allowsTool(undefined, "query_logs"), true);
+});
+
+test("allowsTool — empty allow-list = Product with no tools field = every tool allowed", () => {
+  assert.equal(allowsTool([], "list_sources"), true);
+});
+
+test("allowsTool — non-empty allow-list gates by exact match", () => {
+  const allow = ["list_sources", "query_metrics"];
+  assert.equal(allowsTool(allow, "list_sources"), true);
+  assert.equal(allowsTool(allow, "query_metrics"), true);
+  assert.equal(allowsTool(allow, "query_logs"), false);
+  assert.equal(allowsTool(allow, "get_topology"), false);
+});
+
+test("allowsTool — case-sensitive (matches MCP spec)", () => {
+  const allow = ["list_sources"];
+  assert.equal(allowsTool(allow, "List_Sources"), false);
+});
+
+test("principalContext — passes allowedTools through; empty array → undefined", () => {
+  const ctx1 = principalContext("agent", undefined, { allowedTools: ["query_logs"] });
+  assert.deepEqual(ctx1.allowedTools, ["query_logs"]);
+  // Empty array carries the "no restriction" semantic — we normalise
+  // to undefined so allowsTool() takes the back-compat short path.
+  const ctx2 = principalContext("agent", undefined, { allowedTools: [] });
+  assert.equal(ctx2.allowedTools, undefined);
+  const ctx3 = principalContext("agent");
+  assert.equal(ctx3.allowedTools, undefined);
+});
+
+test("defaultContext — no allowedTools (anonymous sees every tool, back-compat)", () => {
+  const ctx = defaultContext();
+  assert.equal(ctx.allowedTools, undefined);
+  assert.equal(allowsTool(ctx.allowedTools, "any_tool"), true);
+});

--- a/mcp-server/src/context.ts
+++ b/mcp-server/src/context.ts
@@ -31,6 +31,12 @@ export interface RequestContext {
    *  "default" for anonymous principals + missing-tenant credentials,
    *  preserving the single-namespace behaviour of pre-E7 deployments. */
   tenant: string;
+  /** When set, the /mcp tools/list response is filtered to this
+   *  allow-list. Resolved from the active credential's bound Product
+   *  (OMCP_KEY_PRODUCTS) against the catalogue at request entry.
+   *  Anonymous + Product-less credentials leave this unset and see
+   *  every registered tool. */
+  allowedTools?: string[];
   /** Correlates all tool calls within one transport request/session. */
   correlationId: string;
 }
@@ -49,7 +55,7 @@ export function defaultContext(): RequestContext {
 export function principalContext(
   principalId: string,
   allowedSources?: string[],
-  opts: { allowBypassRedaction?: boolean; tenant?: string } = {},
+  opts: { allowBypassRedaction?: boolean; tenant?: string; allowedTools?: string[] } = {},
 ): RequestContext {
   return {
     principalId,
@@ -57,6 +63,25 @@ export function principalContext(
     allowedSources: allowedSources && allowedSources.length > 0 ? allowedSources : undefined,
     allowBypassRedaction: opts.allowBypassRedaction || undefined,
     tenant: normaliseTenant(opts.tenant),
+    allowedTools: opts.allowedTools && opts.allowedTools.length > 0 ? opts.allowedTools : undefined,
     correlationId: randomUUID(),
   };
+}
+
+/** Decide whether a given tool name is accessible under the active
+ *  Product binding. Pure helper so the registration site stays
+ *  declarative and the filtering policy is unit-testable in isolation.
+ *
+ *  Semantics:
+ *    - undefined allow-list → no Product binding, every tool allowed
+ *      (anonymous + Product-less credentials — back-compat).
+ *    - empty allow-list → a Product with no `tools` field. The schema
+ *      treats this as "all tools allowed", matching the YAML loader's
+ *      view that an absent / empty list means no restriction.
+ *    - non-empty → the named tool must appear verbatim.
+ *  Tool names are compared case-sensitively; the MCP spec is
+ *  case-sensitive on `name`. */
+export function allowsTool(allowedTools: string[] | undefined, toolName: string): boolean {
+  if (!allowedTools || allowedTools.length === 0) return true;
+  return allowedTools.includes(toolName);
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { loadConfig, saveConfig, DEFAULT_HEALTH_THRESHOLDS, DEFAULT_SETTINGS } from "./config/loader.js";
 import { ConnectorRegistry, getSupportedTypes } from "./connectors/registry.js";
 import { isTopologyProvider } from "./connectors/interface.js";
-import { defaultContext, principalContext, type RequestContext } from "./context.js";
+import { defaultContext, principalContext, allowsTool, type RequestContext } from "./context.js";
 import {
   enforceEntitledAccess,
   enterpriseGateStatus,
@@ -368,8 +368,18 @@ async function main() {
     });
 
   // --- Register tools with Zod schemas ---
+  // Product-aware registration: when the active credential is bound
+  // to a Product (OMCP_KEY_PRODUCTS), `ctx.allowedTools` carries that
+  // Product's `tools` allow-list and we skip the registration of any
+  // tool not in it. Anonymous + Product-less sessions leave
+  // allowedTools undefined and see every tool — the bypass is the
+  // back-compat path the open-source default relies on.
+  const registerTool = ((name: string, ...rest: unknown[]) => {
+    if (!allowsTool(ctx.allowedTools, name)) return undefined as never;
+    return (mcpServer.tool as unknown as (...a: unknown[]) => unknown)(name, ...rest) as never;
+  }) as typeof mcpServer.tool;
 
-  mcpServer.tool(
+  registerTool(
     "list_sources",
     [
       "List the configured observability backends (Prometheus, Loki, and any connector) and whether each is currently reachable.",
@@ -384,7 +394,7 @@ async function main() {
     }
   );
 
-  mcpServer.tool(
+  registerTool(
     "list_services",
     [
       "Discover the service names that can be queried, aggregated across every connected backend.",
@@ -411,7 +421,7 @@ async function main() {
   const metricNames = registry.getBySignal("metrics").flatMap(c => c.getMetrics().map(m => m.name));
   const uniqueNames = [...new Set(metricNames)];
 
-  mcpServer.tool(
+  registerTool(
     "query_metrics",
     [
       "Fetch the raw time-series for ONE metric of ONE service over a look-back window, returned together with pre-computed summary statistics.",
@@ -457,7 +467,7 @@ async function main() {
     }
   );
 
-  mcpServer.tool(
+  registerTool(
     "query_logs",
     [
       "Fetch recent log entries for ONE service over a look-back window, with a pre-computed summary (error/warning counts and the most frequent error patterns).",
@@ -545,7 +555,7 @@ async function main() {
     }
   );
 
-  mcpServer.tool(
+  registerTool(
     "get_service_health",
     [
       "Produce a single aggregated health verdict for ONE service by combining its metrics and logs.",
@@ -568,7 +578,7 @@ async function main() {
     }
   );
 
-  mcpServer.tool(
+  registerTool(
     "detect_anomalies",
     [
       "Scan one or all monitored services for abnormal behavior and return the findings ranked by severity.",
@@ -602,7 +612,7 @@ async function main() {
     }
   );
 
-  mcpServer.tool(
+  registerTool(
     "get_topology",
     [
       "Return the infrastructure topology graph (Resources and Edges) from every topology-capable connector.",
@@ -645,7 +655,7 @@ async function main() {
     }
   );
 
-  mcpServer.tool(
+  registerTool(
     "get_blast_radius",
     [
       "Given a resource, return who else fails if its underlying host(s) fail.",
@@ -2011,10 +2021,10 @@ async function main() {
 
   // Bearer/X-API-Key on every /mcp request; resolve the principal + its
   // coarse source allow-list into the RequestContext.
-  function gateCtx(
+  async function gateCtx(
     req: import("express").Request,
     res: import("express").Response
-  ): RequestContext | null {
+  ): Promise<RequestContext | null> {
     if (!credentialsConfigured()) return defaultContext();
     const cred = resolveToken(
       extractToken(req.headers as Record<string, unknown>),
@@ -2047,14 +2057,33 @@ async function main() {
       });
       return null;
     }
+    // Resolve the credential's bound Product (OMCP_KEY_PRODUCTS) into
+    // a concrete tools allow-list. Cross-tenant Products are invisible
+    // — products.get() returns undefined when the productId belongs to
+    // another tenant, mirroring the rest of the tenancy layer. A bound
+    // Product whose own `tools` field is absent / empty leaves the
+    // allow-list undefined (== unrestricted), matching the YAML
+    // loader's "no tools key = no restriction" semantics.
+    let allowedTools: string[] | undefined;
+    if (cred.productId) {
+      // Pick up out-of-band edits to OMCP_PRODUCTS_FILE before each
+      // /mcp request — cheap (one stat), keeps the binding live.
+      // Best-effort: if the catalogue reload fails we keep the prior
+      // good state (the store handles that internally) rather than
+      // failing the request.
+      await products.maybeReload().catch(() => undefined);
+      const p = products.get(cred.productId, credTenant);
+      if (p && p.tools && p.tools.length > 0) allowedTools = p.tools.slice();
+    }
     return principalContext(cred.name, cred.allowedSources, {
       allowBypassRedaction: cred.bypassRedaction,
       tenant: cred.tenant,
+      allowedTools,
     });
   }
 
   app.post("/mcp", async (req, res) => {
-    const ctx = gateCtx(req, res);
+    const ctx = await gateCtx(req, res);
     if (!ctx) return;
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
     let transport: StreamableHTTPServerTransport;
@@ -2090,7 +2119,7 @@ async function main() {
   });
 
   app.get("/mcp", async (req, res) => {
-    if (!gateCtx(req, res)) return;
+    if (!(await gateCtx(req, res))) return;
     const sessionId = req.headers["mcp-session-id"] as string;
     const transport = transports.get(sessionId);
     if (!transport) {
@@ -2101,7 +2130,7 @@ async function main() {
   });
 
   app.delete("/mcp", async (req, res) => {
-    if (!gateCtx(req, res)) return;
+    if (!(await gateCtx(req, res))) return;
     const sessionId = req.headers["mcp-session-id"] as string;
     const transport = transports.get(sessionId);
     if (transport) {


### PR DESCRIPTION
## Summary

- Bind a named bearer credential to an MCP Product so its \`/mcp\` session only sees the tools the Product allows
- New env: \`OMCP_KEY_PRODUCTS=\"agent=ops-bundle;ci=dev-bundle\"\`
- \`RequestContext.allowedTools\` populated via \`products.get(productId, credTenant)\` — cross-tenant Products return undefined, no leak
- \`registerTool(...)\` wrapper short-circuits registration when the active session isn't allowed the tool
- Hot-reload aware: out-of-band catalogue edits take effect on the next /mcp session
- Anonymous + Product-less credentials see every tool (back-compat with open-source default)

## Why

Closes the \"future header / arg, slice 2+\" gap from docs/products.md. Operators can now ship governed tool bundles per agent.

## Test plan

- [x] 7 new tests (allowsTool semantics, principalContext normalisation, OMCP_KEY_PRODUCTS parser, malformed-entry skip)
- [x] 52/52 targeted tests pass (context, credentials, products, opa)
- [x] tsc clean
- [x] Reviewer-agent: clean (registerTool cast is localized & type-safe at call sites; cross-tenant lookup holds)
- [x] Pre-existing prometheus.test.ts failure on main is unrelated (confirmed via git stash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)