### PR TITLE
feat(api): /api/policy snapshot + dry-run is tenant-aware

### DIFF
--- a/docs/policy-engines.md
+++ b/docs/policy-engines.md
@@ -136,6 +136,38 @@ admin_grants := [..., {"resource": "redaction", "action": "bypass"}]
 
 See [`docs/access-control.md`](access-control.md) for the full design.
 
+## Probing the live engine
+
+`GET /api/policy` (admin-gated, `users:delete`) reflects the active
+engine and supports a dry-run for ad-hoc verdict probes — useful for
+debugging "why doesn't my tenant-conditional Rego rule fire?".
+
+Snapshot:
+
+```bash
+curl -s -b "omcp_session=$ADMIN_COOKIE" "$URL/api/policy" | jq '{engine, tenantAware}'
+# { "engine": "opa:http://opa:8181", "tenantAware": true }
+```
+
+`tenantAware` reflects whether the active engine honours
+`session.tenant` on `.evaluate()`. The built-in / file-loaded engines
+ignore it (false); OPA threads it into the Rego input (true).
+
+Dry-run a single verdict — tenant defaults to the caller's session
+tenant, an explicit `?tenant=` override probes any tenant:
+
+```bash
+# As tenant Acme, what does the engine say about sources:delete for the admin role?
+curl -s -b "omcp_session=$ADMIN_COOKIE" \
+  "$URL/api/policy?roles=admin&resource=sources&action=delete&tenant=acme" | jq .
+# { "dryRun": { "roles": ["admin"], "resource": "sources", "action": "delete",
+#              "tenant": "acme", "allowed": true, "reason": "allowed by OPA" } }
+```
+
+If `tenantAware` is `false` and a Rego rule keyed on `input.tenant`
+isn't firing, the engine kind is the diagnostic — switch the gate
+plumbing to OPA mode.
+
 ## Troubleshooting
 
 ### "OPA decision pending (warming cache); request again"

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1072,9 +1072,18 @@ async function main() {
   // to non-admin sessions.
   app.get("/api/policy", need("users", "delete"), (req, res) => {
     const map = policyEngineToMap(policyEngine);
-    // Optional dry-run: ?roles=admin,operator&resource=sources&action=delete
+    // The OPA engine's kind() is prefixed `opa:` (see opa.ts:198).
+    // Surface a `tenantAware` boolean so operators can confirm at a
+    // glance whether the active engine honours session.tenant in
+    // .evaluate() — the BuiltinPolicyEngine ignores tenant ctx; OPA
+    // threads it into the Rego input. This is the property required
+    // for `allow { input.tenant == "acme" }` rules to actually fire.
+    const tenantAware = policyEngine.kind().startsWith("opa:");
+    // Optional dry-run: ?roles=admin,operator&resource=sources&action=delete[&tenant=acme]
     // returns { allowed, reason } so operators can probe the active
-    // engine without writing tests against a checkout.
+    // engine without writing tests against a checkout. Tenant defaults
+    // to the caller's session tenant; an admin can override via the
+    // ?tenant= query string to probe verdicts for any tenant.
     const q = req.query as Record<string, string | undefined>;
     if (q.resource && q.action) {
       const dryRoles = typeof q.roles === "string" ? q.roles.split(",").map((r) => r.trim()).filter(Boolean) : undefined;
@@ -1089,12 +1098,35 @@ async function main() {
         res.json({ dryRun: { roles: dryRoles ?? [], resource: q.resource, action: q.action, allowed: false, reason: `unknown action '${q.action}' (valid: ${[...VALID_ACTIONS].join(", ")})` } });
         return;
       }
-      const result = policyEngine.evaluate(dryRoles, q.resource as Resource, q.action as Action);
-      res.json({ dryRun: { roles: dryRoles ?? [], resource: q.resource, action: q.action, ...result } });
+      const callerSess = (req as AuthedRequest).session;
+      // Tenant resolution: explicit ?tenant= override wins, else the
+      // caller's session tenant. The probe runs at users:delete (admin),
+      // so a cross-tenant override is intentional — exactly how an
+      // operator debugs "why doesn't my tenant-conditional Rego rule
+      // fire for tenant Acme?".
+      const probeTenant = typeof q.tenant === "string" && q.tenant
+        ? q.tenant.trim()
+        : callerSess?.tenant;
+      const result = policyEngine.evaluate(
+        dryRoles,
+        q.resource as Resource,
+        q.action as Action,
+        probeTenant ? { tenant: probeTenant } : undefined,
+      );
+      res.json({
+        dryRun: {
+          roles: dryRoles ?? [],
+          resource: q.resource,
+          action: q.action,
+          tenant: probeTenant,
+          ...result,
+        },
+      });
       return;
     }
     res.json({
       engine: policyEngine.kind(),
+      tenantAware,
       policy: map,
       roles: policyEngine.roles(),
       note: policyEngine.kind() === "builtin"


### PR DESCRIPTION
## Summary

Operator-facing /api/policy now reflects + probes the live engine in a tenant-aware way.

**Snapshot** gains \`tenantAware: <bool>\` — true when engine kind is \`opa:*\`. Surfaces at a glance whether \`allow { input.tenant == \"acme\" }\` rules can fire under the current deployment.

**Dry-run** (\`?roles=&resource=&action=\`) accepts an optional \`?tenant=\` override (default = caller's session tenant) and threads it via \`{ tenant: probeTenant }\` into \`engine.evaluate()\`. Cross-tenant overrides are intentional — exactly how an admin debugs \"why doesn't my tenant-conditional Rego rule fire for tenant Acme?\". The reply echoes the tenant used.

## Why

The previous gate fix (PR #327) made tenant flow into engine.evaluate at request time, but operators had no way to probe it. /api/policy was returning the SAME map collapse regardless of which tenant, hiding OPA's tenant-conditional behaviour from the only debugging surface.

## Test plan

- [x] tsc clean
- [x] 557/557 suite green
- [x] tenantAware key matches the existing \`opa:*\` prefix pinned by opa.test.ts:126
- [x] docs/policy-engines.md gains a \"Probing the live engine\" section with curl snippets

🤖 Generated with [Claude Code](https://claude.com/claude-code)