### PR TITLE
fix(api): thread session tenant into /api/services, /api/health, /api/topology

### DIFF
--- a/mcp-server/src/context.test.ts
+++ b/mcp-server/src/context.test.ts
@@ -41,3 +41,30 @@ test("defaultContext — no allowedTools (anonymous sees every tool, back-compat
   assert.equal(ctx.allowedTools, undefined);
   assert.equal(allowsTool(ctx.allowedTools, "any_tool"), true);
 });
+
+import { sessionContext } from "./context.js";
+
+test("sessionContext — undefined session → defaultContext shape (anonymous, default tenant)", () => {
+  const ctx = sessionContext(undefined);
+  assert.equal(ctx.auth, "anonymous");
+  assert.equal(ctx.tenant, "default");
+  assert.equal(ctx.principalId, "anonymous");
+});
+
+test("sessionContext — session.tenant flows into ctx.tenant (the load-bearing property for /api/services + /api/health)", () => {
+  const ctx = sessionContext({ sub: "alice", name: "Alice", tenant: "acme" });
+  assert.equal(ctx.tenant, "acme");
+  assert.equal(ctx.principalId, "alice");
+  assert.equal(ctx.auth, "apikey");
+});
+
+test("sessionContext — falls back to session.name when sub absent", () => {
+  const ctx = sessionContext({ name: "operator-bot", tenant: "bigco" });
+  assert.equal(ctx.principalId, "operator-bot");
+});
+
+test("sessionContext — sessionless tenant inherits DEFAULT (no leak from a previous tenant'd request)", () => {
+  // Belt-and-suspenders: explicit empty tenant string normalises to default.
+  const ctx = sessionContext({ sub: "u", tenant: "" });
+  assert.equal(ctx.tenant, "default");
+});

--- a/mcp-server/src/context.ts
+++ b/mcp-server/src/context.ts
@@ -68,6 +68,24 @@ export function principalContext(
   };
 }
 
