### PR TITLE
feat(release): cosign-signed OCI Helm chart variant

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -34,6 +34,13 @@ jobs:
     permissions:
       contents: write
       pages: write
+      # Required for the OCI publish step: helm push goes to ghcr.io,
+      # cosign keyless attest pushes the signature into the same OCI
+      # registry alongside the chart artifact.
+      packages: write
+      # Keyless cosign needs OIDC to exchange a short-lived token with
+      # Sigstore Fulcio — same pattern as docker-publish.yml.
+      id-token: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -123,6 +130,55 @@ jobs:
           config: /tmp/cr.yaml
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Parallel OCI publish (ghcr.io) + keyless cosign signing.
+      # chart-releaser writes the packaged tarball to .cr-release-packages/
+      # (one .tgz per chart version it just released). If that directory
+      # is empty — e.g. skip_existing skipped the only chart this run —
+      # the OCI publish is a no-op so a re-run that publishes nothing
+      # new doesn't error out.
+      - name: Lowercase OCI repo path
+        id: oci
+        run: |
+          echo "repo=ghcr.io/$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')/charts" >> "$GITHUB_OUTPUT"
+      - name: Log in to GHCR (helm OCI)
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
+            -u "${{ github.actor }}" --password-stdin
+      - name: Install cosign
+        # Pin matches docker-publish.yml — sigstore/cosign-installer v4.1.2.
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Publish chart to OCI + sign with cosign (keyless)
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          pkgs=(.cr-release-packages/*.tgz)
+          if [ ${#pkgs[@]} -eq 0 ]; then
+            echo "::notice::no chart tarballs in .cr-release-packages — nothing to push to OCI"
+            exit 0
+          fi
+          REPO="${{ steps.oci.outputs.repo }}"
+          for tgz in "${pkgs[@]}"; do
+            # `helm push` emits "Pushed: <repo>/<name>:<version>" and
+            # "Digest: sha256:..." on stdout. We capture both — the
+            # digest is what cosign signs (signing the tag would race
+            # an unrelated push to the same tag, the digest is stable).
+            out="$(helm push "$tgz" "oci://${REPO}" 2>&1 | tee /dev/stderr)"
+            ref="$(echo "$out" | awk '/^Pushed:/ {print $2; exit}')"
+            digest="$(echo "$out" | awk '/^Digest:/ {print $2; exit}')"
+            if [ -z "$ref" ] || [ -z "$digest" ]; then
+              echo "could not parse helm push output for $tgz" >&2
+              exit 1
+            fi
+            # Drop the :tag from the ref so we sign by digest, which is
+            # the recommended cosign pattern for OCI artifacts.
+            repo_only="${ref%:*}"
+            echo "signing ${repo_only}@${digest}"
+            cosign sign --yes "${repo_only}@${digest}"
+          done
+      - name: Log out of GHCR
+        if: always()
+        run: helm registry logout ghcr.io || true
 
       - name: Wipe signing material
         if: always()

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -162,26 +162,39 @@ cosign verify-attestation \
   ghcr.io/thotischner/observability-mcp:latest
 ```
 
-### Helm chart — GPG-signed
+### Helm chart — GPG-signed (HTTP) + cosign-signed (OCI)
 
-The Helm chart is GPG-signed; the public key is committed at
-[`docs/helm-signing.pub.asc`](docs/helm-signing.pub.asc) and the fingerprint
-is advertised on ArtifactHub via the `artifacthub.io/signKey` annotation.
+The chart is published **twice** on every release: the GPG-signed
+tarball lives on the GitHub Pages chart repo (the path the
+`helm repo add` command targets), and the same chart is pushed to
+GHCR as an OCI artifact and signed with cosign keyless. Either path is
+authoritative; pick whichever fits the consumer's posture.
+
+**GPG path (default `helm repo add`).** Public key committed at
+[`docs/helm-signing.pub.asc`](docs/helm-signing.pub.asc); fingerprint
+also advertised on ArtifactHub via `artifacthub.io/signKey`.
 
 ```bash
-# Add the signing key to your keyring
 curl -sS https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc \
   | gpg --import
-
-# Verify the .tgz + .prov pair before installing
 helm verify ./observability-mcp-<version>.tgz
 ```
 
-> **Roadmap.** A cosign-signed OCI chart variant is on the deferred
-> list — once the chart is also pushed as an OCI artifact to GHCR
-> via `helm push`, the same `cosign verify --certificate-identity-…`
-> pattern that covers the image will apply to the chart. Until then,
-> the GPG signature above is the authoritative verification path.
+**OCI / cosign path.** The chart is pushed to
+`oci://ghcr.io/thotischner/charts/observability-mcp` and each version
+is cosign-signed by digest via Sigstore keyless OIDC. No GPG keyring
+required on the consumer side:
+
+```bash
+# Pull (or install directly from OCI):
+helm pull oci://ghcr.io/thotischner/charts/observability-mcp --version <version>
+
+# Verify the cosign signature against the GitHub Actions workflow identity:
+cosign verify \
+  --certificate-identity-regexp "^https://github\.com/ThoTischner/observability-mcp/\.github/workflows/helm-release\.yml@refs/" \
+  --certificate-oidc-issuer    "https://token.actions.githubusercontent.com" \
+  ghcr.io/thotischner/charts/observability-mcp:<version>
+```
 
 ### MCP tool surface — `tools/list` is the contract
 


### PR DESCRIPTION
## Summary

Closes the explicit \"Roadmap: cosign-signed OCI chart variant\" TODO in SECURITY.md.

The chart is now published twice on every release:
- **GPG-signed tarball** on the GitHub Pages chart repo (unchanged — the path \`helm repo add\` targets)
- **OCI artifact** at \`oci://ghcr.io/<owner>/charts/observability-mcp\`, cosign-signed keyless via Sigstore OIDC

Same workflow-identity verification pattern that covers the container image. Either distribution path is authoritative; consumers pick whichever fits their posture.

## Implementation

- \`packages: write\` + \`id-token: write\` added to the release job
- After chart-releaser: glob \`.cr-release-packages/*.tgz\` (empty = clean no-op)
- \`helm registry login ghcr.io\` with GITHUB_TOKEN
- \`helm push <tgz> oci://<repo>\`, parse \`Pushed:\` ref + \`Digest:\` from merged output
- \`cosign sign --yes <repo>@<digest>\` — sign by digest, not tag (race-safe)
- \`helm registry logout\` in always() guard

## SECURITY.md

Replaces the deferred-follow-up blurb with a working verification snippet against the workflow-identity regex.

## Test plan

- [x] YAML parses cleanly
- [x] Reviewer-agent: clean (empty-dir handled, owner lowercased, sign-by-digest correct, logout guarded)
- [x] cosign-installer pin matches docker-publish.yml (v4.1.2)
- [x] No sensitive data

🤖 Generated with [Claude Code](https://claude.com/claude-code)