### PR TITLE
feat(products): typo guard + POST /api/products + keystone tool-name registry test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -188,9 +188,13 @@ jobs:
             -H "Content-Type: application/json" \
             -H "Accept: application/json, text/event-stream" \
             -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' -o "$tools_body"
-          echo "--- bound tools/list ---"; cat "$tools_body"
+          echo "--- bound tools/list (raw, may be SSE-framed) ---"; cat "$tools_body"
 
-          names=$(jq -r '.result.tools[].name' < "$tools_body" | sort | tr '\n' ' ' | sed 's/ $//')
+          # The /mcp Streamable HTTP transport returns SSE-framed JSON
+          # when Accept includes text/event-stream. Strip the
+          # `data: ` envelope before jq.
+          json=$(grep -E '^(data: )?\{' "$tools_body" | head -1 | sed -E 's/^data: //')
+          names=$(echo "$json" | jq -r '.result.tools[].name' | sort | tr '\n' ' ' | sed 's/ $//')
           expected='list_sources query_metrics'
           if [ "$names" != "$expected" ]; then
             echo "FAIL: tools/list did not match the bound Product."
@@ -199,9 +203,9 @@ jobs:
             exit 1
           fi
 
-          # Negative control: a bound tool that IS NOT in the Product
-          # (e.g. get_topology) must NOT appear.
-          if echo "$names" | grep -q "get_topology"; then
+          # Negative control: a registered tool that is NOT in the
+          # Product's allow-list (e.g. get_topology) must NOT appear.
+          if echo "$names" | tr ' ' '\n' | grep -qx "get_topology"; then
             echo "FAIL: tools/list leaked a tool NOT in the Product's allow-list"
             exit 1
           fi

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -116,6 +116,102 @@ jobs:
           curl -fsS http://localhost:8081/health | head -5
           curl -fsS -X POST http://localhost:8081/chaos/reset
 
