### PR TITLE
refactor(rbac): gate via PolicyEngine.evaluate so tenant flows to OPA Rego rules

### DIFF
--- a/mcp-server/src/auth/rbac.test.ts
+++ b/mcp-server/src/auth/rbac.test.ts
@@ -142,3 +142,72 @@ test("DEFAULT_POLICY shape — has the three built-in roles", () => {
   assert.ok(DEFAULT_POLICY.operator);
   assert.ok(DEFAULT_POLICY.admin);
 });
+
+import { buildRequirePermissionFromEngine } from "./rbac.js";
+import { BuiltinPolicyEngine } from "./policy/engine.js";
+import type { EvalContext, EvalResult } from "./policy/engine.js";
+import type { Resource, Action } from "./rbac.js";
+
+test("buildRequirePermissionFromEngine — anonymous always allows (no-op middleware)", () => {
+  const engine = new BuiltinPolicyEngine(DEFAULT_POLICY);
+  const mw = buildRequirePermissionFromEngine({ mode: "anonymous" } as AuthRuntime, "sources", "write", engine);
+  const res = mkRes() as ReturnType<typeof mkRes>;
+  let called = false;
+  mw(mkReq(), res as unknown as import("express").Response, () => { called = true; });
+  assert.equal(called, true);
+  assert.equal(res.statusCode, 0);
+});
+
+test("buildRequirePermissionFromEngine — engine.evaluate verdict is surfaced verbatim in the 403 body", () => {
+  // Spy engine returns a custom reason so we can prove the gate forwards it.
+  const engine = {
+    evaluate: () => ({ allowed: false, reason: "test deny reason from engine" } as EvalResult),
+    list: () => [],
+    roles: () => [],
+    kind: () => "test",
+  };
+  const runtime = { mode: "basic", session: { secret: "x".repeat(48) } } as AuthRuntime;
+  const mw = buildRequirePermissionFromEngine(runtime, "sources", "write", engine);
+  const res = mkRes() as ReturnType<typeof mkRes>;
+  mw(mkReq(["viewer"]), res as unknown as import("express").Response, () => undefined);
+  assert.equal(res.statusCode, 403);
+  const body = res.body as Record<string, unknown>;
+  assert.equal(body.code, "OMCP_PERMISSION_DENIED");
+  assert.equal(body.reason, "test deny reason from engine");
+});
+
+test("buildRequirePermissionFromEngine — passes session.tenant into engine.evaluate's EvalContext (load-bearing for OPA tenant rules)", () => {
+  // This is the property the OPA-input-tenant refine relies on:
+  // the gate MUST pass session.tenant to engine.evaluate so a Rego
+  // rule like `allow { input.tenant == "acme" }` can fire. Capture
+  // the ctx and assert it carries the tenant verbatim.
+  let seenCtx: EvalContext | undefined;
+  const engine = {
+    evaluate: (_roles: string[] | undefined, _r: Resource, _a: Action, ctx?: EvalContext) => {
+      seenCtx = ctx;
+      return { allowed: true, reason: "ok" } as EvalResult;
+    },
+    list: () => [],
+    roles: () => [],
+    kind: () => "spy",
+  };
+  const runtime = { mode: "basic", session: { secret: "x".repeat(48) } } as AuthRuntime;
+  const mw = buildRequirePermissionFromEngine(runtime, "sources", "read", engine);
+  const res = mkRes() as ReturnType<typeof mkRes>;
+  const req = {
+    session: { sub: "u", name: "u", roles: ["viewer"], tenant: "acme", iat: 0, exp: Date.now() / 1000 + 60 },
+  } as AuthedRequest;
+  mw(req, res as unknown as import("express").Response, () => undefined);
+  assert.equal(seenCtx?.tenant, "acme", "tenant from session must flow into engine.evaluate ctx");
+});
+
+test("buildRequirePermissionFromEngine — sessionless basic-mode request denies via engine (roles undefined → no permission)", () => {
+  const engine = new BuiltinPolicyEngine(DEFAULT_POLICY);
+  const runtime = { mode: "basic", session: { secret: "x".repeat(48) } } as AuthRuntime;
+  const mw = buildRequirePermissionFromEngine(runtime, "sources", "read", engine);
+  const res = mkRes() as ReturnType<typeof mkRes>;
+  let called = false;
+  mw(mkReq(), res as unknown as import("express").Response, () => { called = true; });
+  assert.equal(called, false);
+  assert.equal(res.statusCode, 403);
+});

--- a/mcp-server/src/auth/rbac.ts
+++ b/mcp-server/src/auth/rbac.ts
@@ -18,6 +18,7 @@
 import type { NextFunction, Request, RequestHandler, Response } from "express";
 
 import type { AuthedRequest, AuthRuntime } from "./middleware.js";
+import type { PolicyEngine } from "./policy/engine.js";
 
 export type Action = "read" | "write" | "delete" | "bypass";
 export type Resource =
@@ -38,7 +39,11 @@ export interface Permission {
   action: Action;
 }
 
