### PR TITLE
refactor(quota): extract token-budget charge helper + pin distinct error codes

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -67,6 +67,7 @@ import { readProductsFile, ProductsStore, validateProduct, writeProductsFile, Pr
 import { redactValue } from "./policy/redact.js";
 import { IdentityRateLimiter, resolveToolRatePerMin } from "./quota/limiter.js";
 import { TokenBudget, estimateTokensFor, resolveDailyTokenLimit } from "./quota/token-budget.js";
+import { applyBudgetDecision } from "./quota/charge.js";
 import { getPluginLoader } from "./connectors/loader.js";
 import {
   resolveHubCatalogUrl,
@@ -296,36 +297,7 @@ async function main() {
     const text = result.content[0]?.text ?? "";
     const tokens = estimateTokensFor(text);
     const decision = tokenBudget.check(identityKey(ctx), tokens);
-    if (decision.allowed || decision.limit === 0) return result;
-    // A single request larger than the entire daily cap can never
-    // succeed by waiting — surface a distinct error code so the
-    // agent doesn't loop. Otherwise the wait-then-retry path is the
-    // right answer (and freedAtRetry tells the agent how much they
-    // can request after the wait).
-    const requestExceedsCap = tokens > decision.limit;
-    const errBody = {
-      error: requestExceedsCap ? "OMCP_TOKEN_REQUEST_EXCEEDS_BUDGET" : "OMCP_TOKEN_BUDGET_EXCEEDED",
-      tool: toolName,
-      used: decision.used,
-      limit: decision.limit,
-      requested: tokens,
-      retryAfterSeconds: requestExceedsCap ? 0 : decision.retryAfterSeconds,
-      freedAtRetry: decision.freedAtRetry,
-      message: requestExceedsCap
-        ? `This single response (~${tokens} tokens) is larger than the entire daily budget (${decision.limit}). Retrying won't help — narrow the query (smaller window / lower limit / more selective filter) or raise OMCP_TOOL_DAILY_TOKENS.`
-        : `Daily token budget exceeded (${decision.used}/${decision.limit} tokens used in the trailing 24h; this call would have added ~${tokens}). Try again in ~${Math.ceil(decision.retryAfterSeconds / 3600)}h or raise OMCP_TOOL_DAILY_TOKENS.`,
-    };
-    // Preserve any additional content entries (e.g. a future
-    // tool returning [text, image]) — only the text payload of the
-    // first entry is replaced with the error JSON; everything after
-    // it passes through.
-    return {
-      ...result,
-      content: [
-        { ...result.content[0], text: JSON.stringify(errBody) },
-        ...result.content.slice(1),
-      ],
-    } as T;
+    return applyBudgetDecision(result, decision, tokens, toolName);
   }
 
   const REDACTION_ENABLED = String(process.env.OMCP_REDACTION ?? "on").toLowerCase() !== "off";

--- a/mcp-server/src/quota/charge.test.ts
+++ b/mcp-server/src/quota/charge.test.ts
@@ -1,0 +1,107 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { applyBudgetDecision } from "./charge.js";
+import type { CheckResult } from "./token-budget.js";
+
+function decision(over: Partial<CheckResult>): CheckResult {
+  return {
+    allowed: false,
+    used: 0,
+    limit: 1000,
+    retryAfterSeconds: 3600,
+    freedAtRetry: 100,
+    ...over,
+  };
+}
+
+const sampleResult = () => ({ content: [{ text: "original tool output" }] });
+
+test("applyBudgetDecision — passes the result through when allowed", () => {
+  const r = sampleResult();
+  const out = applyBudgetDecision(r, decision({ allowed: true }), 50, "query_logs");
+  assert.equal(out, r, "exact passthrough when allowed");
+});
+
+test("applyBudgetDecision — passes through when uncapped (limit === 0)", () => {
+  const r = sampleResult();
+  const out = applyBudgetDecision(r, decision({ allowed: false, limit: 0 }), 50_000, "query_logs");
+  assert.equal(out.content[0].text, "original tool output");
+});
+
+test("applyBudgetDecision — cumulative exceed emits OMCP_TOKEN_BUDGET_EXCEEDED", () => {
+  // Tokens fit a single request (<= limit) but cumulative pushes over.
+  const r = sampleResult();
+  const out = applyBudgetDecision(
+    r,
+    decision({ used: 950, limit: 1000, retryAfterSeconds: 7200, freedAtRetry: 200 }),
+    100,
+    "query_logs",
+  );
+  const body = JSON.parse(out.content[0].text);
+  assert.equal(body.error, "OMCP_TOKEN_BUDGET_EXCEEDED");
+  assert.equal(body.tool, "query_logs");
+  assert.equal(body.used, 950);
+  assert.equal(body.limit, 1000);
+  assert.equal(body.requested, 100);
+  assert.equal(body.retryAfterSeconds, 7200);
+  assert.equal(body.freedAtRetry, 200);
+  assert.match(body.message, /Daily token budget exceeded/);
+  assert.match(body.message, /Try again in ~2h/);
+});
+
+test("applyBudgetDecision — single request > limit emits the DISTINCT OMCP_TOKEN_REQUEST_EXCEEDS_BUDGET", () => {
+  // The whole point of the distinct code: an agent that sees this
+  // must NOT retry — waiting can never fit a request larger than the
+  // entire daily cap. retryAfterSeconds is forced to 0 so naive
+  // backoff loops terminate.
+  const r = sampleResult();
+  const out = applyBudgetDecision(
+    r,
+    decision({ used: 0, limit: 1000, retryAfterSeconds: 3600, freedAtRetry: 0 }),
+    5000, // request > limit
+    "query_metrics",
+  );
+  const body = JSON.parse(out.content[0].text);
+  assert.equal(body.error, "OMCP_TOKEN_REQUEST_EXCEEDS_BUDGET");
+  assert.equal(body.tool, "query_metrics");
+  assert.equal(body.requested, 5000);
+  assert.equal(body.limit, 1000);
+  assert.equal(body.retryAfterSeconds, 0, "retry-loop killer: 0 instead of inherited 3600");
+  assert.match(body.message, /larger than the entire daily budget/);
+  assert.match(body.message, /Retrying won't help/);
+});
+
+test("applyBudgetDecision — boundary: request == limit is NOT the request-exceeds-cap code", () => {
+  // A request exactly equal to the cap can theoretically succeed on
+  // an empty bucket — it's the cumulative-exceeded path, not the
+  // unconditional-deny path.
+  const r = sampleResult();
+  const out = applyBudgetDecision(
+    r,
+    decision({ used: 100, limit: 1000 }),
+    1000,
+    "query_logs",
+  );
+  const body = JSON.parse(out.content[0].text);
+  assert.equal(body.error, "OMCP_TOKEN_BUDGET_EXCEEDED");
+});
+
+test("applyBudgetDecision — preserves additional content entries past the first", () => {
+  const r = {
+    content: [
+      { text: "first", extraField: 42 },
+      { text: "second" },
+      { text: "third" },
+    ],
+  };
+  const out = applyBudgetDecision(r, decision({}), 10, "t");
+  assert.equal(out.content.length, 3);
+  // First entry's text replaced; its other fields (extraField) preserved.
+  const body = JSON.parse(out.content[0].text);
+  assert.equal(body.error, "OMCP_TOKEN_BUDGET_EXCEEDED");
+  assert.equal((out.content[0] as { extraField: number }).extraField, 42);
+  // Trailing entries pass through verbatim.
+  assert.equal(out.content[1].text, "second");
+  assert.equal(out.content[2].text, "third");
+});

--- a/mcp-server/src/quota/charge.ts
+++ b/mcp-server/src/quota/charge.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure helper that turns a TokenBudget decision into either the
+ * original tool result (when allowed / uncapped) or a structured
+ * error payload distinguishing the two budget-denial cases:
+ *
+ *   - OMCP_TOKEN_BUDGET_EXCEEDED         — cumulative trailing-24h
+ *     usage would push the principal past its cap. Waiting helps;
+ *     `retryAfterSeconds` says how long until enough buckets drop
+ *     off to fit the request.
+ *
+ *   - OMCP_TOKEN_REQUEST_EXCEEDS_BUDGET  — this single response is
+ *     larger than the entire daily cap. Waiting does NOT help — the
+ *     agent must narrow the query or the operator must raise the
+ *     cap. `retryAfterSeconds` is 0 here so retry-with-backoff loops
+ *     terminate instead of churning.
+ *
+ * Extracted from the createMcpServer closure in index.ts purely for
+ * unit-testability. Behaviour is identical to the previous inline
+ * version.
+ */
+import type { CheckResult } from "./token-budget.js";
+
+export interface ToolResult {
+  content: Array<{ text: string; [k: string]: unknown }>;
+}
+
+export function applyBudgetDecision<T extends ToolResult>(
+  result: T,
+  decision: CheckResult,
+  tokens: number,
+  toolName: string,
+): T {
+  if (decision.allowed || decision.limit === 0) return result;
+  // A request larger than the entire daily cap can never succeed by
+  // waiting — distinct error code so the agent doesn't spin.
+  const requestExceedsCap = tokens > decision.limit;
+  const errBody = {
+    error: requestExceedsCap ? "OMCP_TOKEN_REQUEST_EXCEEDS_BUDGET" : "OMCP_TOKEN_BUDGET_EXCEEDED",
+    tool: toolName,
+    used: decision.used,
+    limit: decision.limit,
+    requested: tokens,
+    retryAfterSeconds: requestExceedsCap ? 0 : decision.retryAfterSeconds,
+    freedAtRetry: decision.freedAtRetry,
+    message: requestExceedsCap
+      ? `This single response (~${tokens} tokens) is larger than the entire daily budget (${decision.limit}). Retrying won't help — narrow the query (smaller window / lower limit / more selective filter) or raise OMCP_TOOL_DAILY_TOKENS.`
+      : `Daily token budget exceeded (${decision.used}/${decision.limit} tokens used in the trailing 24h; this call would have added ~${tokens}). Try again in ~${Math.ceil(decision.retryAfterSeconds / 3600)}h or raise OMCP_TOOL_DAILY_TOKENS.`,
+  };
+  // Preserve any additional content entries (e.g. a future tool
+  // returning [text, image]) — only the text payload of the first
+  // entry is replaced with the error JSON; everything after passes
+  // through unchanged.
+  return {
+    ...result,
+    content: [
+      { ...result.content[0], text: JSON.stringify(errBody) },
+      ...result.content.slice(1),
+    ],
+  } as T;
+}


### PR DESCRIPTION
## Summary

- Extract \`chargeTokenBudget\`'s payload-shaping logic into a pure helper \`applyBudgetDecision(result, decision, tokens, toolName)\` in \`src/quota/charge.ts\`
- 6 new tests pin the **two distinct error-code paths**:
  - \`OMCP_TOKEN_BUDGET_EXCEEDED\` — cumulative exceed, retry helps
  - \`OMCP_TOKEN_REQUEST_EXCEEDS_BUDGET\` — single request > limit, \`retryAfterSeconds\` forced to **0** so naive retry loops terminate
- Boundary: request == limit takes the cumulative path; allowed / uncapped passes through; \`content[N>0]\` entries preserved verbatim

## Why

The helper was a closure inside \`createMcpServer\` with no unit coverage. The distinct request-exceeds-cap code is a real terminal-state signal to the agent — accidentally regressing it to the generic budget-exceeded code would cause infinite retry storms.

## Test plan

- [x] 6 new tests
- [x] 546/546 full suite green
- [x] tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)