### PR TITLE
test(openapi): pin the new tenant fields against contract drift

### DIFF
--- a/mcp-server/src/openapi.test.ts
+++ b/mcp-server/src/openapi.test.ts
@@ -66,3 +66,38 @@ test("openapi — info.version is the version string the caller passed in", () =
   const spec = buildOpenApiSpec("9.9.9-test");
   assert.equal(spec.info?.version, "9.9.9-test");
 });
+
+test("openapi — SOURCE_SCHEMA exposes the tenant field (tenant-aware sources contract)", () => {
+  // Source entries gained a `tenant` field when per-tenant connector
+  // scoping shipped. The spec is the contract operators write
+  // generated clients against — drift = broken downstream clients.
+  const spec = buildOpenApiSpec("test-1.0.0");
+  // SOURCE_SCHEMA is inlined into both `items` of GET /api/sources and
+  // the requestBody of POST/PUT — pick the GET response, the canonical
+  // read path.
+  const sources = spec.paths?.["/api/sources"]?.get as unknown as { responses: { "200": { content: { "application/json": { schema: { items: { properties: Record<string, unknown> } } } } } } };
+  const items = sources.responses["200"].content["application/json"].schema.items;
+  assert.ok(items.properties.tenant, "SOURCE_SCHEMA must document `tenant` (added when per-tenant scoping shipped)");
+});
+
+test("openapi — /api/sources GET documents the admin `?tenant=` drill-down query param", () => {
+  const spec = buildOpenApiSpec("test-1.0.0");
+  const get = spec.paths?.["/api/sources"]?.get as unknown as { parameters?: Array<{ name: string; in: string }> };
+  const params = get.parameters || [];
+  const tenantParam = params.find((p) => p.name === "tenant" && p.in === "query");
+  assert.ok(tenantParam, "GET /api/sources must document the admin `?tenant=` drill-down param");
+});
+
+test("openapi — /api/policy GET documents the `?tenant=` probe param + `tenantAware` snapshot field", () => {
+  const spec = buildOpenApiSpec("test-1.0.0");
+  const get = spec.paths?.["/api/policy"]?.get as unknown as {
+    parameters: Array<{ name: string; in: string }>;
+    responses: { "200": { content: { "application/json": { schema: { properties: Record<string, unknown> } } } } };
+  };
+  const params = get.parameters || [];
+  assert.ok(params.some((p) => p.name === "tenant" && p.in === "query"), "GET /api/policy must document the `?tenant=` probe param");
+  const schema = get.responses["200"].content["application/json"].schema;
+  assert.ok(schema.properties.tenantAware, "snapshot must document the `tenantAware` field");
+  const dryRun = schema.properties.dryRun as { properties?: Record<string, unknown> };
+  assert.ok(dryRun?.properties?.tenant, "dryRun must echo the `tenant` field so operators see which tenant the verdict ran under");
+});


### PR DESCRIPTION
## Summary

PR #337 documented tenant-aware fields in the OpenAPI spec; the upstream PRs (#331/#333/#335/#336) wired the underlying server behaviour. This adds three drift-guard tests so a future refactor that accidentally drops the tenant fields from the spec gets caught at test time, not by a downstream generated-client breaking in production.

| Guard | What it pins |
|---|---|
| \`SOURCE_SCHEMA\` keeps documenting \`tenant\` | per-tenant connector scoping contract |
| \`GET /api/sources\` keeps its admin \`?tenant=\` param | drill-down API |
| \`GET /api/policy\` keeps \`?tenant=\` + \`tenantAware\` + \`dryRun.tenant\` | engine probe contract |

Same shape as the existing \`/api/info\` governance-block guard.

## Test plan

- [x] 576/576 full suite green
- [x] tsc clean (casts via \`unknown\` so openapi-types deep generics don't fail structural assignability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)