### PR TITLE
feat(quota): explicit-disable for OMCP_TOOL_RATE_PER_MIN + refresh stale OIDC roadmap

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -159,8 +159,11 @@ The `/mcp` HTTP transport carries one per-identity sliding window:
 `OMCP_TOOL_RATE_PER_MIN` overrides — accepts any positive integer;
 unset / empty / non-numeric / `0` / negative all fall back to the
 default 60 (so an operator setting `0` to mean "disable" doesn't
-accidentally lock every caller out). The explicit-disable path is
-on the roadmap. Anonymous `/mcp` traffic (no `OMCP_API_KEYS`) is
+accidentally lock every caller out). To truly disable the per-identity
+cap — e.g. when an upstream gateway already enforces quotas —
+set it to `off`, `none`, `unlimited`, `disabled`, or `false`
+(case-insensitive). In that mode `/api/usage` reports `limit: null`
+for every identity. Anonymous `/mcp` traffic (no `OMCP_API_KEYS`) is
 unaffected; the existing IP-level express-rate-limit still applies.
 
 Every `/mcp` response carries the live bucket state in headers so a

--- a/docs/auth-basic.md
+++ b/docs/auth-basic.md
@@ -4,15 +4,13 @@ The observability-mcp server can optionally require a logged-in user before
 serving any `/api/*` management endpoint or the Web UI. This is **off by
 default** — single-user demos / local development behave exactly as before.
 
-Two modes ship today:
+Three modes ship today:
 
 | `OMCP_AUTH` value | Behaviour |
 |---|---|
 | unset / `anonymous` (default) | Every `/api/*` request is accepted. The UI shows no login screen. |
-| `basic` | A signed cookie session is required. The UI shows a login modal on first 401. |
-
-A third mode (`oidc`) is on the roadmap and will plug into the same session
-machinery without changing the UI experience.
+| `basic` | A signed cookie session is required. Local users live in `OMCP_USERS_FILE`; the UI shows a login modal on first 401. |
+| `oidc` | A signed cookie session is required, but the credential exchange goes through an external IdP (Keycloak, Auth0, Authentik, generic OIDC) via PKCE. Same session machinery as `basic`. See [auth-oidc.md](auth-oidc.md). |
 
 > The `/mcp` Streamable HTTP transport keeps using **bearer tokens** through
 > the existing `OMCP_API_KEYS` mechanism (see [auth-and-tls.md](auth-and-tls.md)).

--- a/helm/observability-mcp/values.yaml
+++ b/helm/observability-mcp/values.yaml
@@ -72,7 +72,13 @@ sources:
 #   - OMCP_API_KEYS                bearer tokens for the /mcp transport
 #   - OMCP_MGMT_AUDIT_FILE         JSONL audit log; in-memory ring (500) when unset
 #   - OMCP_SERVICE_CATALOG_FILE    owner / tier / on-call / SLO metadata
-#   - OMCP_TOOL_RATE_PER_MIN       per-identity /mcp cap; default 60
+#   - OMCP_TOOL_RATE_PER_MIN       per-identity /mcp cap; default 60.
+#                                  Set to off/none/unlimited/disabled/
+#                                  false (case-insensitive) to disable
+#                                  the cap entirely — useful when an
+#                                  upstream gateway already enforces
+#                                  quotas. /api/usage reports
+#                                  limit: null in that mode.
 #   - OMCP_TOOL_DAILY_TOKENS       per-identity 24h-rolling token cap;
 #                                  default 0 (uncapped). Charges only
 #                                  named bearer-token callers, never

--- a/mcp-server/src/quota/limiter.test.ts
+++ b/mcp-server/src/quota/limiter.test.ts
@@ -130,3 +130,32 @@ test("default limit applies when constructed with no args", () => {
   }
   assert.equal(lim.check("alice", t + 60).allowed, false);
 });
+
+test("resolveToolRatePerMin — explicit-disable tokens map to Infinity (any case, with whitespace)", () => {
+  for (const tok of ["off", "OFF", "Off", "none", "NONE", "unlimited", "UNLIMITED", "disabled", "false", "  off  "]) {
+    assert.equal(resolveToolRatePerMin(tok), Number.POSITIVE_INFINITY, `'${tok}' should disable the limiter`);
+  }
+});
+
+test("IdentityRateLimiter — limit=Infinity always allows (the explicit-disable contract)", () => {
+  const lim = new IdentityRateLimiter({ limit: Number.POSITIVE_INFINITY });
+  const t = 1_700_000_000_000;
+  // Burst far past the default cap; every call must allow.
+  for (let i = 0; i < 1000; i++) {
+    const r = lim.check("alice", t + i);
+    assert.equal(r.allowed, true);
+    assert.equal(r.retryAfterSeconds, 0);
+    // Limit reflects the configured Infinity — JSON serialisation
+    // would render this as null; callers can branch on Number.isFinite.
+    assert.equal(r.limit, Number.POSITIVE_INFINITY);
+  }
+});
+
+test("resolveToolRatePerMin — disable tokens are NOT a number trap (\"infinity\" alone is not a token)", () => {
+  // We deliberately do NOT accept the literal string "infinity"
+  // because Number("Infinity") === Infinity — operators expect
+  // OMCP_TOOL_RATE_PER_MIN=Infinity to error out, not silently
+  // mean "unlimited". The explicit tokens are off/none/unlimited/
+  // disabled/false. (Number.isFinite is what the resolver checks.)
+  assert.equal(resolveToolRatePerMin("Infinity"), 60, "literal 'Infinity' must NOT secretly enable unlimited mode");
+});