+/** Context for an authenticated management-plane (browser / OIDC /
+ *  basic-auth) request. The session-derived tenant flows into tool
+ *  handlers exactly like the MCP-credential path, so a viewer in
+ *  tenant Acme reading /api/services through the dashboard sees the
+ *  same service set as an /mcp client bound to Acme. Anonymous mode
+ *  (no session) → behaves like defaultContext(). */
+export function sessionContext(
+  session: { sub?: string; name?: string; tenant?: string } | undefined,
+): RequestContext {
+  if (!session) return defaultContext();
+  return {
+    principalId: session.sub || session.name || "anonymous",
+    auth: "apikey",
+    tenant: normaliseTenant(session.tenant),
+    correlationId: randomUUID(),
+  };
+}
+
 /** Decide whether a given tool name is accessible under the active
  *  Product binding. Pure helper so the registration site stays
  *  declarative and the filtering policy is unit-testable in isolation.

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { loadConfig, saveConfig, DEFAULT_HEALTH_THRESHOLDS, DEFAULT_SETTINGS } from "./config/loader.js";
 import { ConnectorRegistry, getSupportedTypes } from "./connectors/registry.js";
 import { isTopologyProvider } from "./connectors/interface.js";
-import { defaultContext, principalContext, allowsTool, type RequestContext } from "./context.js";
+import { defaultContext, principalContext, sessionContext, allowsTool, type RequestContext } from "./context.js";
 import {
   enforceEntitledAccess,
   enterpriseGateStatus,
@@ -1680,7 +1680,10 @@ async function main() {
     try {
       const sess = (req as AuthedRequest).session;
       const callerTenant = sess?.tenant || "default";
-      const result = await listServicesHandler(registry, {}, defaultContext());
+      // sessionContext threads the caller's tenant into the handler so
+      // PR #331's per-tenant connector scoping fires for the dashboard
+      // surface too (was previously bypassed with defaultContext()).
+      const result = await listServicesHandler(registry, {}, sessionContext(sess));
       const parsed = parseToolResult(result) as { services?: Array<Record<string, unknown> & { name?: string }> };
       // Tenant-scope catalog enrichment so a viewer in tenant A
       // doesn't accidentally see acme's owner/SLO metadata on a
@@ -1842,9 +1845,10 @@ async function main() {
   // Health endpoint for UI dashboard
   app.get("/api/health/:service", async (req, res) => {
     try {
-      const callerTenant = (req as AuthedRequest).session?.tenant || "default";
+      const sess = (req as AuthedRequest).session;
+      const callerTenant = sess?.tenant || "default";
       const service = String(req.params.service);
-      const result = await getServiceHealthHandler(registry, { service }, defaultContext());
+      const result = await getServiceHealthHandler(registry, { service }, sessionContext(sess));
       const parsed = parseToolResult(result) as Record<string, unknown>;
       const entry = catalog.get(service, callerTenant);
       if (entry && parsed && typeof parsed === "object") parsed.catalog = entry;
@@ -1857,14 +1861,16 @@ async function main() {
   // Health for all services
   app.get("/api/health", async (req, res) => {
     try {
-      const callerTenant = (req as AuthedRequest).session?.tenant || "default";
-      const servicesResult = await listServicesHandler(registry, {}, defaultContext());
+      const sess = (req as AuthedRequest).session;
+      const callerTenant = sess?.tenant || "default";
+      const ctx = sessionContext(sess);
+      const servicesResult = await listServicesHandler(registry, {}, ctx);
       const parsed = parseToolResult(servicesResult) as { services?: Array<{ name: string }> };
       const services = parsed?.services || [];
       const health: Record<string, unknown> = {};
       for (const svc of services) {
         try {
-          const result = await getServiceHealthHandler(registry, { service: svc.name }, defaultContext());
+          const result = await getServiceHealthHandler(registry, { service: svc.name }, ctx);
           const h = parseToolResult(result) as Record<string, unknown>;
           // Same tenant scoping as /api/services to avoid the
           // dashboard cross-tenant catalog leak the reviewer
@@ -1884,8 +1890,10 @@ async function main() {
   // Returns the union of topology snapshots across all topology-capable
   // connectors (today only "kubernetes"). One JSON document so the UI can
   // render summary + grouped views without N round-trips.
-  app.get("/api/topology", async (_req, res) => {
+  app.get("/api/topology", async (req, res) => {
     try {
+      const sess = (req as AuthedRequest).session;
+      const callerTenant = sess?.tenant || "default";
       const sources: Array<{
         source: string;
         type: string;
@@ -1895,7 +1903,11 @@ async function main() {
       }> = [];
       const allResources = [];
       const allEdges = [];
-      for (const c of registry.getAll()) {
+      // Tenant-scoped: non-anonymous callers only see topology from
+      // connectors their tenant can reach. Anonymous mode keeps the
+      // global view (single-tenant default).
+      const connectors = sess ? registry.getByTenant(callerTenant) : registry.getAll();
+      for (const c of connectors) {
         if (!isTopologyProvider(c)) continue;
         const snap = await c.getTopologySnapshot();
         sources.push({


### PR DESCRIPTION
## Summary

PR #331 made the MCP tool handlers tenant-aware via \`ctx.tenant\`. The management-plane REST endpoints (\`/api/services\`, \`/api/health\`, \`/api/health/:service\`, \`/api/topology\`) called the same handlers but with \`defaultContext()\` — which always has \`tenant=default\` — so the **dashboard surface bypassed the per-tenant scoping**.

Closed by introducing \`sessionContext(session)\` in \`context.ts\`. It builds a RequestContext from the auth session (\`sub\`/\`name\` → \`principalId\`, \`session.tenant\` → normalised \`ctx.tenant\`). Anonymous sessionless callers fall through to \`defaultContext()\` so single-tenant deployments are bit-for-bit identical.

\`/api/topology\` additionally consults \`registry.getByTenant(callerTenant)\` when a session exists, scoping the dashboard topology graph to the caller's tenant.

## Test plan

- [x] 4 new tests pin: undefined session → default; tenant flows through; sub/name fallback; empty tenant normalises to default
- [x] 573/573 full suite green
- [x] tsc clean
- [x] Anonymous-only deployments unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)