### PR TITLE
feat(release): per-platform Syft SBOMs (amd64 + arm64), attested per-digest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -241,28 +241,69 @@ jobs:
         # Pin label corrected by reviewer: this SHA is the
         # anchore/sbom-action v0.20.4 release.
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-      - name: Generate SBOMs (Syft)
-        # Note: Syft handed a manifest-list digest defaults to the
-        # host runner's platform (linux/amd64 on GitHub-hosted
-        # runners). The arm64 variant of the image is covered by
-        # the buildx-embedded SBOM only; doing a second per-platform
-        # Syft pass is tracked as an E9 follow-up.
+      - name: Generate per-platform SBOMs (Syft)
+        # Per-platform pass: Syft handed a manifest-list digest defaults
+        # to the host runner's platform (linux/amd64 on GitHub-hosted
+        # runners). To produce a true SBOM for the arm64 variant we
+        # enumerate the manifest-list, look up each platform's
+        # per-platform digest, and scan with --platform so Syft pulls
+        # the correct layer set. Output files are suffixed with the
+        # platform pair (e.g. -amd64, -arm64) so downstream consumers
+        # can pick the SBOM matching the arch they actually run.
         run: |
-          syft "${{ env.REGISTRY }}/${{ steps.image.outputs.lower }}@${{ steps.inspect.outputs.digest }}" \
-            -o cyclonedx-json=image-sbom.cdx.json \
-            -o spdx-json=image-sbom.spdx.json
-      - name: Attest SBOM to the image (cosign attestation)
+          set -euo pipefail
+          IMAGE="${{ env.REGISTRY }}/${{ steps.image.outputs.lower }}"
+          LIST_DIGEST="${{ steps.inspect.outputs.digest }}"
+          # `imagetools inspect --raw` returns the OCI image-index JSON
+          # of the manifest list — one `manifests[]` entry per platform
+          # with the per-platform digest plus its os/architecture.
+          MANIFEST_JSON="$(docker buildx imagetools inspect --raw "${IMAGE}@${LIST_DIGEST}")"
+          # Track per-platform digests in a side file so the attest
+          # step (next) can iterate without re-running inspect.
+          : > /tmp/sbom-platforms.tsv
+          echo "$MANIFEST_JSON" | jq -r '
+            .manifests[]
+            | select(.platform.os == "linux")
+            | select(.platform.architecture == "amd64" or .platform.architecture == "arm64")
+            | [.platform.architecture, .digest] | @tsv' \
+            | tee /tmp/sbom-platforms.tsv
+          if ! [ -s /tmp/sbom-platforms.tsv ]; then
+            echo "no per-platform manifests found in $IMAGE@$LIST_DIGEST" >&2
+            exit 1
+          fi
+          while IFS=$'\t' read -r ARCH DIGEST; do
+            echo "scanning ${ARCH} variant @ ${DIGEST}"
+            # --platform tells Syft to follow the named entry in the
+            # index instead of defaulting to the runner's arch. The
+            # digest in the URL still resolves the manifest list; the
+            # flag selects the variant.
+            syft "${IMAGE}@${DIGEST}" --platform "linux/${ARCH}" \
+              -o cyclonedx-json="image-sbom-${ARCH}.cdx.json" \
+              -o spdx-json="image-sbom-${ARCH}.spdx.json"
+          done < /tmp/sbom-platforms.tsv
+      - name: Attest per-platform SBOMs (cosign attestation)
         run: |
-          cosign attest --yes --predicate image-sbom.cdx.json --type cyclonedx \
-            "${{ env.REGISTRY }}/${{ steps.image.outputs.lower }}@${{ steps.inspect.outputs.digest }}"
-          cosign attest --yes --predicate image-sbom.spdx.json --type spdxjson \
-            "${{ env.REGISTRY }}/${{ steps.image.outputs.lower }}@${{ steps.inspect.outputs.digest }}"
-      - name: Upload SBOM as workflow artifact
+          set -euo pipefail
+          IMAGE="${{ env.REGISTRY }}/${{ steps.image.outputs.lower }}"
+          # Attest each SBOM against its OWN per-platform digest, not
+          # the manifest-list digest — that way `cosign verify-
+          # attestation --platform linux/arm64` against the user-facing
+          # tag resolves to the right predicate, instead of a single
+          # SBOM bound to the index hash.
+          while IFS=$'\t' read -r ARCH DIGEST; do
+            cosign attest --yes --predicate "image-sbom-${ARCH}.cdx.json" --type cyclonedx \
+              "${IMAGE}@${DIGEST}"
+            cosign attest --yes --predicate "image-sbom-${ARCH}.spdx.json" --type spdxjson \
+              "${IMAGE}@${DIGEST}"
+          done < /tmp/sbom-platforms.tsv
+      - name: Upload per-platform SBOMs as workflow artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: image-sbom-${{ steps.meta.outputs.version }}
           path: |
