### PR TITLE
feat(quota): OMCP_KEY_RATE_PER_MIN — per-credential cap overrides

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -411,8 +411,22 @@ env:
   OMCP_TOOL_RATE_PER_MIN: "240"
 ```
 
-For a per-role cap, the limiter is structured to accept a per-identity
-override map — wiring is on the roadmap.
+For a per-credential cap override, set `OMCP_KEY_RATE_PER_MIN`:
+
+```yaml
+env:
+  OMCP_TOOL_RATE_PER_MIN: "60"           # default everyone else
+  OMCP_KEY_RATE_PER_MIN: "agent=600;ci=240;noisy-bot=off"
+```
+
+The override syntax mirrors `OMCP_KEY_TENANTS` / `OMCP_KEY_PRODUCTS` —
+`name=count` pairs separated by `;`. The same disable vocabulary as
+the global cap (`off`, `none`, `unlimited`, `disabled`, `false`,
+case-insensitive) lifts the cap entirely for that credential —
+useful for an internal automation that shouldn't be rate-limited.
+Unknown credentials silently fall back to the global default; a
+non-numeric override silently skips so a typo doesn't lock the
+credential out at boot.
 
 ### "Restart broke my audit chain"
 

--- a/helm/observability-mcp/values.yaml
+++ b/helm/observability-mcp/values.yaml
@@ -79,6 +79,13 @@ sources:
 #                                  upstream gateway already enforces
 #                                  quotas. /api/usage reports
 #                                  limit: null in that mode.
+#   - OMCP_KEY_RATE_PER_MIN        per-credential override of the
+#                                  /mcp cap, "agent=600;ci=240" style
+#                                  (mirrors OMCP_KEY_TENANTS /
+#                                  OMCP_KEY_PRODUCTS). Same disable
+#                                  vocabulary as the global override.
+#                                  Unknown credentials fall back to
+#                                  the global default.
 #   - OMCP_TOOL_DAILY_TOKENS       per-identity 24h-rolling token cap;
 #                                  default 0 (uncapped). Charges only
 #                                  named bearer-token callers, never

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -67,7 +67,7 @@ import { buildBypassBreadcrumb, buildBypassAuditParams } from "./audit/redaction
 import { readCatalogFile, CatalogStore } from "./catalog/loader.js";
 import { readProductsFile, ProductsStore, validateProduct, writeProductsFile, ProductsLoadError } from "./products/loader.js";
 import { redactValue } from "./policy/redact.js";
-import { IdentityRateLimiter, resolveToolRatePerMin } from "./quota/limiter.js";
+import { IdentityRateLimiter, resolveToolRatePerMin, parseKeyRateLimits } from "./quota/limiter.js";
 import { TokenBudget, estimateTokensFor, resolveDailyTokenLimit } from "./quota/token-budget.js";
 import { applyBudgetDecision } from "./quota/charge.js";
 import { getPluginLoader } from "./connectors/loader.js";
@@ -1972,8 +1972,22 @@ async function main() {
   // 429 with a Retry-After. Anonymous /mcp traffic (no OMCP_API_KEYS
   // configured) bypasses this — the global express-rate-limit IP gate
   // still applies. Override via OMCP_TOOL_RATE_PER_MIN.
+  // Per-credential cap overrides: OMCP_KEY_RATE_PER_MIN="agent=600;ci=240"
+  // wins over the global OMCP_TOOL_RATE_PER_MIN for the named credentials.
+  // The bucket identity is "<tenant> <credName>"; the override map keys on
+  // credName, so the lookup pulls the cred-name back out of the composite.
+  const keyRateLimits = parseKeyRateLimits(process.env.OMCP_KEY_RATE_PER_MIN);
   const toolRateLimiter = new IdentityRateLimiter({
     limit: resolveToolRatePerMin(process.env.OMCP_TOOL_RATE_PER_MIN),
+    limitFor: keyRateLimits.size === 0 ? undefined : (identity: string) => {
+      // Composite identity is "<tenant> <credName>" — split on the
+      // single space that gateCtx put there (NUL would be safer but
+      // would break existing /api/usage actor labels; cred names are
+      // operator-set and don't contain spaces in practice).
+      const sp = identity.indexOf(" ");
+      const credName = sp >= 0 ? identity.slice(sp + 1) : identity;
+      return keyRateLimits.get(credName);
+    },
   });
   // Per-identity tracker key. Composes tenant + principalId so two
   // credentials of the same name in different tenants don't share

--- a/mcp-server/src/quota/limiter.test.ts
+++ b/mcp-server/src/quota/limiter.test.ts
@@ -159,3 +159,69 @@ test("resolveToolRatePerMin — disable tokens are NOT a number trap (\"infinity
   // disabled/false. (Number.isFinite is what the resolver checks.)
   assert.equal(resolveToolRatePerMin("Infinity"), 60, "literal 'Infinity' must NOT secretly enable unlimited mode");
 });
+
+import { parseKeyRateLimits } from "./limiter.js";
+
+test("parseKeyRateLimits — parses name=count pairs, skips malformed entries", () => {
+  const m = parseKeyRateLimits("agent=600;ci=240;bad;empty=;negative=-1;zero=0;notnum=abc");
+  assert.equal(m.get("agent"), 600);
+  assert.equal(m.get("ci"), 240);
+  assert.equal(m.get("bad"), undefined);
+  assert.equal(m.get("empty"), undefined);
+  assert.equal(m.get("negative"), undefined);
+  assert.equal(m.get("zero"), undefined);
+  assert.equal(m.get("notnum"), undefined);
+});
+
+test("parseKeyRateLimits — disable tokens map to Infinity (same vocabulary as the global override)", () => {
+  const m = parseKeyRateLimits("agent=off;ci=unlimited;loud=DISABLED");
+  assert.equal(m.get("agent"), Number.POSITIVE_INFINITY);
+  assert.equal(m.get("ci"), Number.POSITIVE_INFINITY);
+  assert.equal(m.get("loud"), Number.POSITIVE_INFINITY);
+});
+
+test("IdentityRateLimiter — limitFor override wins over the default cap", () => {
+  // Default is 60; override gives agent=2.
+  const lim = new IdentityRateLimiter({
+    limit: 60,
+    limitFor: (id) => (id === "default agent" ? 2 : undefined),
+  });
+  const t = 1_700_000_000_000;
+  // Two calls allowed for agent, third denies.
+  assert.equal(lim.check("default agent", t).allowed, true);
+  assert.equal(lim.check("default agent", t + 1).allowed, true);
+  const denied = lim.check("default agent", t + 2);
+  assert.equal(denied.allowed, false);
+  assert.equal(denied.limit, 2, "reported limit must be the per-identity override, not the default");
+  // Default identity still gets the global 60.
+  for (let i = 0; i < 60; i++) {
+    assert.equal(lim.check("default other", t + i).allowed, true);
+  }
+  assert.equal(lim.check("default other", t + 60).allowed, false);
+});
+
+test("IdentityRateLimiter — limitFor returning undefined falls back to default; Infinity disables for that identity", () => {
+  const lim = new IdentityRateLimiter({
+    limit: 5,
+    limitFor: (id) => (id === "default vip" ? Number.POSITIVE_INFINITY : undefined),
+  });
+  const t = 1_700_000_000_000;
+  // VIP can burst far past 5.
+  for (let i = 0; i < 1000; i++) {
+    assert.equal(lim.check("default vip", t + i).allowed, true);
+  }
+  // Default user still capped at 5.
+  for (let i = 0; i < 5; i++) {
+    assert.equal(lim.check("default user", t + i).allowed, true);
+  }
+  assert.equal(lim.check("default user", t + 5).allowed, false);
+});
+
+test("IdentityRateLimiter — inspect() reports the per-identity limit too (not just the default)", () => {
+  const lim = new IdentityRateLimiter({
+    limit: 60,
+    limitFor: (id) => (id === "default agent" ? 600 : undefined),
+  });
+  assert.equal(lim.inspect("default agent").limit, 600);
+  assert.equal(lim.inspect("default other").limit, 60);
+});

--- a/mcp-server/src/quota/limiter.ts
+++ b/mcp-server/src/quota/limiter.ts
@@ -56,10 +56,44 @@ export function resolveToolRatePerMin(raw: string | undefined): number {
 }
 
 export interface LimiterConfig {
-  /** Cap per identity per window. Defaults to 60. */
+  /** Default cap per identity per window. Defaults to 60. */
   limit?: number;
   /** Window length in milliseconds. Defaults to 60_000. */
   windowMs?: number;
+  /** Optional per-identity override. Returns the cap for the named
+   *  identity, or undefined to fall back to the default `limit`.
+   *  Useful for the OMCP_KEY_RATE_PER_MIN credential-level override
+   *  (`agent=600;ci=240`) — admin gives a noisy automation a higher
+   *  quota without affecting every other caller. Returning Infinity
+   *  disables the cap for that identity (matches the global
+   *  unlimited-token contract). */
+  limitFor?: (identity: string) => number | undefined;
+}
+
+/** Parse OMCP_KEY_RATE_PER_MIN — `name=count;name2=count2`. Same
+ *  shape as parseKeyTenants / parseKeyProducts so operators have one
+ *  syntactic model across all per-credential overrides. Unknown
+ *  counts (non-numeric / ≤ 0) silently skip. Magic disable tokens
+ *  (off/none/unlimited/disabled/false) map to Infinity, same as the
+ *  global OMCP_TOOL_RATE_PER_MIN. */
+export function parseKeyRateLimits(raw: string | undefined): Map<string, number> {
+  const m = new Map<string, number>();
+  if (!raw) return m;
+  for (const entry of raw.split(";").map((s) => s.trim()).filter(Boolean)) {
+    const eq = entry.indexOf("=");
+    if (eq <= 0) continue;
+    const name = entry.slice(0, eq).trim();
+    const valueRaw = entry.slice(eq + 1).trim();
+    if (!name || !valueRaw) continue;
+    if (UNLIMITED_TOKENS.has(valueRaw.toLowerCase())) {
+      m.set(name, Number.POSITIVE_INFINITY);
+      continue;
+    }
+    const n = Number(valueRaw);
+    if (!Number.isFinite(n) || n < 1) continue;
+    m.set(name, Math.floor(n));
+  }
+  return m;
 }
 
 export interface CheckResult {
@@ -77,14 +111,28 @@ export interface CheckResult {
 }
 
 export class IdentityRateLimiter {
-  private readonly limit: number;
+  private readonly defaultLimit: number;
   private readonly windowMs: number;
+  private readonly limitFor?: (identity: string) => number | undefined;
   // identity → ring of millisecond timestamps, newest at the end.
   private readonly buckets = new Map<string, number[]>();
 
   constructor(cfg: LimiterConfig = {}) {
-    this.limit = cfg.limit ?? DEFAULT_LIMIT_PER_MIN;
+    this.defaultLimit = cfg.limit ?? DEFAULT_LIMIT_PER_MIN;
     this.windowMs = cfg.windowMs ?? DEFAULT_WINDOW_MS;
+    this.limitFor = cfg.limitFor;
+  }
+
+  /** Resolved cap for one identity: the per-identity override wins
+   *  when defined; otherwise the process-wide default applies. */
+  private resolveLimit(identity: string): number {
+    if (this.limitFor) {
+      const v = this.limitFor(identity);
+      if (typeof v === "number" && (Number.isFinite(v) ? v >= 1 : v === Number.POSITIVE_INFINITY)) {
+        return v;
+      }
+    }
+    return this.defaultLimit;
   }
 
   /** Record-and-test a call for the given identity. Returns the
@@ -97,7 +145,8 @@ export class IdentityRateLimiter {
     while (i < bucket.length && bucket[i] <= cutoff) i++;
     const fresh = i === 0 ? bucket : bucket.slice(i);
 
-    if (fresh.length >= this.limit) {
+    const limit = this.resolveLimit(identity);
+    if (fresh.length >= limit) {
       // Compute when the oldest in-window record drops off.
       const retryAfterMs = fresh[0] + this.windowMs - now;
       // Don't store the call we just denied — that would push the
@@ -106,7 +155,7 @@ export class IdentityRateLimiter {
       return {
         allowed: false,
         count: fresh.length,
-        limit: this.limit,
+        limit,
         windowMs: this.windowMs,
         retryAfterSeconds: Math.max(1, Math.ceil(retryAfterMs / 1000)),
       };
@@ -117,7 +166,7 @@ export class IdentityRateLimiter {
     return {
       allowed: true,
       count: fresh.length,
-      limit: this.limit,
+      limit,
       windowMs: this.windowMs,
       retryAfterSeconds: 0,
     };
@@ -129,7 +178,7 @@ export class IdentityRateLimiter {
     const bucket = this.buckets.get(identity) ?? [];
     let count = 0;
     for (const t of bucket) if (t > cutoff) count++;
-    return { count, limit: this.limit, windowMs: this.windowMs };
+    return { count, limit: this.resolveLimit(identity), windowMs: this.windowMs };
   }
 
   /** All identities we've ever seen — for /api/usage aggregation. */


### PR DESCRIPTION
## Summary

Closes the \"per-role cap is on the roadmap\" TODO in docs/access-control.md. Operators can now override the /mcp cap per credential:

\`\`\`bash
OMCP_TOOL_RATE_PER_MIN=\"60\"                           # default for everyone
OMCP_KEY_RATE_PER_MIN=\"agent=600;ci=240;noisy-bot=off\"
\`\`\`

Syntax mirrors \`OMCP_KEY_TENANTS\` / \`OMCP_KEY_PRODUCTS\` so operators learn one model. Same disable vocabulary as the global cap (\`off\`/\`none\`/\`unlimited\`/...) lifts the cap for that credential — useful for an internal automation.

## Implementation

- \`IdentityRateLimiter\` gains optional \`limitFor(id) => number | undefined\` callback
- Per-call lookup: undefined → fall back to global default; finite ≥1 → use it; Infinity → uncapped for that identity
- Composite identity \`<tenant> <credName>\` is split back to cred name for the override map lookup
- \`/api/usage\` already passes through \`limit\` so per-credential caps surface there automatically

## Test plan

- [x] 5 new tests: parser (incl. malformed-skip), disable-token mapping, override-wins, undefined-falls-through, Infinity-disables, inspect() per-identity
- [x] 565/565 full suite green
- [x] tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)