### PR TITLE
refactor(agent): extract IncidentDeduper + add unit tests

### DIFF
--- a/examples/agent/src/dedup.test.ts
+++ b/examples/agent/src/dedup.test.ts
@@ -1,0 +1,70 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { IncidentDeduper, anomalyHash } from "./dedup.js";
+
+const A = { service: "payment-service", metric: "cpu", severity: "warning" };
+const B = { service: "payment-service", metric: "errors", severity: "warning" };
+const C = { service: "payment-service", metric: "cpu", severity: "critical" };
+
+test("anomalyHash — distinct triples produce distinct hashes (no false collapse)", () => {
+  assert.notEqual(anomalyHash(A), anomalyHash(B));
+  assert.notEqual(anomalyHash(A), anomalyHash(C));
+  assert.equal(anomalyHash(A), anomalyHash({ ...A }));
+});
+
+test("IncidentDeduper — first sighting is NOT a duplicate; second sighting within TTL IS", () => {
+  let now = 1_000_000;
+  const d = new IncidentDeduper(60_000, () => now);
+  assert.equal(d.isDuplicate(A), false);
+  d.markReported(A);
+  // 30 seconds later — still inside the 60s TTL.
+  now += 30_000;
+  assert.equal(d.isDuplicate(A), true);
+  // 60 seconds later — past TTL → no longer a duplicate.
+  now += 31_000; // total = 61s after markReported
+  assert.equal(d.isDuplicate(A), false);
+});
+
+test("IncidentDeduper — distinct severities or metrics are NOT collapsed (different hash)", () => {
+  const d = new IncidentDeduper(60_000);
+  d.markReported(A);
+  // Same service+metric, escalating severity → distinct incident.
+  assert.equal(d.isDuplicate(C), false);
+  // Same service+severity, different metric → distinct incident.
+  assert.equal(d.isDuplicate(B), false);
+});
+
+test("IncidentDeduper — cleanExpired drops stale entries, retains in-window ones", () => {
+  let now = 1_000_000;
+  const d = new IncidentDeduper(60_000, () => now);
+  d.markReported(A);
+  // Fast-forward past TTL, then mark a fresh one.
+  now += 61_000;
+  d.markReported(B);
+  // Before clean: A is stale but the map still holds it.
+  assert.equal(d.size(), 2);
+  d.cleanExpired();
+  assert.equal(d.size(), 1, "stale A should have been dropped, fresh B retained");
+  assert.equal(d.isDuplicate(B), true);
+});
+
+test("IncidentDeduper — markReported on a duplicate refreshes the timestamp (slides the window)", () => {
+  let now = 1_000_000;
+  const d = new IncidentDeduper(60_000, () => now);
+  d.markReported(A);
+  // 30s later — still a dup; re-mark refreshes the clock.
+  now += 30_000;
+  d.markReported(A);
+  // Another 50s — total 80s since the first mark, but only 50s since
+  // the refresh → still inside the 60s window → still a dup.
+  now += 50_000;
+  assert.equal(d.isDuplicate(A), true);
+});
+
+test("IncidentDeduper — production default clock works (sanity smoke against Date.now)", () => {
+  const d = new IncidentDeduper(10);
+  assert.equal(d.isDuplicate(A), false);
+  d.markReported(A);
+  assert.equal(d.isDuplicate(A), true);
+});

