### PR TITLE
fix(api): close cross-tenant leak on /api/sources/:name/metrics GET/PUT/DELETE

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1986,9 +1986,19 @@ async function main() {
 
   // Get metrics for a source (active metrics or defaults)
   app.get("/api/sources/:name/metrics", (req, res) => {
-    const connector = registry.getByName(String(req.params.name));
+    const name = String(req.params.name);
+    const sess = (req as AuthedRequest).session;
+    const isAdmin = hasPermission(sess?.roles, "users", "delete");
+    const callerTenant = sess?.tenant || "default";
+    // Tenant-aware: getByNameForTenant returns undefined for both
+    // "doesn't exist" and "cross-tenant" — same no-leak posture as
+    // /api/sources GET/PUT/DELETE. Anonymous / admin keep the
+    // single-tenant behaviour by falling back to getByName.
+    const connector = (sess && !isAdmin)
+      ? registry.getByNameForTenant(name, callerTenant)
+      : registry.getByName(name);
     if (!connector) {
-      res.status(404).json({ error: `Source "${String(req.params.name)}" not found` });
+      res.status(404).json({ error: `Source "${name}" not found` });
       return;
     }
     res.json({
@@ -1997,11 +2007,15 @@ async function main() {
     });
   });
 
-  // Update metrics for a source
+  // Update metrics for a source — tenant-aware mutation.
   app.put("/api/sources/:name/metrics", need("sources","write"), audit("sources","write"), async (req, res) => {
     const name = String(req.params.name);
     const sourceIdx = config.sources.findIndex((s) => s.name === name);
-    if (sourceIdx === -1) {
+    const sess = (req as AuthedRequest).session;
+    const isAdmin = hasPermission(sess?.roles, "users", "delete");
+    const callerTenant = sess?.tenant || "default";
+    const src = sourceIdx >= 0 ? config.sources[sourceIdx] : undefined;
+    if (!src || (!isAdmin && src.tenant && src.tenant !== callerTenant)) {
       res.status(404).json({ error: `Source "${name}" not found` });
       return;
     }
@@ -2012,11 +2026,15 @@ async function main() {
     res.json({ ok: true });
   });
 
-  // Reset a source's metrics to connector defaults
+  // Reset a source's metrics to connector defaults — tenant-aware.
   app.delete("/api/sources/:name/metrics", need("sources","write"), audit("sources","write"), async (req, res) => {
     const name = String(req.params.name);
     const sourceIdx = config.sources.findIndex((s) => s.name === name);
-    if (sourceIdx === -1) {
+    const sess = (req as AuthedRequest).session;
+    const isAdmin = hasPermission(sess?.roles, "users", "delete");
+    const callerTenant = sess?.tenant || "default";
+    const src = sourceIdx >= 0 ? config.sources[sourceIdx] : undefined;
+    if (!src || (!isAdmin && src.tenant && src.tenant !== callerTenant)) {
       res.status(404).json({ error: `Source "${name}" not found` });
       return;
     }


### PR DESCRIPTION
## Summary

PR #332 added tenant gating to \`/api/sources\` GET/POST/PUT/DELETE/PATCH but the **three per-source metrics handlers** (\`GET\` / \`PUT\` / \`DELETE\` on \`/api/sources/:name/metrics\`) were skipped — a non-admin in tenant \`bigco\` could still **read OR overwrite** the metrics definitions of an \`acme\`-tagged source. Both a confidentiality and integrity gap.

All three now use the same posture as the other source handlers:
- **GET**: \`getByNameForTenant\` for non-admin sessions; anonymous and admin keep the unrestricted \`getByName\` path so single-tenant deployments are bit-for-bit identical
- **PUT/DELETE**: cross-tenant source returns **404** (no existence leak), same posture as \`PUT /api/sources/:name\`

## Test plan

- [x] 576/576 full suite green
- [x] tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)