+      - name: Real E2E — OMCP_KEY_PRODUCTS filters /mcp tools/list
+        # End-to-end proof that a credential bound to an MCP Product
+        # sees ONLY the Product's tools allow-list — not the full 8.
+        # Boots a second mcp-server container (same image, port 3002)
+        # with OMCP_API_KEYS + OMCP_KEY_PRODUCTS + a mounted
+        # products.yaml fixture, then does a real MCP handshake with
+        # the bound bearer token and asserts the tools/list payload.
+        # No mocks. Touches every layer: env parsing → credential
+        # binding → tenant resolution → ctx.allowedTools →
+        # registerTool() filter → tools/list response.
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/products-fixture
+          cat > /tmp/products-fixture/products.yaml <<'EOF'
+          products:
+            - id: ci-ops
+              name: CI Ops Bundle
+              status: published
+              tools:
+                - list_sources
+                - query_metrics
+          EOF
+
+          # Start a one-off test container sharing the demo network.
+          # `docker compose run` reuses the project image + network so
+          # the test instance can reach Prometheus / Loki by service
+          # name like the real one does. -d keeps it backgrounded.
+          docker compose run -d --rm --name mcp-test \
+            -e PORT=3000 \
+            -e OMCP_API_KEYS=ci:tok_e2e_secret \
+            -e OMCP_KEY_PRODUCTS=ci=ci-ops \
+            -e OMCP_PRODUCTS_FILE=/fixture/products.yaml \
+            -v /tmp/products-fixture:/fixture:ro \
+            -p 3002:3000 \
+            --no-deps \
+            mcp-server
+
+          # Wait for the test instance.
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:3002/api/sources >/dev/null 2>&1; then
+              echo "test instance ready"
+              break
+            fi
+            sleep 1
+          done
+
+          # MCP handshake with bearer.
+          hdr=/tmp/init.h
+          body=/tmp/init.body
+          curl -fsS -X POST http://localhost:3002/mcp \
+            -H "Authorization: Bearer tok_e2e_secret" \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json, text/event-stream" \
+            -D "$hdr" -o "$body" \
+            -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"ci-product-binding","version":"1.0"}}}'
+          sid=$(grep -i '^mcp-session-id:' "$hdr" | awk '{print $2}' | tr -d '\r\n')
+          [ -n "$sid" ] || { echo "no mcp-session-id"; exit 1; }
+          curl -fsS -X POST http://localhost:3002/mcp \
+            -H "Mcp-Session-Id: $sid" \
+            -H "Authorization: Bearer tok_e2e_secret" \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json, text/event-stream" \
+            -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' >/dev/null || true
+
+          # tools/list — must return EXACTLY the Product's two tools.
+          tools_body=/tmp/tools.body
+          curl -fsS -X POST http://localhost:3002/mcp \
+            -H "Mcp-Session-Id: $sid" \
+            -H "Authorization: Bearer tok_e2e_secret" \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json, text/event-stream" \
+            -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' -o "$tools_body"
+          echo "--- bound tools/list ---"; cat "$tools_body"
+
+          names=$(jq -r '.result.tools[].name' < "$tools_body" | sort | tr '\n' ' ' | sed 's/ $//')
+          expected='list_sources query_metrics'
+          if [ "$names" != "$expected" ]; then
+            echo "FAIL: tools/list did not match the bound Product."
+            echo "  expected: $expected"
+            echo "  got:      $names"
+            exit 1
+          fi
+
+          # Negative control: a bound tool that IS NOT in the Product
+          # (e.g. get_topology) must NOT appear.
+          if echo "$names" | grep -q "get_topology"; then
+            echo "FAIL: tools/list leaked a tool NOT in the Product's allow-list"
+            exit 1
+          fi
+
+          echo "OK: real E2E — Product binding filtered tools/list to exactly the bound subset"
+
+      - name: Cleanup product-binding test instance
+        if: always()
+        run: docker rm -f mcp-test 2>/dev/null || true
+
       - name: Dump logs on failure
         if: failure()
         run: |

--- a/docs/products.md
+++ b/docs/products.md
@@ -81,9 +81,17 @@ RBAC / users-file failures.
 | Endpoint | Method | RBAC | Notes |
 |---|---|---|---|
 | `/api/products` | GET | `products:read` | Tenant + staging-aware. `?tenant=X` admin drill-down. |
+| `/api/products` | POST | `products:write` | Strict create — 409 on conflict. Use when you want create-vs-update semantics. |
 | `/api/products/:id` | GET | `products:read` | 404 on cross-tenant or staging probe by non-admin (no existence leak). |
-| `/api/products/:id` | PUT | `products:write` | Body validated through the same parser; persists to file when set. |
+| `/api/products/:id` | PUT | `products:write` | Upsert. Body validated through the same parser; persists to file when set. |
 | `/api/products/:id` | DELETE | `products:delete` | 404 on cross-tenant; admin-only via DEFAULT_POLICY. |
+
+Both POST + PUT enforce the **tools[] typo guard**: a Product whose
+`tools` list names tools that don't actually register (e.g. a typo
+`query_logz`) is rejected with **422** + `code:
+OMCP_PRODUCT_UNKNOWN_TOOL` + the `unknown` names + the `available`
+list. Without the guard, a bound credential would open an `/mcp`
+session with an empty tool surface — silent dead session.
 
 Default permission grants:
 

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -67,6 +67,7 @@ import { buildAuditMiddleware } from "./audit/middleware.js";
 import { buildBypassBreadcrumb, buildBypassAuditParams } from "./audit/redaction-bypass.js";
 import { readCatalogFile, CatalogStore } from "./catalog/loader.js";
 import { readProductsFile, ProductsStore, validateProduct, writeProductsFile, ProductsLoadError } from "./products/loader.js";