-            image-sbom.cdx.json
-            image-sbom.spdx.json
+            image-sbom-amd64.cdx.json
+            image-sbom-amd64.spdx.json
+            image-sbom-arm64.cdx.json
+            image-sbom-arm64.spdx.json
           if-no-files-found: error
           retention-days: 90

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -108,16 +108,26 @@ cosign verify \
 ```
 
 **SBOM attestations.** CycloneDX-JSON + SPDX-JSON SBOMs (Syft-generated, in
-addition to the buildx-embedded SBOM) are attached as cosign attestations.
-Fetch + verify either format:
+addition to the buildx-embedded SBOM) are attached as cosign attestations,
+**per platform** — one CycloneDX + one SPDX predicate is bound to each
+per-platform digest in the manifest list. Resolve the platform digest
+first, then verify:
 
 ```bash
+IMAGE=ghcr.io/thotischner/observability-mcp:latest
+
+# Pick the platform you actually run (linux/amd64 or linux/arm64).
+PLATFORM=linux/amd64
+PER_PLATFORM_DIGEST=$(docker buildx imagetools inspect --raw "$IMAGE" \
+  | jq -r --arg p "$PLATFORM" '
+      .manifests[] | select((.platform.os + "/" + .platform.architecture) == $p) | .digest')
+
 # CycloneDX
 cosign verify-attestation \
   --type cyclonedx \
   --certificate-identity-regexp "^https://github\.com/ThoTischner/observability-mcp/\.github/workflows/docker-publish\.yml@refs/" \
   --certificate-oidc-issuer    "https://token.actions.githubusercontent.com" \
-  ghcr.io/thotischner/observability-mcp:latest \
+  "ghcr.io/thotischner/observability-mcp@${PER_PLATFORM_DIGEST}" \
   | jq -r '.payload | @base64d | fromjson | .predicate' > image-sbom.cdx.json
 
 # SPDX
@@ -125,14 +135,16 @@ cosign verify-attestation \
   --type spdxjson \
   --certificate-identity-regexp "^https://github\.com/ThoTischner/observability-mcp/\.github/workflows/docker-publish\.yml@refs/" \
   --certificate-oidc-issuer    "https://token.actions.githubusercontent.com" \
-  ghcr.io/thotischner/observability-mcp:latest \
+  "ghcr.io/thotischner/observability-mcp@${PER_PLATFORM_DIGEST}" \
   | jq -r '.payload | @base64d | fromjson | .predicate' > image-sbom.spdx.json
 ```
 
-> The Syft SBOMs cover the `linux/amd64` variant (GitHub-runner host
-> platform). The `linux/arm64` variant is covered by buildx's
-> embedded SBOM only; a second per-platform Syft attestation is a
-> tracked E9 follow-up.
+> Per-platform coverage: Syft scans both the amd64 and arm64 variants
+> on the amd64 runner via the `--platform` flag (it pulls the right
+> layer set from the manifest list) and attaches the resulting SBOMs
+> as cosign attestations on the matching per-platform digest. The
+> buildx-embedded SBOM remains as well, for tools that read attached
+> SBOMs from the image directly.
 
 The raw SBOM files are also uploaded as workflow artifacts on each release
 (90-day retention), so an air-gapped operator can pull them from the


### PR DESCRIPTION
## Summary

Closes the explicit \`E9 follow-up\` TODO in the docker-publish workflow. Both \`linux/amd64\` and \`linux/arm64\` variants now get a Syft-generated CycloneDX-JSON + SPDX-JSON SBOM, attested via cosign to **their own per-platform digest** (not the manifest-list digest).

## Implementation

- Parse \`docker buildx imagetools inspect --raw\` to enumerate per-platform digests
- \`syft <image>@<per-platform-digest> --platform linux/<arch>\` for each
- cosign-attest each predicate against the matching per-platform digest
- Upload 4 SBOM files as workflow artifact (cdx + spdx × amd64 + arm64)
- SECURITY.md updated: shows how to resolve the per-platform digest from the manifest list before verifying

## Why per-platform-digest attestations

If you attest twice (amd64 + arm64) against the same manifest-list digest, downstream \`cosign verify-attestation --platform linux/arm64 <tag>\` doesn't know which predicate is which. Binding each predicate to its per-platform digest is the spec-compliant resolution path.

## Test plan

- [x] YAML parses cleanly
- [x] Reviewer-agent: clean (jq query correct, /tmp preserved across steps, \`set -euo pipefail\` guards empty manifest list)
- [x] Unused \`id: sbom\` removed
- [x] No sensitive data (only public ghcr URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)