--- a/mcp-server/src/quota/limiter.ts
+++ b/mcp-server/src/quota/limiter.ts
@@ -20,6 +20,12 @@
 const DEFAULT_LIMIT_PER_MIN = 60;
 const DEFAULT_WINDOW_MS = 60_000;
 
+/** Magic strings that explicitly disable the per-identity cap.
+ *  Matched case-insensitively. Operators picked any of these to
+ *  mean "no rate limit at all" — useful when the caps are enforced
+ *  upstream (envoy / API-gateway) and OMCP shouldn't double-count. */
+const UNLIMITED_TOKENS = new Set(["off", "none", "unlimited", "disabled", "false"]);
+
 /** Resolve `OMCP_TOOL_RATE_PER_MIN` (or any equivalent caller-supplied
  * string) into the per-identity cap used by the limiter and reported
  * by `/api/info` + `/api/usage`. Single source of truth, so the three
@@ -29,14 +35,21 @@ const DEFAULT_WINDOW_MS = 60_000;
  * - unset / empty / non-numeric → DEFAULT_LIMIT_PER_MIN (60)
  * - `"0"` → DEFAULT_LIMIT_PER_MIN (limit=0 would deny every request,
  *   which is almost never what an operator setting "0" wants — they
- *   either mean "default" or "disable"; we treat it as "default" and
- *   leave the explicit disable path on the roadmap)
+ *   either mean "default" or "disable"; this function maps it to the
+ *   default so they aren't accidentally locked out, and the explicit
+ *   disable path is one of the UNLIMITED_TOKENS instead)
+ * - `"off"` / `"none"` / `"unlimited"` / `"disabled"` / `"false"`
+ *   (case-insensitive) → Number.POSITIVE_INFINITY, which the
+ *   `count >= limit` comparison in check() always allows. JSON
+ *   serialisation renders Infinity as `null`; consumers can treat
+ *   a null limit as "uncapped".
  * - negative → DEFAULT_LIMIT_PER_MIN (limit=-1 with the current
  *   `count >= limit` check would also deny every request)
  * - any positive integer ≥ 1 → that value
  */
 export function resolveToolRatePerMin(raw: string | undefined): number {
   if (raw === undefined || raw === "") return DEFAULT_LIMIT_PER_MIN;
+  if (UNLIMITED_TOKENS.has(raw.trim().toLowerCase())) return Number.POSITIVE_INFINITY;
   const n = Number(raw);
   if (!Number.isFinite(n) || n < 1) return DEFAULT_LIMIT_PER_MIN;
   return Math.floor(n);


### PR DESCRIPTION
## Summary

Two contained refines:

**1. Rate-limit explicit-disable** — closes the \"explicit-disable path is on the roadmap\" TODO in docs/access-control.md and mcp-server/src/quota/limiter.ts. \`OMCP_TOOL_RATE_PER_MIN=off|none|unlimited|disabled|false\` (case-insensitive, whitespace tolerant) maps to \`Number.POSITIVE_INFINITY\`; the existing \`count >= limit\` comparison treats it as \"always allow\". \`/api/usage\` serialises \`limit: null\` in that mode.

Number-trap guard: the literal string \"Infinity\" is NOT a disable token — operators expecting an error get the default 60, not a silent uncap.

**2. Stale OIDC roadmap claim** — docs/auth-basic.md said the \`oidc\` mode was on the roadmap, but it shipped two months ago. Refreshed the table to honestly list all three modes with a pointer to docs/auth-oidc.md.

## Why explicit-disable?

When an upstream gateway (envoy / API-gateway) already enforces quotas, double-counting at OMCP causes false 429s. Operators need a clean way to delegate.

## Test plan

- [x] 3 new tests (case-insensitive disable tokens, Infinity allows 1000 calls, \"Infinity\" string is NOT a disable token)
- [x] 560/560 full suite green
- [x] tsc clean
- [x] Helm values.yaml extraEnv hint updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)