+import { REGISTERED_TOOL_NAMES, unknownToolNames } from "./tools/registry-names.js";
 import { redactValue } from "./policy/redact.js";
 import { IdentityRateLimiter, resolveToolRatePerMin, parseKeyRateLimits } from "./quota/limiter.js";
 import { TokenBudget, estimateTokensFor, resolveDailyTokenLimit } from "./quota/token-budget.js";
@@ -1760,6 +1761,63 @@ async function main() {
       includesStaging: includeStaging,
     });
   });
+  // Create a new product (REST convention: POST = create, 409 on
+  // conflict). Same tenancy + typo-guard posture as PUT. The PUT
+  // upsert path remains for the existing UI; new integrations that
+  // want strict create-vs-update semantics use POST.
+  app.post("/api/products", need("products", "write"), audit("products", "write"), async (req, res) => {
+    await products.maybeReload();
+    const sess = (req as AuthedRequest).session;
+    const isAdmin = hasPermission(sess?.roles, "users", "delete");
+    const callerTenant = sess?.tenant || "default";
+    const body = req.body as Record<string, unknown> | undefined;
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      res.status(400).json({ error: "body must be a product object" });
+      return;
+    }
+    if (typeof body.id !== "string" || !body.id) {
+      res.status(400).json({ error: "body.id is required" });
+      return;
+    }
+    let validated;
+    try { validated = validateProduct(body, `POST /api/products`); }
+    catch (e) {
+      if (e instanceof ProductsLoadError) { res.status(400).json({ error: e.message }); return; }
+      throw e;
+    }
+    if (validated.tools && validated.tools.length > 0) {
+      const unknown = unknownToolNames(validated.tools);
+      if (unknown.length > 0) {
+        res.status(422).json({
+          error: `unknown tool name(s) in product '${validated.id}': ${unknown.join(", ")}`,
+          code: "OMCP_PRODUCT_UNKNOWN_TOOL",
+          unknown,
+          available: REGISTERED_TOOL_NAMES,
+        });
+        return;
+      }
+    }
+    if (!isAdmin && (validated.tenant || "default") !== callerTenant) {
+      res.status(403).json({ error: "cannot create product in another tenant" });
+      return;
+    }
+    if (products.get(validated.id)) {
+      res.status(409).json({ error: `product '${validated.id}' already exists; use PUT to update` });
+      return;
+    }
+    const next = products.upsert(validated);
+    if (process.env.OMCP_PRODUCTS_FILE) {
+      try {
+        await writeProductsFile(process.env.OMCP_PRODUCTS_FILE, next);
+        await products.pinMtimeAfterWrite();
+      }
+      catch (e) {
+        console.warn(`[products] POST ${validated.id}: failed to persist to ${process.env.OMCP_PRODUCTS_FILE}: ${(e as Error).message} — in-memory state is still updated`);
+      }
+    }
+    res.status(201).json({ product: validated, persisted: !!process.env.OMCP_PRODUCTS_FILE });
+  });
+
   // Upsert a product. Body is the same shape as a single entry
   // in OMCP_PRODUCTS_FILE. The URL-path id must match the body id
   // (defence-in-depth: the gate keys on body, the path keys the
@@ -1792,6 +1850,23 @@ async function main() {
     catch (e) {
       if (e instanceof ProductsLoadError) { res.status(400).json({ error: e.message }); return; }
       throw e;
+    }
+    // Typo guard: a Product whose `tools` allow-list names tools
+    // that don't actually register would bind a credential to an
+    // empty /mcp tool surface (silent dead session). Reject with
+    // 422 + a hint of valid tool names so the operator can see the
+    // intended typo immediately.
+    if (validated.tools && validated.tools.length > 0) {
+      const unknown = unknownToolNames(validated.tools);
+      if (unknown.length > 0) {
+        res.status(422).json({
+          error: `unknown tool name(s) in product '${id}': ${unknown.join(", ")}`,
+          code: "OMCP_PRODUCT_UNKNOWN_TOOL",
+          unknown,
+          available: REGISTERED_TOOL_NAMES,
+        });
+        return;
+      }
     }
     // Tenant gate: non-admins can only write into their own tenant.
     if (!isAdmin && (validated.tenant || "default") !== callerTenant) {

--- a/mcp-server/src/openapi.ts
+++ b/mcp-server/src/openapi.ts
@@ -573,6 +573,25 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
             "403": { description: "Missing products:read permission." },
           },
         },