--- a/examples/agent/src/dedup.ts
+++ b/examples/agent/src/dedup.ts
@@ -1,0 +1,62 @@
+/**
+ * Anomaly-deduper for the demo agent.
+ *
+ * Pulled out of index.ts so the dedup contract can be unit-tested
+ * without spinning up the full agent + Ollama + MCP stack:
+ *
+ *   - Same (service, metric, severity) reported within the TTL = dup
+ *   - Past the TTL, the same triple counts as new again
+ *   - cleanExpired() drops stale entries so the Map doesn't grow
+ *     unboundedly over a long agent run
+ *
+ * `now` is injected so tests can step time deterministically; the
+ * default uses Date.now() so the production code stays a one-liner.
+ */
+export interface AnomalyKey {
+  service: string;
+  metric: string;
+  severity: string;
+}
+
+export function anomalyHash(a: AnomalyKey): string {
+  return `${a.service}:${a.metric}:${a.severity}`;
+}
+
+export class IncidentDeduper {
+  private readonly seen = new Map<string, number>();
+
+  constructor(
+    private readonly ttlMs: number,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  /** True when an anomaly with this (service, metric, severity)
+   *  was already reported inside the TTL window. */
+  isDuplicate(a: AnomalyKey): boolean {
+    const at = this.seen.get(anomalyHash(a));
+    return at !== undefined && this.now() - at < this.ttlMs;
+  }
+
+  /** Record this anomaly as just-reported. Subsequent isDuplicate
+   *  calls inside the TTL window return true. */
+  markReported(a: AnomalyKey): void {
+    this.seen.set(anomalyHash(a), this.now());
+  }
+
+  /** Drop entries older than the TTL so the map doesn't grow
+   *  unboundedly. The agent calls this periodically; not strictly
+   *  necessary for correctness — isDuplicate already treats expired
+   *  entries as non-duplicates. */
+  cleanExpired(): void {
+    const cutoff = this.now() - this.ttlMs;
+    for (const [hash, at] of this.seen) {
+      if (at <= cutoff) this.seen.delete(hash);
+    }
+  }
+
+  /** Snapshot the live entry count — useful for /metrics-style
+   *  introspection and assertions in tests. */
+  size(): number {
+    return this.seen.size;
+  }
+}

--- a/examples/agent/src/index.ts
+++ b/examples/agent/src/index.ts
@@ -1,5 +1,6 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { IncidentDeduper } from "./dedup.js";
 
 // Config from env vars
 const MCP_URL = process.env.MCP_URL || "http://mcp-server:3000/mcp";
@@ -46,29 +47,12 @@ async function syncSettings(): Promise<void> {
 }
 
 // --- Incident Deduplication ---
-const reportedIncidents = new Map<string, number>(); // hash → timestamp
-
-function anomalyHash(anomaly: { service: string; metric: string; severity: string }): string {
-  return `${anomaly.service}:${anomaly.metric}:${anomaly.severity}`;
-}
-
-function isDuplicate(anomaly: { service: string; metric: string; severity: string }): boolean {
-  const hash = anomalyHash(anomaly);
-  const lastReported = reportedIncidents.get(hash);
-  if (lastReported && Date.now() - lastReported < DEDUP_TTL_MS) return true;
-  return false;
-}
-
-function markReported(anomaly: { service: string; metric: string; severity: string }) {
-  reportedIncidents.set(anomalyHash(anomaly), Date.now());
-}
-
-function cleanExpiredIncidents() {
-  const now = Date.now();
-  for (const [hash, ts] of reportedIncidents) {
-    if (now - ts > DEDUP_TTL_MS) reportedIncidents.delete(hash);
-  }
-}
+// IncidentDeduper extracted to ./dedup.ts so the contract is unit-
+// testable without spinning up the full agent + Ollama + MCP stack.
+const deduper = new IncidentDeduper(DEDUP_TTL_MS);
+const isDuplicate = (a: { service: string; metric: string; severity: string }) => deduper.isDuplicate(a);
+const markReported = (a: { service: string; metric: string; severity: string }) => deduper.markReported(a);
+const cleanExpiredIncidents = () => deduper.cleanExpired();
 
 // --- MCP Connection ---
 async function waitForService(url: string, name: string, maxRetries = 60): Promise<void> {


### PR DESCRIPTION
## Summary

The demo agent's incident-deduplication contract — same (service, metric, severity) within TTL = duplicate; past TTL = new again — was inlined in \`index.ts\` as module-globals plus four free functions, with zero direct test coverage. It's the single piece of agent code with a real behavioural contract worth pinning (the rest is loop / I/O glue).

Extracted to \`examples/agent/src/dedup.ts\` as a small class:

- \`IncidentDeduper(ttlMs, now?)\` — clock injected for tests
- \`isDuplicate(a)\` / \`markReported(a)\` / \`cleanExpired()\` / \`size()\`
- \`anomalyHash(a)\` exported for the hash-collision invariant test

\`index.ts\` call sites swapped to thin wrappers over a single module-level deduper; behaviour is identical.

## Test plan

- [x] 6 new tests: first sighting, in-window dup, post-TTL no dup, distinct severities/metrics not collapsed, cleanExpired drops stale + retains fresh, markReported refreshes window, default Date.now clock
- [x] tsc clean (agent typescript)

🤖 Generated with [Claude Code](https://claude.com/claude-code)