-/** Built-in default policy. Operators can replace this via OMCP_RBAC_POLICY in a follow-up. */
+/** Built-in default policy. Operators replace this via OMCP_RBAC_POLICY_FILE
+ *  (YAML/JSON file → BuiltinPolicyEngine) or OMCP_OPA_URL (external
+ *  OPA → OpaPolicyEngine). The gate consumes whichever via
+ *  `buildRequirePermissionFromEngine` so tenant-conditional Rego
+ *  rules can fire. */
 export const DEFAULT_POLICY: Record<string, Permission[]> = {
   viewer: [
     { resource: "sources", action: "read" },
@@ -128,6 +133,50 @@ export function buildRequirePermission(
       code: "OMCP_PERMISSION_DENIED",
       required: { resource, action },
       have: roles ?? [],
+    });
+  };
+}
+
+/**
+ * Engine-aware variant of `buildRequirePermission`. Prefer this when an
+ * external policy engine (OPA, custom Rego) is in play — the legacy
+ * `(roles, resource, action) → boolean` map cannot carry the active
+ * tenant, so a Rego rule like `allow { input.tenant == "acme" }` can
+ * never fire if you go through the map. This variant calls
+ * `engine.evaluate(roles, resource, action, { tenant: session.tenant })`
+ * so tenant-conditional rules see the input they need.
+ *
+ * Anonymous mode stays a no-op — same as the map variant.
+ *
+ * Performance: `evaluate` is sync by contract. OPA hits its cache; on
+ * first miss it returns a conservative deny and warms in the
+ * background — the second request inside the TTL gets the real
+ * verdict. Documented in opa.ts.
+ */
+export function buildRequirePermissionFromEngine(
+  runtime: AuthRuntime,
+  resource: Resource,
+  action: Action,
+  engine: PolicyEngine,
+): RequestHandler {
+  if (runtime.mode === "anonymous") {
+    return function rbacNoop(_req: Request, _res: Response, next: NextFunction): void {
+      next();
+    };
+  }
+  return function rbacGateEngine(req: Request, res: Response, next: NextFunction): void {
+    const sess = (req as AuthedRequest).session;
+    const verdict = engine.evaluate(sess?.roles, resource, action, { tenant: sess?.tenant });
+    if (verdict.allowed) {
+      next();
+      return;
+    }
+    res.status(403).json({
+      error: "permission denied",
+      code: "OMCP_PERMISSION_DENIED",
+      required: { resource, action },
+      have: sess?.roles ?? [],
+      reason: verdict.reason,
     });
   };
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -48,6 +48,7 @@ import {
 } from "./auth/middleware.js";
 import {
   buildRequirePermission,
+  buildRequirePermissionFromEngine,
   hasPermission,
   listGrantedPermissions,
   DEFAULT_POLICY,
@@ -865,8 +866,13 @@ async function main() {
     }
   }
 
+  // Use the engine-aware variant so tenant (session.tenant) flows into
+  // engine.evaluate() — required for tenant-conditional Rego rules
+  // (`input.tenant == "acme"` etc.) under OMCP_OPA_URL. Built-in /
+  // file-loaded engines ignore the tenant ctx, so the behaviour is
+  // unchanged for those deployments.
   const need = (resource: Resource, action: Action) =>
-    buildRequirePermission(authRuntime, resource, action, policyEngineToMap(policyEngine));
+    buildRequirePermissionFromEngine(authRuntime, resource, action, policyEngine);
 
   // Management-plane audit log. Records one entry per mutating /api/*
   // request. Writes JSONL to disk when OMCP_MGMT_AUDIT_FILE is set;


### PR DESCRIPTION
## Summary

Closes a hidden coverage gap. The earlier OPA-input-tenant refine threaded \`input.tenant\` into every Rego query and isolated the cache per-tenant — but the gate was still collapsing the engine to a \`{role: Permission[]}\` map via \`policyEngineToMap\` and calling \`hasPermission\` against it. That path has nowhere to carry tenant, so a Rego rule like \`allow { input.tenant == \"acme\" }\` could never fire from a real request even though OpaPolicyEngine knew how to receive it.

This PR introduces \`buildRequirePermissionFromEngine(runtime, resource, action, engine)\` that calls \`engine.evaluate(roles, resource, action, { tenant: session.tenant })\` directly. \`need()\` in index.ts uses it, passing \`policyEngine\` through verbatim. Built-in / file-loaded engines ignore the ctx (existing behaviour preserved); OPA finally gets the tenant it needs.

## Bonus

Engine \`verdict.reason\` is now surfaced in the 403 body for operator debugging.

## Snapshot views unchanged

\`/api/me\` and \`/api/policy\` still use \`policyEngineToMap\` — they're per-role enumerations with no request context, so the map view is the right shape there.

## Test plan

- [x] 4 new tests pin the load-bearing properties (anonymous no-op, reason verbatim, **session.tenant → engine.evaluate ctx**, sessionless deny)
- [x] 557/557 full suite green
- [x] tsc clean
- [x] Reviewer-agent: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)