### PR TITLE
feat(products): agent preview endpoint + Review pane embed + card action (Slice E)

### DIFF
--- a/mcp-server/playwright/products.spec.mjs
+++ b/mcp-server/playwright/products.spec.mjs
@@ -90,6 +90,67 @@ test.describe("Products UI", () => {
     await page.locator("#mcp-products-leitfaden .card-header").click();
   });
 
+  test("Agent preview — /api/products/:id/preview returns filtered tools + card 'Preview as agent' opens the modal", async ({ page, request: apiReq }) => {
+    // The endpoint reflects the same filter the /mcp transport
+    // applies, so this test doubles as a contract pin between the
+    // server's tools/list filter and the UI preview affordance.
+    const resp = await apiReq.get("/api/products/playwright-ops/preview");
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.unrestricted).toBe(false);
+    expect(body.tools.map((t) => t.name).sort()).toEqual(["query_logs", "query_metrics"]);
+    // Open the page + click the per-card preview button.
+    await page.goto(BASE);
+    await page.click("[data-page=products]");
+    await page.waitForSelector("#page-products.active");
+    await page.locator(".pcard").first().locator("button:has-text(\"Preview as agent\")").click();
+    await expect(page.locator("#mcp-agent-preview-modal.open")).toBeVisible();
+    await expect(page.locator("#mcp-agent-preview-title")).toContainText("Playwright Ops Bundle");
+    await expect(page.locator("#mcp-agent-preview-list")).toContainText("query_logs");
+    await expect(page.locator("#mcp-agent-preview-list")).toContainText("query_metrics");
+    // Negative control: a tool NOT in the allow-list isn't rendered.
+    await expect(page.locator("#mcp-agent-preview-list")).not.toContainText("get_topology");
+    // Close + sanity check.
+    await page.locator("#mcp-agent-preview-modal button:has-text(\"Close\")").click();
+    await expect(page.locator("#mcp-agent-preview-modal.open")).toBeHidden();
+  });
+
+  test("Wizard Review pane — embedded agent preview reflects the in-form tools selection (no server roundtrip)", async ({ page }) => {
+    // Delete the seeded product so the empty-state path renders the
+    // templates we click in the next step.
+    const api = await request.newContext({ baseURL: BASE });
+    await api.delete("/api/products/playwright-ops");
+    await api.dispose();
+    await page.goto(BASE);
+    await page.click("[data-page=products]");
+    await page.waitForSelector("#page-products.active");
+    // Open via the Ops template — pre-checks 4 tools.
+    await page.locator(".pempty-tpl").first().click();
+    await page.locator("#mcp-product-id").fill("playwright-wiz-preview");
+    // Jump straight to Review.
+    await page.click('.wiz-step-btn[data-step="4"]');
+    await expect(page.locator("#wiz-pane-4")).toBeVisible();
+    // Embedded preview shows the 4 ops-bundle tools.
+    const preview = page.locator("#mcp-wiz-agent-preview");
+    await expect(preview).toBeVisible();
+    for (const t of ["query_logs", "query_metrics", "get_service_health", "detect_anomalies"]) {
+      await expect(preview).toContainText(t);
+    }
+    // A tool NOT in the template is not in the preview.
+    await expect(preview).not.toContainText("get_topology");
+    // Cancel + re-seed.
+    await page.locator("button:has-text(\"Cancel\")").first().click();
+    const api2 = await request.newContext({ baseURL: BASE });
+    await api2.put("/api/products/playwright-ops", {
+      data: {
+        id: "playwright-ops", name: "Playwright Ops Bundle",
+        status: "published", tools: ["query_logs", "query_metrics"],
+        branding: { color: "#3178c6" },
+      },
+    });
+    await api2.dispose();
+  });
+
   test("Wizard — 4 panes, Back/Next navigation, validation gates Identity, Review summary", async ({ page }) => {
     // Delete the seeded product so the empty-state templates path
     // gives us a clean wizard open.

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1947,6 +1947,36 @@ async function main() {
     res.json(p);
   });
 
+  // Agent preview — what would the /mcp tools/list response look
+  // like for a credential bound to this product? Same RBAC + tenant
+  // gate as the singular GET above. The body mirrors the actual
+  // tools/list shape (name + description + category), filtered the
+  // same way the /mcp transport filters it via allowsTool +
+  // registerTool — so the UI's Review pane shows the exact set the
+  // agent will see, not an approximation. Branding metadata travels
+  // alongside so the preview can render with the product's identity.
+  app.get("/api/products/:id/preview", need("products", "read"), async (req, res) => {
+    await products.maybeReload();
+    const sess = (req as AuthedRequest).session;
+    const isAdmin = hasPermission(sess?.roles, "users", "delete");
+    const callerTenant = sess?.tenant || "default";
+    const tenantFilter = isAdmin ? undefined : callerTenant;
+    const id = String(req.params.id);
+    const p = products.get(id, tenantFilter);
+    if (!p) { res.status(404).json({ error: "not found" }); return; }
+    if (!isAdmin && p.status === "staging") { res.status(404).json({ error: "not found" }); return; }
+    const allowList = p.tools && p.tools.length > 0 ? p.tools : undefined;
+    const filteredTools = REGISTERED_TOOLS.filter((t) => allowsTool(allowList, t.name));
+    res.json({
+      product: { id: p.id, name: p.name, version: p.version, branding: p.branding, tenant: p.tenant, status: p.status },
+      // unrestricted = true when the product has no tools allow-list,
+      // i.e. the bound agent sees every registered tool. UI uses this
+      // to render a distinct "no filter" preview banner.
+      unrestricted: !allowList,
+      tools: filteredTools,
+    });
+  });
+
   // Health endpoint for UI dashboard
   app.get("/api/health/:service", async (req, res) => {
     try {

--- a/mcp-server/src/openapi.test.ts
+++ b/mcp-server/src/openapi.test.ts
@@ -30,6 +30,7 @@ test("openapi — every user-visible /api path is documented", () => {
     "/api/catalog",
     "/api/products",
     "/api/products/{id}",
+    "/api/products/{id}/preview",
     "/api/info",
     "/api/openapi.json",
   ];

--- a/mcp-server/src/openapi.ts
+++ b/mcp-server/src/openapi.ts
@@ -672,6 +672,52 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
           },
         },
       },
+      "/api/products/{id}/preview": {
+        get: {
+          tags: ["products"],
+          summary: "Agent preview — the filtered tools/list a credential bound to this product would receive.",
+          description: "Same tenancy + staging filter as GET /api/products/{id}. Returns the product's branding/identity metadata + the registered MCP tools after applying its tools allow-list. The UI uses this for the per-card 'Preview as agent' affordance.",
+          parameters: [
+            { name: "id", in: "path", required: true, schema: { type: "string" } },
+          ],
+          responses: {
+            "200": {
+              description: "Preview payload.",
+              content: { "application/json": { schema: {
+                type: "object",
+                required: ["product", "unrestricted", "tools"],
+                properties: {
+                  product: {
+                    type: "object",
+                    properties: {
+                      id: { type: "string" },
+                      name: { type: "string" },
+                      version: { type: "string" },
+                      branding: { type: "object", additionalProperties: true },
+                      tenant: { type: "string" },
+                      status: { type: "string" },
+                    },
+                  },
+                  unrestricted: { type: "boolean", description: "True when the product has no tools allow-list — the bound agent sees every registered tool." },
+                  tools: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        name: { type: "string" },
+                        category: { type: "string", enum: ["discovery", "query", "diagnose", "topology"] },
+                        summary: { type: "string" },
+                      },
+                    },
+                  },
+                },
+              } } },
+            },
+            "404": { description: "Not found (or hidden by tenant / staging scope)." },
+            "403": { description: "Missing products:read permission." },
+          },
+        },
+      },
       "/api/catalog": {
         get: {
           tags: ["catalog"],

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -1030,6 +1030,18 @@
     .wiz-review-tools { display: flex; flex-wrap: wrap; gap: 4px; }
     .wiz-review-tools .pcard-tool { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 10.5px; padding: 2px 6px; background: var(--surface); border-radius: var(--radius-sm); border: 1px solid var(--border); }
 
+    /* Wizard Review — agent preview panel */
+    .wiz-agent-preview-h { margin: var(--sp-4) 0 var(--sp-2); font-size: 13px; font-weight: 600; }
+    .wiz-agent-preview { border: 1px solid var(--border); border-radius: var(--radius-sm); padding: var(--sp-3); background: var(--surface-2); }
+    .wiz-agent-banner { padding: var(--sp-2) var(--sp-3); margin-bottom: var(--sp-3); border-radius: var(--radius-sm); background: var(--warning-soft); color: var(--warning); font-size: 12px; }
+    .wiz-agent-group { padding: var(--sp-1) 0; }
+    .wiz-agent-group + .wiz-agent-group { border-top: 1px dashed var(--border); padding-top: var(--sp-2); margin-top: var(--sp-2); }
+    .wiz-agent-tool { padding: 4px 0; }
+    .wiz-agent-tool-name { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 12px; font-weight: 500; }
+    .wiz-agent-tool-summary { font-size: 11px; opacity: .75; line-height: 1.4; margin-top: 1px; }
+    .mcp-agent-preview { width: min(640px, 92vw); }
+    .mcp-agent-preview .modal-header { padding-left: var(--sp-3); }
+
     /* Products modal — tools picker (multi-select grouped by category) */
     .tools-picker { border: 1px solid var(--border); border-radius: var(--radius-sm); padding: var(--sp-2); background: var(--surface-2); max-height: 280px; overflow-y: auto; }
     .tools-picker .tp-group { padding: var(--sp-1) 0; }
@@ -2276,6 +2288,28 @@ curl -s http://localhost:3000/api/enterprise/status</pre>
         <button class="btn btn-ghost" id="mcp-wiz-back" onclick="mcpWizBack()" hidden>Back</button>
         <button class="btn btn-primary" id="mcp-wiz-next" onclick="mcpWizNext()">Next</button>
         <button class="btn btn-primary" id="mcp-wiz-save" onclick="mcpProductSave()" hidden>Save Product</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Agent preview modal — invoked from per-card "Preview as agent"
+       button. Same /api/products/:id/preview backend the wizard
+       Review pane could call, but the wizard uses the live registry
+       in-form because the draft hasn't been saved yet. -->
+  <div class="modal-overlay" id="mcp-agent-preview-modal">
+    <div class="modal mcp-agent-preview" style="--mcp-agent-accent: var(--accent)">
+      <div class="modal-header" style="border-left: 4px solid var(--mcp-agent-accent)">
+        <h3 id="mcp-agent-preview-title">Agent preview</h3>
+        <button class="btn-icon" onclick="closeModal('mcp-agent-preview-modal')">&times;</button>
+      </div>
+      <div class="modal-body">
+        <div id="mcp-agent-preview-meta" class="t-sm" style="opacity:.7;margin-bottom:var(--sp-3);font-family:'JetBrains Mono', ui-monospace, monospace;"></div>
+        <p class="t-sm" style="opacity:.85">This is the <code>tools/list</code> set a credential bound to this product would receive on its <code>/mcp</code> session.</p>
+        <div id="mcp-agent-preview-list" class="wiz-agent-preview"></div>
+      </div>
+      <div class="modal-footer">
+        <span style="flex:1"></span>
+        <button class="btn btn-primary" onclick="closeModal('mcp-agent-preview-modal')">Close</button>
       </div>
     </div>
   </div>
@@ -3620,6 +3654,7 @@ function mcpProductCardHtml(p) {
       <div class="pcard-tools">${toolsLabel}</div>
     </div>
     <div class="pcard-footer">
+      <button class="btn btn-ghost btn-sm" title="Preview as agent" aria-label="Preview ${escHtml(p.id)} as agent" onclick="mcpProductPreviewAgent('${idAttr}')">Preview as agent</button>
       <div class="pcard-spacer"></div>
       <button class="btn-icon" data-rbac="products:write" title="Edit" aria-label="Edit ${escHtml(p.id)}" onclick="mcpProductsEdit('${idAttr}')">&#9998;</button>
       <button class="btn-icon" data-rbac="products:delete" title="Delete" aria-label="Delete ${escHtml(p.id)}" onclick="mcpProductsDelete('${idAttr}')">&#128465;</button>
@@ -3826,7 +3861,77 @@ function mcpWizRenderReview() {
     <dt>Version</dt><dd>${empty(version)}</dd>
     <dt>Colour</dt><dd>${colorCell}</dd>
     <dt>Icon URL</dt><dd>${icon ? `<code>${escHtml(icon)}</code>` : '<span class="wiz-review-empty">—</span>'}</dd>
-  </dl>`;
+  </dl>
+  <h4 class="wiz-agent-preview-h">Agent preview <span class="t-sm" style="opacity:.6;font-weight:400">— what the bound agent will see in <code>tools/list</code></span></h4>
+  <div id="mcp-wiz-agent-preview" class="wiz-agent-preview"><div class="t-sm" style="opacity:.7">${tools.length === 0
+    ? 'No filter set. Agent would see every registered tool — load the live registry to confirm.'
+    : `Filter active. Agent would see ${tools.length} tool${tools.length===1?'':'s'} from the allow-list.`}</div></div>`;
+  // Resolve the preview from the live tool registry — same source the
+  // server uses to filter /mcp tools/list. We don't hit
+  // /api/products/:id/preview here because the wizard's form-state
+  // hasn't been saved yet (the id may not exist on the server). The
+  // resolution mirrors allowsTool's semantics exactly.
+  mcpLoadToolsRegistry().then(() => {
+    const previewEl = document.getElementById('mcp-wiz-agent-preview');
+    if (!previewEl) return;
+    const allow = new Set(tools);
+    const filtered = (MCP_TOOLS_REGISTRY || []).filter((t) => tools.length === 0 || allow.has(t.name));
+    previewEl.innerHTML = mcpAgentPreviewHtml(filtered, tools.length === 0);
+  });
+}
+
+// Shared renderer for the agent-preview list — used by the wizard
+// Review pane and by the per-card "Preview as agent" action.
+function mcpAgentPreviewHtml(tools, unrestricted) {
+  if (!tools || tools.length === 0) {
+    return '<div class="t-sm" style="opacity:.7">No tools available.</div>';
+  }
+  const order = ['discovery', 'query', 'diagnose', 'topology'];
+  const groups = {};
+  for (const t of tools) (groups[t.category] = groups[t.category] || []).push(t);
+  const labels = { discovery: 'Discovery', query: 'Query', diagnose: 'Diagnose', topology: 'Topology' };
+  const banner = unrestricted
+    ? '<div class="wiz-agent-banner" data-unrestricted="true">Unrestricted — the bound agent sees every registered tool below.</div>'
+    : '';
+  const html = order.filter((c) => groups[c]).map((cat) => {
+    const items = groups[cat].map((t) => `
+      <div class="wiz-agent-tool">
+        <div class="wiz-agent-tool-name">${escHtml(t.name)}</div>
+        <div class="wiz-agent-tool-summary">${escHtml(t.summary)}</div>
+      </div>`).join('');
+    return `<div class="wiz-agent-group">
+      <div class="tp-cat">${escHtml(labels[cat] || cat)}</div>
+      ${items}
+    </div>`;
+  }).join('');
+  return banner + html;
+}
+
+// "Preview as agent" — called from the per-card button. Hits the
+// authoritative server endpoint so the operator sees what the bound
+// agent actually receives in production, not a client-side guess.
+async function mcpProductPreviewAgent(idEnc) {
+  const id = decodeURIComponent(idEnc);
+  let body;
+  try {
+    const r = await fetch('/api/products/' + encodeURIComponent(id) + '/preview');
+    if (!r.ok) { toast('Preview unavailable: HTTP ' + r.status); return; }
+    body = await r.json();
+  } catch (e) { toast('Preview failed: ' + (e && e.message || e)); return; }
+  const accent = (body.product && body.product.branding && /^#[0-9a-fA-F]{3,8}$/.test(body.product.branding.color || ''))
+    ? body.product.branding.color : 'var(--accent)';
+  const dlg = document.getElementById('mcp-agent-preview-modal');
+  const title = document.getElementById('mcp-agent-preview-title');
+  const meta = document.getElementById('mcp-agent-preview-meta');
+  const list = document.getElementById('mcp-agent-preview-list');
+  if (!dlg || !title || !meta || !list) return;
+  title.textContent = body.product.name || body.product.id;
+  meta.innerHTML = `<code>${escHtml(body.product.id)}</code>${body.product.version ? ' · v' + escHtml(body.product.version) : ''} · tenant: ${escHtml(body.product.tenant || 'default')} · status: ${escHtml(body.product.status || 'published')}`;
+  list.innerHTML = mcpAgentPreviewHtml(body.tools || [], !!body.unrestricted);
+  // Apply branding to the modal's left rail for a quick at-a-glance
+  // identity confirmation that the right product was probed.
+  dlg.style.setProperty('--mcp-agent-accent', accent);
+  dlg.classList.add('open');
 }
 
 function mcpProductOpen(mode, current) {


### PR DESCRIPTION
Slice E of the UI/UX rework — what the bound agent actually sees, surfaced as a first-class affordance.

## What's new

### Server
- New \`GET /api/products/:id/preview\` returns the filtered \`tools/list\` for a credential bound to this product. Uses **the same** \`REGISTERED_TOOLS + allowsTool\` filter the \`/mcp\` transport applies. Same RBAC + tenant + staging filter as the singular GET (404 on cross-tenant + staging-by-non-admin).
- OpenAPI entry + the documented-routes guard extended.

### UI
- Per-card **\"Preview as agent\"** button opens a modal styled with the product's brand colour on a left rail (set via the CSSOM \`setProperty()\` — sanitised by the browser, plus a pre-existing hex regex = XSS-safe on two layers).
- **Wizard Review pane** embeds the same preview INLINE, resolved from the live \`MCP_TOOLS_REGISTRY\` cache against the form's current selection (the draft isn't on the server yet). Same \`allowsTool\` semantics client-side. Progressive enhancement when the registry is still loading.
- Shared \`mcpAgentPreviewHtml(tools, unrestricted)\` helper drives both surfaces.

## Test plan

- [x] Local stack: endpoint exercised in all three states (allow-list / unrestricted / 404 on missing id)
- [x] 14/14 unit + openapi tests green
- [x] 2 new playwright tests pin: per-card preview endpoint + modal contract with negative-control (\`get_topology\` NOT in Ops bundle); wizard Review-pane embedded preview reflects the ops template
- [x] Reviewer-agent clean (XSS surface analysed; RBAC parity confirmed; error paths don't corrupt DOM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)