### PR TITLE
feat(products): tools registry endpoint + UI multi-select picker (Slice C)

### DIFF
--- a/mcp-server/playwright/products.spec.mjs
+++ b/mcp-server/playwright/products.spec.mjs
@@ -90,6 +90,53 @@ test.describe("Products UI", () => {
     await page.locator("#mcp-products-leitfaden .card-header").click();
   });
 
+  test("Tools picker — renders categories, syncs selections to the hidden textarea, prefills from a template", async ({ page }) => {
+    // Delete the seeded product so the empty-state templates render
+    // a "+ click to open with tools prefilled" path we can exercise.
+    const api = await request.newContext({ baseURL: BASE });
+    await api.delete("/api/products/playwright-ops");
+    await api.dispose();
+    await page.goto(BASE);
+    await page.click("[data-page=products]");
+    await page.waitForSelector("#page-products.active");
+    await expect(page.locator(".pempty-templates")).toBeVisible();
+    // Click "Ops Bundle" — opens the modal prefilled with 4 tools.
+    await page.locator(".pempty-tpl").nth(0).click();
+    await expect(page.locator("#mcp-product-modal.open")).toBeVisible();
+    // Picker categories present.
+    await expect(page.locator(".tools-picker .tp-cat", { hasText: "Discovery" })).toBeVisible();
+    await expect(page.locator(".tools-picker .tp-cat", { hasText: "Query" })).toBeVisible();
+    await expect(page.locator(".tools-picker .tp-cat", { hasText: "Diagnose" })).toBeVisible();
+    await expect(page.locator(".tools-picker .tp-cat", { hasText: "Topology" })).toBeVisible();
+    // The 4 ops-bundle tools are pre-checked.
+    const opsTools = ["query_logs", "query_metrics", "get_service_health", "detect_anomalies"];
+    for (const t of opsTools) {
+      await expect(page.locator(`.tools-picker input[data-tool="${t}"]`)).toBeChecked();
+    }
+    // Tools NOT in the template are unchecked.
+    await expect(page.locator(`.tools-picker input[data-tool="list_sources"]`)).not.toBeChecked();
+    // Toggle one off and verify the hidden textarea reflects it.
+    await page.locator(`.tools-picker input[data-tool="detect_anomalies"]`).click();
+    const textareaValue = await page.locator("#mcp-product-tools").inputValue();
+    const lines = textareaValue.split("\n").filter(Boolean).sort();
+    expect(lines).toEqual(["get_service_health", "query_logs", "query_metrics"]);
+    // "Select all" enables every tool.
+    await page.locator(".tools-picker .tp-actions button", { hasText: "Select all" }).click();
+    const all = (await page.locator("#mcp-product-tools").inputValue()).split("\n").filter(Boolean);
+    expect(all.length).toBe(8);
+    // Cancel + re-seed for remaining tests.
+    await page.locator("button:has-text(\"Cancel\")").first().click();
+    const api2 = await request.newContext({ baseURL: BASE });
+    await api2.put("/api/products/playwright-ops", {
+      data: {
+        id: "playwright-ops", name: "Playwright Ops Bundle",
+        status: "published", tools: ["query_logs", "query_metrics"],
+        branding: { color: "#3178c6" },
+      },
+    });
+    await api2.dispose();
+  });
+
   test("Empty-state templates prefill the product modal (regression: was a no-op in initial slice)", async ({ page }) => {
     // Delete the seeded product so the empty state with templates
     // renders. afterAll restores ordering for the next workers.

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -67,7 +67,7 @@ import { buildAuditMiddleware } from "./audit/middleware.js";
 import { buildBypassBreadcrumb, buildBypassAuditParams } from "./audit/redaction-bypass.js";
 import { readCatalogFile, CatalogStore } from "./catalog/loader.js";
 import { readProductsFile, ProductsStore, validateProduct, writeProductsFile, ProductsLoadError } from "./products/loader.js";
-import { REGISTERED_TOOL_NAMES, unknownToolNames } from "./tools/registry-names.js";
+import { REGISTERED_TOOL_NAMES, REGISTERED_TOOLS, unknownToolNames } from "./tools/registry-names.js";
 import { redactValue } from "./policy/redact.js";
 import { IdentityRateLimiter, resolveToolRatePerMin, parseKeyRateLimits } from "./quota/limiter.js";
 import { TokenBudget, estimateTokensFor, resolveDailyTokenLimit } from "./quota/token-budget.js";
@@ -1016,6 +1016,16 @@ async function main() {
   // Get supported connector types
   app.get("/api/source-types", (_req, res) => {
     res.json(getSupportedTypes());
+  });
+
+  // Get the registry of MCP tools the server can advertise (name +
+  // category + one-line summary). The Products modal uses this to
+  // populate the tools-allowlist picker so a typo can't happen at
+  // authoring time; the server-side typo guard (PR #343) stays as
+  // defence-in-depth. Open to every viewer — there's nothing
+  // sensitive in the catalogue, it's just static metadata.
+  app.get("/api/tools/registry", (_req, res) => {
+    res.json({ tools: REGISTERED_TOOLS });
   });
 
   // Server info — version, loaded plugins, MCP protocol version, build metadata.

--- a/mcp-server/src/openapi.test.ts
+++ b/mcp-server/src/openapi.test.ts
@@ -15,6 +15,7 @@ test("openapi — every user-visible /api path is documented", () => {
     "/api/sources/{name}",
     "/api/sources/{name}/metrics",
     "/api/source-types",
+    "/api/tools/registry",
     "/api/settings",
     "/api/health-thresholds",
     "/api/me",

--- a/mcp-server/src/openapi.ts
+++ b/mcp-server/src/openapi.ts
@@ -153,6 +153,35 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
           },
         },
       },
+      "/api/tools/registry": {
+        get: {
+          tags: ["products"],
+          summary: "MCP tool catalogue — name + category + one-line summary, used by the Products picker.",
+          description: "Static metadata derived from REGISTERED_TOOLS. The Products modal pulls this to populate a multi-select picker grouped by category (discovery / query / diagnose / topology); the server-side typo guard (PR #343) stays as defence-in-depth.",
+          responses: {
+            "200": {
+              description: "Tool registry.",
+              content: { "application/json": { schema: {
+                type: "object",
+                properties: {
+                  tools: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      required: ["name", "category", "summary"],
+                      properties: {
+                        name: { type: "string" },
+                        category: { type: "string", enum: ["discovery", "query", "diagnose", "topology"] },
+                        summary: { type: "string" },
+                      },
+                    },
+                  },
+                },
+              } } },
+            },
+          },
+        },
+      },
       "/api/services": {
         get: {
           tags: ["services"],

--- a/mcp-server/src/tools/registry-names.test.ts
+++ b/mcp-server/src/tools/registry-names.test.ts
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
-import { REGISTERED_TOOL_NAMES, unknownToolNames } from "./registry-names.js";
+import { REGISTERED_TOOL_NAMES, REGISTERED_TOOLS, unknownToolNames } from "./registry-names.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const INDEX_TS = join(here, "..", "index.ts");
@@ -50,4 +50,25 @@ test("unknownToolNames — case-sensitive (MCP spec)", () => {
   // worse failure mode than rejecting (mismatched casing wouldn't
   // route to a real tool).
   assert.deepEqual(unknownToolNames(["List_Sources"]), ["List_Sources"]);
+});
+
+test("REGISTERED_TOOLS — every name has a category + summary", () => {
+  for (const t of REGISTERED_TOOLS) {
+    assert.ok(t.name, "name required");
+    assert.ok(t.category, `category required on ${t.name}`);
+    assert.ok(t.summary && t.summary.length > 10, `summary required on ${t.name}`);
+  }
+});
+
+test("REGISTERED_TOOLS — matches REGISTERED_TOOL_NAMES 1:1 (no drift)", () => {
+  const a = REGISTERED_TOOLS.map((t) => t.name).sort();
+  const b = [...REGISTERED_TOOL_NAMES].sort();
+  assert.deepEqual(a, b, "REGISTERED_TOOLS and REGISTERED_TOOL_NAMES must agree");
+});
+
+test("REGISTERED_TOOLS — every category is one of the four valid values", () => {
+  const valid = new Set(["discovery", "query", "diagnose", "topology"]);
+  for (const t of REGISTERED_TOOLS) {
+    assert.ok(valid.has(t.category), `unknown category '${t.category}' on ${t.name}`);
+  }
 });

--- a/mcp-server/src/tools/registry-names.ts
+++ b/mcp-server/src/tools/registry-names.ts
@@ -26,6 +26,31 @@ export const REGISTERED_TOOL_NAMES = [
 
 export type RegisteredToolName = typeof REGISTERED_TOOL_NAMES[number];
 
+/** Functional category of a tool, surfaced in /api/tools/registry and
+ *  used by the Products UI to group the multi-select picker. Keeps
+ *  operator-facing taxonomy stable even when tool descriptions evolve. */
+export type ToolCategory = "discovery" | "query" | "diagnose" | "topology";
+
+export interface ToolRegistryEntry {
+  name: RegisteredToolName;
+  category: ToolCategory;
+  /** One-liner — what the tool does, no fluff. The full multi-paragraph
+   *  description lives in createMcpServer's registerTool() call; this
+   *  is the catalogue summary the picker shows alongside the name. */
+  summary: string;
+}
+
+export const REGISTERED_TOOLS: readonly ToolRegistryEntry[] = [
+  { name: "list_sources",       category: "discovery", summary: "List configured observability backends + reachability." },
+  { name: "list_services",      category: "discovery", summary: "Discover service names across every connected backend." },
+  { name: "query_metrics",      category: "query",     summary: "Fetch the raw time-series for one metric of one service over a window." },
+  { name: "query_logs",         category: "query",     summary: "Fetch matching log lines for one service over a window." },
+  { name: "get_service_health", category: "diagnose",  summary: "Aggregated health verdict for one service (metrics + logs)." },
+  { name: "detect_anomalies",   category: "diagnose",  summary: "Scan for anomalous services using z-score / heuristics." },
+  { name: "get_topology",       category: "topology",  summary: "Return the infrastructure topology graph (resources + edges)." },
+  { name: "get_blast_radius",   category: "topology",  summary: "Given a resource, return the impact set if its host(s) fail." },
+] as const;
+
 /** Validate a candidate Product tools[] array. Returns the unknown
  *  names (empty array = all OK). Pure helper — the caller decides
  *  how to surface the rejection (the API handler emits a 422 with a

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -1003,6 +1003,21 @@
       opacity: .35; pointer-events: none;
     }
 
+    /* Products modal — tools picker (multi-select grouped by category) */
+    .tools-picker { border: 1px solid var(--border); border-radius: var(--radius-sm); padding: var(--sp-2); background: var(--surface-2); max-height: 280px; overflow-y: auto; }
+    .tools-picker .tp-group { padding: var(--sp-1) 0; }
+    .tools-picker .tp-group + .tp-group { margin-top: var(--sp-2); border-top: 1px dashed var(--border); padding-top: var(--sp-2); }
+    .tools-picker .tp-cat { font-size: 11px; font-weight: 600; opacity: .65; text-transform: uppercase; letter-spacing: .04em; margin-bottom: var(--sp-1); padding: 0 var(--sp-1); }
+    .tools-picker .tp-item { display: flex; align-items: flex-start; gap: var(--sp-2); padding: var(--sp-1) var(--sp-2); border-radius: var(--radius-sm); cursor: pointer; }
+    .tools-picker .tp-item:hover { background: var(--surface); }
+    .tools-picker .tp-item input { margin-top: 3px; flex: 0 0 auto; }
+    .tools-picker .tp-item .tp-text { flex: 1; min-width: 0; }
+    .tools-picker .tp-item .tp-name { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 12px; font-weight: 500; }
+    .tools-picker .tp-item .tp-summary { font-size: 11px; opacity: .7; line-height: 1.4; margin-top: 1px; }
+    .tools-picker .tp-actions { display: flex; gap: var(--sp-2); margin-bottom: var(--sp-2); }
+    .tools-picker .tp-actions button { font-size: 11px; padding: 2px 8px; }
+    .tools-picker .tools-picker-hint { padding: var(--sp-2); opacity: .7; }
+
     /* Products — empty state with templates */
     .pempty { padding: var(--sp-5); text-align: center; }
     .pempty h3 { margin: 0 0 var(--sp-2); font-size: 16px; }
@@ -2161,9 +2176,14 @@ curl -s http://localhost:3000/api/enterprise/status</pre>
           </div>
         </div>
         <div class="form-group">
-          <label for="mcp-product-tools">Tools allow-list <span class="t-sm" style="opacity:.6">(optional)</span></label>
-          <textarea id="mcp-product-tools" rows="3" placeholder="query_logs&#10;query_metrics&#10;get_service_health"></textarea>
-          <div class="form-hint">One MCP tool name per line. Empty = no filter (every registered tool).</div>
+          <label>Tools allow-list <span class="t-sm" style="opacity:.6">(optional)</span></label>
+          <div id="mcp-product-tools-picker" class="tools-picker">
+            <div class="tools-picker-hint t-sm">Loading…</div>
+          </div>
+          <!-- Hidden textarea kept for back-compat — the picker syncs
+               selections here, and save() still reads from it. -->
+          <textarea id="mcp-product-tools" rows="2" hidden></textarea>
+          <div class="form-hint">Select the tools an agent bound to this product can call. Nothing selected = no filter (every registered tool).</div>
         </div>
         <div class="form-row">
           <div class="form-group">
@@ -3364,6 +3384,88 @@ function mcpLeitfadenToggle() {
   try { localStorage.setItem('omcp-mcp-leitfaden-collapsed', nextCollapsed ? '1' : '0'); } catch (e) { /* noop */ }
 }
 
+// Cache the tool registry — fetched once on first modal open and
+// reused thereafter. Falsy means not-yet-loaded; an empty array
+// means the endpoint replied but with no tools (server bug — we
+// fall back to a textarea-style entry in that case).
+let MCP_TOOLS_REGISTRY = null;
+async function mcpLoadToolsRegistry() {
+  if (MCP_TOOLS_REGISTRY) return MCP_TOOLS_REGISTRY;
+  try {
+    const r = await fetch('/api/tools/registry');
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+    const j = await r.json();
+    MCP_TOOLS_REGISTRY = Array.isArray(j.tools) ? j.tools : [];
+    return MCP_TOOLS_REGISTRY;
+  } catch (e) {
+    // Surface but don't break the modal — fall back to []
+    // (operator can still hand-edit via the textarea fallback).
+    MCP_TOOLS_REGISTRY = [];
+    return MCP_TOOLS_REGISTRY;
+  }
+}
+function mcpRenderToolsPicker(selected) {
+  const picker = document.getElementById('mcp-product-tools-picker');
+  const textarea = document.getElementById('mcp-product-tools');
+  if (!picker || !textarea) return;
+  const tools = MCP_TOOLS_REGISTRY || [];
+  if (tools.length === 0) {
+    // Fallback: expose the textarea so the operator can still author
+    // by hand. The server-side typo guard catches mistakes either way.
+    textarea.hidden = false;
+    textarea.value = (selected || []).join('\n');
+    picker.innerHTML = '<div class="tools-picker-hint">Tool registry unavailable — type names one per line.</div>';
+    return;
+  }
+  const selSet = new Set(selected || []);
+  // Group by category, ordered. Keep an "(other)" bucket for any
+  // future category we forgot in the CSS.
+  const order = ['discovery', 'query', 'diagnose', 'topology'];
+  const groups = {};
+  for (const t of tools) (groups[t.category] = groups[t.category] || []).push(t);
+  const labels = { discovery: 'Discovery', query: 'Query', diagnose: 'Diagnose', topology: 'Topology' };
+  const html = order.filter((c) => groups[c]).map((cat) => {
+    const items = groups[cat].map((t) => {
+      const checked = selSet.has(t.name) ? 'checked' : '';
+      return `<label class="tp-item">
+        <input type="checkbox" data-tool="${escHtml(t.name)}" ${checked} onchange="mcpToolsPickerSync()">
+        <span class="tp-text">
+          <span class="tp-name">${escHtml(t.name)}</span>
+          <span class="tp-summary">${escHtml(t.summary)}</span>
+        </span>
+      </label>`;
+    }).join('');
+    return `<div class="tp-group">
+      <div class="tp-cat">${escHtml(labels[cat] || cat)}</div>
+      ${items}
+    </div>`;
+  }).join('');
+  picker.innerHTML = `
+    <div class="tp-actions">
+      <button type="button" class="btn btn-ghost" onclick="mcpToolsPickerAll(true)">Select all</button>
+      <button type="button" class="btn btn-ghost" onclick="mcpToolsPickerAll(false)">Clear</button>
+    </div>
+    ${html}
+  `;
+  // Keep the hidden textarea in sync with the initial selection.
+  textarea.value = (selected || []).join('\n');
+}
+function mcpToolsPickerSync() {
+  const picker = document.getElementById('mcp-product-tools-picker');
+  const textarea = document.getElementById('mcp-product-tools');
+  if (!picker || !textarea) return;
+  const checked = Array.from(picker.querySelectorAll('input[type=checkbox][data-tool]:checked'))
+    .map((el) => el.getAttribute('data-tool'))
+    .filter(Boolean);
+  textarea.value = checked.join('\n');
+}
+function mcpToolsPickerAll(on) {
+  const picker = document.getElementById('mcp-product-tools-picker');
+  if (!picker) return;
+  picker.querySelectorAll('input[type=checkbox][data-tool]').forEach((el) => { el.checked = on; });
+  mcpToolsPickerSync();
+}
+
 // Empty-state product templates. Cloning a template prefills the
 // modal — the operator only has to pick an id + tweak before save.
 // Templates are pure UI; the server doesn't know about them.
@@ -3591,6 +3693,13 @@ function mcpProductOpen(mode, current) {
     iconEl.value = (c.branding && c.branding.iconUrl) || '';
   }
   document.getElementById('mcp-product-modal').classList.add('open');
+  // Build the tools picker from the registry — fetched once on the
+  // first modal open and cached client-side. Selected = whatever was
+  // already in the (potentially template-prefilled) textarea.
+  mcpLoadToolsRegistry().then(() => {
+    const seeded = (toolsEl.value || '').split(/[\n,]+/).map((s) => s.trim()).filter(Boolean);
+    mcpRenderToolsPicker(seeded);
+  });
   // When opening from a template the id is the one thing the operator
   // hasn't picked yet; in every other case (edit, blank new) the name
   // is the most natural focus target.


### PR DESCRIPTION
Slice C of the UI/UX rework — closes the tools-allowlist typo class at the source.

## What's new

### Server
- \`REGISTERED_TOOLS\` array in \`src/tools/registry-names.ts\` — \`{name, category, summary}\` per tool, 4 categories (\`discovery\` / \`query\` / \`diagnose\` / \`topology\`), 8 entries
- New \`GET /api/tools/registry\` returns the catalogue. Open to every viewer (static metadata, nothing sensitive)
- 3 new unit tests: every entry has category + summary; 1:1 match with \`REGISTERED_TOOL_NAMES\`; only valid categories
- OpenAPI spec entry + the routes-allowlist guard extended

### UI
- Products modal's tools textarea is now \`hidden\`. A new \`#mcp-product-tools-picker\` div renders a multi-select grouped by category with summary lines and Select-all / Clear actions
- \`mcpLoadToolsRegistry()\` lazy-fetches on first modal open (client-cached). Fallback: unhidden textarea if the endpoint fails
- \`mcpToolsPickerSync()\` writes selections into the hidden textarea — the existing \`save()\` flow stays byte-identical
- 1 new playwright test: 4 category headers visible, ops-bundle template pre-checks the right 4 tools, toggling syncs the textarea, \"Select all\" enables all 8

The server-side typo guard (PR #343) stays as defence-in-depth for curl POST + file imports.

## Test plan

- [x] Local stack: \`/api/tools/registry\` returns 8 tools across 4 categories
- [x] 14/14 unit + openapi tests green; tsc clean
- [x] Reviewer-agent clean (cache-on-failure intentional, escHtml on every interpolated string, label-wraps-input toggle correct)
- [x] New playwright spec exercises picker + sync + select-all

🤖 Generated with [Claude Code](https://claude.com/claude-code)