### PR TITLE
feat(opa): tenant-aware boot pre-warm — cache covers known tenants too

### DIFF
--- a/docs/policy-engines.md
+++ b/docs/policy-engines.md
@@ -94,17 +94,28 @@ responses also work; the UI just shows an empty grant table.
 ### Boot pre-warm
 
 `PolicyEngine.evaluate()` is synchronous; OPA HTTP is not. The
-engine ships a 5s per-(roles, resource, action) cache. On a cache
-miss, `evaluate()` returns a conservative deny + async-fires a warm.
-To avoid that "warming-deny" for the very first user request, OMCP
-hits every (declared role × valid resource × valid action) combo at
-boot — for the 3-role default catalogue that's 120 calls; OPA
-handles this in <1s.
+engine ships a 5s per-(roles, resource, action, tenant) cache. On a
+cache miss, `evaluate()` returns a conservative deny + async-fires
+a warm. To avoid that "warming-deny" for the very first user
+request, OMCP hits every (declared role × valid resource × valid
+action × known tenant) combo at boot.
+
+Known tenants = `"default"` plus every value parsed from
+`OMCP_KEY_TENANTS`. With 3 roles × 10 resources × 4 actions ×
+N tenants, the warm count scales linearly in N; for the typical
+case of 1–5 tenants OPA handles it in well under a second.
+
+OIDC tenants only become known at session time, so the very first
+request from a brand-new OIDC tenant still pays one warming-deny
+per `(role, resource, action)`. Operators that want zero warming-
+deny for OIDC-only deployments can list expected tenant names in
+`OMCP_KEY_TENANTS` even if no MCP credentials use them — the parser
+treats every value as an additional tenant to pre-warm.
 
 The boot log reports:
 
 ```
-[auth] OPA cache pre-warmed: 124 decisions cached for 3 role(s)
+[auth] OPA cache pre-warmed: 372 decisions cached for 3 role(s) × 3 tenants
 ```
 
 A partial warm (e.g. transient OPA hiccup) logs the count + failure

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -10,6 +10,7 @@ import { loadConfig, saveConfig, DEFAULT_HEALTH_THRESHOLDS, DEFAULT_SETTINGS } f
 import { ConnectorRegistry, getSupportedTypes } from "./connectors/registry.js";
 import { isTopologyProvider } from "./connectors/interface.js";
 import { defaultContext, principalContext, sessionContext, allowsTool, type RequestContext } from "./context.js";
+import { parseKeyTenants } from "./tenancy/context.js";
 import {
   enforceEntitledAccess,
   enterpriseGateStatus,
@@ -838,20 +839,39 @@ async function main() {
       if (roles.length === 0) return;
       const resources = [...VALID_RESOURCES];
       const actions = [...VALID_ACTIONS];
+      // Tenant-aware pre-warm: the gate keys cache per
+      // (roles, resource, action, tenant) so a tenant-conditional
+      // Rego rule that fires for "acme" but not "bigco" produces a
+      // distinct cached verdict per tenant. The pre-warm iterates
+      // every known declared tenant + "default" so the first user
+      // request from a tenant'd identity gets a real decision
+      // instead of a warming-deny. OIDC tenants only known at
+      // runtime are still subject to first-request warming, but
+      // operator-set OMCP_KEY_TENANTS land here.
+      const knownTenants = new Set<string>(["default"]);
+      // parseKeyTenants is the same parser the credentials layer
+      // uses, so the warm set is exactly what the gate will see.
+      for (const t of parseKeyTenants(process.env.OMCP_KEY_TENANTS).values()) {
+        if (t) knownTenants.add(t);
+      }
+      const tenants = Array.from(knownTenants);
       const tasks: Promise<unknown>[] = [];
-      for (const role of roles) {
-        for (const resource of resources) for (const action of actions) {
-          tasks.push(opaEngine.warmEvaluate([role], resource, action));
+      for (const tenant of tenants) {
+        for (const role of roles) {
+          for (const resource of resources) for (const action of actions) {
+            tasks.push(opaEngine.warmEvaluate([role], resource, action, tenant));
+          }
+          tasks.push(opaEngine.warmList([role], tenant));
         }
-        tasks.push(opaEngine.warmList([role]));
       }
       try {
         const settled = await Promise.allSettled(tasks);
         const failed = settled.filter((s) => s.status === "rejected").length;
+        const tlbl = tenants.length === 1 ? "1 tenant" : `${tenants.length} tenants`;
         if (failed === 0) {
-          console.log(`[auth] OPA cache pre-warmed: ${settled.length} decisions cached for ${roles.length} role(s)`);
+          console.log(`[auth] OPA cache pre-warmed: ${settled.length} decisions cached for ${roles.length} role(s) × ${tlbl}`);
         } else {
-          console.warn(`[auth] OPA cache pre-warmed: ${settled.length - failed}/${settled.length} ok, ${failed} failed (gates will retry on first user call)`);
+          console.warn(`[auth] OPA cache pre-warmed: ${settled.length - failed}/${settled.length} ok, ${failed} failed across ${tlbl} (gates will retry on first user call)`);
         }
       } catch { /* best-effort */ }
     })();


### PR DESCRIPTION
## Summary

Earlier OPA-tenant refines made the gate cache key \`(roles, resource, action, tenant)\`. The pre-warm at boot was still tenant-less: it cached one verdict per \`(role, resource, action)\`, so the first request from any tenant'd identity hit the \"warming-deny\" path before getting a real decision.

Now the pre-warm iterates every known tenant — \`\"default\"\` plus every value parsed from \`OMCP_KEY_TENANTS\` — so the cache covers the realistic per-tenant decision set on the first user request. OIDC tenants only known at runtime are still subject to first-request warming; operators can pre-list expected tenant names in \`OMCP_KEY_TENANTS\` to cover those too.

Log line gains the tenant count:

\`\`\`
[auth] OPA cache pre-warmed: 372 decisions cached for 3 role(s) × 3 tenants
\`\`\`

## Test plan

- [x] 573/573 full suite green
- [x] tsc clean
- [x] docs/policy-engines.md updated to explain the new behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)