+        post: {
+          tags: ["products"],
+          summary: "Create a new product (strict create — 409 on conflict; PUT for upsert).",
+          description: "Strict create-only variant of PUT. Same tenancy + typo-guard posture. Returns 409 when a product with body.id already exists. Body must include id + name; tools[] entries must reference registered MCP tool names (typo → 422).",
+          requestBody: {
+            required: true,
+            content: { "application/json": { schema: { type: "object", additionalProperties: true } } },
+          },
+          responses: {
+            "201": { description: "Created.", content: { "application/json": { schema: { type: "object", properties: {
+              product: { type: "object", additionalProperties: true },
+              persisted: { type: "boolean" },
+            } } } } },
+            "400": { description: "Body invalid (missing id / shape rejected by validateProduct)." },
+            "403": { description: "Missing products:write permission, or non-admin attempting to create in another tenant." },
+            "409": { description: "Product with that id already exists — use PUT to update." },
+            "422": { description: "tools[] references unknown tool names. Body includes `unknown` + `available`; error code OMCP_PRODUCT_UNKNOWN_TOOL." },
+          },
+        },
       },
       "/api/products/{id}": {
         get: {
@@ -608,6 +627,7 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
             "400": { description: "Body shape invalid (validateProduct rejected — typo, unknown key, wrong type, ...)." },
             "403": { description: "Missing products:write permission, or non-admin attempting to write into another tenant." },
             "404": { description: "Existing product belongs to a different tenant (non-admin)." },
+            "422": { description: "tools[] references unknown tool names. Body includes `unknown` + `available`; error code OMCP_PRODUCT_UNKNOWN_TOOL." },
           },
         },
         delete: {

--- a/mcp-server/src/tools/registry-names.test.ts
+++ b/mcp-server/src/tools/registry-names.test.ts
@@ -1,0 +1,53 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { REGISTERED_TOOL_NAMES, unknownToolNames } from "./registry-names.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const INDEX_TS = join(here, "..", "index.ts");
+
+test("REGISTERED_TOOL_NAMES — 1:1 with createMcpServer's registerTool() calls", () => {
+  // This is the integration-test-shaped guard: if a future PR adds
+  // or removes a tool registration in index.ts without updating
+  // REGISTERED_TOOL_NAMES, the Product validator will silently
+  // accept or reject the wrong names. We parse index.ts as text and
+  // assert the registered set matches the constant exactly.
+  const src = readFileSync(INDEX_TS, "utf8");
+  // registerTool("name", → captures the first argument of every call site.
+  const re = /\bregisterTool\(\s*"([a-z_][a-z0-9_]*)"/g;
+  const found: string[] = [];
+  for (const m of src.matchAll(re)) found.push(m[1]);
+  found.sort();
+  const expected = [...REGISTERED_TOOL_NAMES].sort();
+  assert.deepEqual(
+    found,
+    expected,
+    `registerTool() call sites in index.ts don't match REGISTERED_TOOL_NAMES. ` +
+      `Add or remove names in src/tools/registry-names.ts to match the actual ` +
+      `registrations.\n  found: ${JSON.stringify(found)}\n  expected: ${JSON.stringify(expected)}`,
+  );
+});
+
+test("unknownToolNames — empty input → no unknowns", () => {
+  assert.deepEqual(unknownToolNames([]), []);
+});
+
+test("unknownToolNames — every registered name is accepted", () => {
+  assert.deepEqual(unknownToolNames([...REGISTERED_TOOL_NAMES]), []);
+});
+
+test("unknownToolNames — surfaces typos and unknown names verbatim", () => {
+  const r = unknownToolNames(["list_sources", "query_logz", "get_topologyy"]);
+  assert.deepEqual(r, ["query_logz", "get_topologyy"]);
+});
+
+test("unknownToolNames — case-sensitive (MCP spec)", () => {
+  // The spec requires exact name match; "List_Sources" is not the
+  // same tool as "list_sources" and silently accepting it would be a
+  // worse failure mode than rejecting (mismatched casing wouldn't
+  // route to a real tool).
+  assert.deepEqual(unknownToolNames(["List_Sources"]), ["List_Sources"]);
+});

--- a/mcp-server/src/tools/registry-names.ts
+++ b/mcp-server/src/tools/registry-names.ts
@@ -1,0 +1,40 @@
+/**
+ * Canonical list of MCP tool names exposed by createMcpServer().
+ *
+ * Used by:
+ *   - the Product validator (typo guard): a Product's `tools` allow-
+ *     list must reference names that actually register, otherwise a
+ *     bound credential opens an /mcp session with an empty tool set
+ *     and the agent silently fails.
+ *   - the keystone integration test in registry-names.test.ts that
+ *     reads index.ts and asserts the registerTool() call sites match
+ *     this list 1:1 — a missing entry or an extra one trips the test.
+ *
+ * Keep this list and the registerTool("name", ...) calls in
+ * createMcpServer in sync. The test enforces it.
+ */
+export const REGISTERED_TOOL_NAMES = [
+  "list_sources",
+  "list_services",
+  "query_metrics",
+  "query_logs",
+  "get_service_health",
+  "detect_anomalies",
+  "get_topology",
+  "get_blast_radius",
+] as const;
+
+export type RegisteredToolName = typeof REGISTERED_TOOL_NAMES[number];
+
+/** Validate a candidate Product tools[] array. Returns the unknown
+ *  names (empty array = all OK). Pure helper — the caller decides
+ *  how to surface the rejection (the API handler emits a 422 with a
+ *  hint of valid names; the YAML loader could decide to warn). */
+export function unknownToolNames(tools: readonly string[]): string[] {
+  const known = new Set<string>(REGISTERED_TOOL_NAMES);
+  const out: string[] = [];
+  for (const t of tools) {
+    if (!known.has(t)) out.push(t);
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Closes the three Products papercuts identified in the audit:

### 1. Typo guard (the real bug)

A Product whose \`tools[]\` names a tool that doesn't actually register (e.g. \`query_logz\` instead of \`query_logs\`) used to validate clean — and then a bound credential would open an \`/mcp\` session with an **empty tool surface** (silent dead session).

POST + PUT \`/api/products\` now reject with **422** + \`code: OMCP_PRODUCT_UNKNOWN_TOOL\` + the \`unknown\` names + the \`available\` list, so the operator sees the typo immediately.

### 2. POST /api/products

Strict create-only variant of the existing PUT upsert (REST convention: 409 on conflict). Same tenancy + typo-guard posture. PUT stays for the existing UI / hot-edit workflow.

### 3. Keystone integration test

\`registry-names.test.ts\` parses \`index.ts\` as text and asserts the \`registerTool()\` call sites match \`REGISTERED_TOOL_NAMES\` **1:1** — a future PR that adds or removes a tool registration without updating the constant trips the test, preventing the typo guard from silently going stale.

## Test plan

- [x] 5 new tests in registry-names.test.ts
- [x] 581/581 full suite green
- [x] tsc clean
- [x] Reviewer-agent: clean (typo-guard ordering correct, 422 per RFC 9110, tenant-leak surface analysed and identical to pre-existing PUT/DELETE pattern)
- [x] OpenAPI spec + docs/products.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)