### PR TITLE
feat(rbac): Subjects sub-tab + /api/subjects endpoint (Slice G)

### DIFF
--- a/mcp-server/playwright/rbac.spec.mjs
+++ b/mcp-server/playwright/rbac.spec.mjs
@@ -95,16 +95,45 @@ test.describe("Policies UI — engine banner + sticky dry-run", () => {
     await expect(deleteCell2).toHaveText("—");
   });
 
-  test("Bindings + Subjects sub-tabs render placeholder copy (slice G/H land them)", async ({ page }) => {
+  test("Subjects sub-tab — /api/subjects returns expected shape + UI sections render", async ({ page, request: apiReq }) => {
+    // Demo profile has no users / api-keys / OIDC mappings — all
+    // three arrays are empty, but the endpoint must still return the
+    // shape with `sources` set to the env-source path / null.
+    const resp = await apiReq.get("/api/subjects");
+    expect(resp.status()).toBe(200);
+    const j = await resp.json();
+    expect(Array.isArray(j.users)).toBe(true);
+    expect(Array.isArray(j.apiKeys)).toBe(true);
+    expect(Array.isArray(j.oidcGroups)).toBe(true);
+    expect(j.sources).toBeTruthy();
+    expect(typeof j.sources.users === "string" || j.sources.users === null).toBe(true);
+
+    // UI: Subjects sub-tab renders the three sections + the
+    // empty-state copy when the env isn't configured.
+    await page.goto(BASE);
+    await page.click("[data-page=policies]");
+    await page.waitForSelector("#page-policies.active");
+    await page.click(".pol-subtab[data-pol-tab=subjects]");
+    await expect(page.locator("#pol-pane-subjects")).toBeVisible();
+    const body = page.locator("#pol-subjects-body");
+    // Three section headings: Users / API keys / OIDC groups.
+    await expect(body.locator("h3", { hasText: "Users" })).toBeVisible();
+    await expect(body.locator("h3", { hasText: "API keys" })).toBeVisible();
+    await expect(body.locator("h3", { hasText: "OIDC groups" })).toBeVisible();
+    // In the demo profile each section shows the appropriate empty-
+    // state copy referencing the env var that drives it.
+    await expect(body).toContainText("OMCP_USERS_FILE");
+    await expect(body).toContainText("OMCP_API_KEYS");
+    await expect(body).toContainText("OMCP_OIDC_ROLE_MAP");
+  });
+
+  test("Bindings sub-tab renders placeholder copy (slice H lands it)", async ({ page }) => {
     await page.goto(BASE);
     await page.click("[data-page=policies]");
     await page.waitForSelector("#page-policies.active");
     await page.click(".pol-subtab[data-pol-tab=bindings]");
     await expect(page.locator("#pol-pane-bindings")).toBeVisible();
     await expect(page.locator("#pol-pane-bindings")).toContainText(/Bindings are the who/i);
-    await page.click(".pol-subtab[data-pol-tab=subjects]");
-    await expect(page.locator("#pol-pane-subjects")).toBeVisible();
-    await expect(page.locator("#pol-pane-subjects")).toContainText(/OMCP_USERS_FILE/);
   });
 
   test("authoring controls keyed on data-engine-required=file stay disabled on read-only engines", async ({ page }) => {

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1186,6 +1186,95 @@ async function main() {
     });
   });
 
+  // --- /api/subjects — aggregated principals catalogue ------------------
+  // The third k8s-shaped RBAC view: who the deployment knows about.
+  // Three independent sources, returned in three independent arrays so
+  // the UI can table each section separately:
+  //   - users     : OMCP_USERS_FILE (basic-mode local users). Password
+  //                 hashes are never returned.
+  //   - apiKeys   : OMCP_API_KEYS names (the bearer-token catalogue).
+  //                 Tokens are never returned; only metadata (tenant,
+  //                 bound product, source allow-list, bypass flag).
+  //   - oidcGroups: keys of OMCP_OIDC_ROLE_MAP — every group the
+  //                 operator has explicitly mapped to an OMCP role.
+  //                 Runtime-only groups (claims that arrive without an
+  //                 OMCP-side mapping) are skipped on purpose; they
+  //                 produce no roles by definition.
+  // Gated identically to /api/policy.
+  app.get("/api/subjects", need("users", "delete"), async (_req, res) => {
+    // Local users.
+    const usersOut: Array<{ username: string; name: string; roles: string[]; tenant: string }> = [];
+    if (process.env.OMCP_USERS_FILE) {
+      try {
+        const f = await readUsersFile(process.env.OMCP_USERS_FILE);
+        if (f && Array.isArray(f.users)) {
+          for (const u of f.users) {
+            usersOut.push({
+              username: u.username,
+              name: u.name,
+              roles: u.roles ? u.roles.slice() : [],
+              tenant: u.tenant || "default",
+            });
+          }
+        }
+      } catch (e) {
+        // Read failures don't 500 the whole endpoint — surface an
+        // empty users array; admins can check the boot log for the
+        // file-load diagnostic.
+        console.warn(`[/api/subjects] readUsersFile failed: ${(e as Error).message}`);
+      }
+    }
+    // API key credentials (tokens stripped).
+    const apiKeysOut: Array<{
+      name: string;
+      tenant: string;
+      productId?: string;
+      bypassRedaction: boolean;
+      allowedSources?: string[];
+    }> = [];
+    for (const c of loadCredentials()) {
+      apiKeysOut.push({
+        name: c.name,
+        tenant: c.tenant || "default",
+        productId: c.productId,
+        bypassRedaction: !!c.bypassRedaction,
+        allowedSources: c.allowedSources,
+      });
+    }
+    // OIDC groups → role mappings.
+    const oidcGroupsOut: Array<{ claim: string; role: string }> = [];
+    const roleMapRaw = process.env.OMCP_OIDC_ROLE_MAP;
+    if (roleMapRaw) {
+      try {
+        const parsed = JSON.parse(roleMapRaw);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          for (const [claim, role] of Object.entries(parsed)) {
+            if (typeof role === "string" && claim) {
+              oidcGroupsOut.push({ claim, role });
+            }
+          }
+        }
+      } catch {
+        // The OIDC runtime already rejects an invalid role map at
+        // boot — if parsing fails here it's almost certainly a
+        // transient state during config reload. Surface empty.
+      }
+    }
+    res.json({
+      users: usersOut,
+      apiKeys: apiKeysOut,
+      oidcGroups: oidcGroupsOut,
+      // Surface which env vars actually drive each list so an
+      // admin diagnosing "where is my user?" sees the source path
+      // without having to read the deploy.
+      sources: {
+        users: process.env.OMCP_USERS_FILE || null,
+        apiKeys: process.env.OMCP_API_KEYS ? "OMCP_API_KEYS" : null,
+        oidcGroups: process.env.OMCP_OIDC_ROLE_MAP ? "OMCP_OIDC_ROLE_MAP" : null,
+      },
+    });
+  });
+
   // --- /api/audit — management-plane audit feed -------------------------
   // Read-only, gated by the "audit:read" permission so only viewers /
   // operators / admins (basically anyone authenticated in the default

--- a/mcp-server/src/openapi.test.ts
+++ b/mcp-server/src/openapi.test.ts
@@ -27,6 +27,7 @@ test("openapi — every user-visible /api path is documented", () => {
     "/api/audit",
     "/api/usage",
     "/api/policy",
+    "/api/subjects",
     "/api/catalog",
     "/api/products",
     "/api/products/{id}",

--- a/mcp-server/src/openapi.ts
+++ b/mcp-server/src/openapi.ts
@@ -575,6 +575,43 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
           },
         },
       },
+      "/api/subjects": {
+        get: {
+          tags: ["auth"],
+          summary: "Aggregated subjects view — local users + API-key names + OIDC group mappings (admin-only).",
+          description: "Read-only catalogue of the principals an OMCP deployment knows about. Three independent sources: OMCP_USERS_FILE (users), OMCP_API_KEYS (apiKeys), OMCP_OIDC_ROLE_MAP (oidcGroups). Tokens + password hashes are never returned — only metadata.",
+          responses: {
+            "200": {
+              description: "Subjects payload.",
+              content: { "application/json": { schema: {
+                type: "object",
+                properties: {
+                  users: { type: "array", items: { type: "object", properties: {
+                    username: { type: "string" }, name: { type: "string" },
+                    roles: { type: "array", items: { type: "string" } },
+                    tenant: { type: "string" },
+                  } } },
+                  apiKeys: { type: "array", items: { type: "object", properties: {
+                    name: { type: "string" }, tenant: { type: "string" },
+                    productId: { type: "string" },
+                    bypassRedaction: { type: "boolean" },
+                    allowedSources: { type: "array", items: { type: "string" } },
+                  } } },
+                  oidcGroups: { type: "array", items: { type: "object", properties: {
+                    claim: { type: "string" }, role: { type: "string" },
+                  } } },
+                  sources: { type: "object", properties: {
+                    users: { type: ["string", "null"] },
+                    apiKeys: { type: ["string", "null"] },
+                    oidcGroups: { type: ["string", "null"] },
+                  } },
+                },
+              } } },
+            },
+            "403": { description: "Missing users:delete permission (admin-only)." },
+          },
+        },
+      },
       "/api/products": {
         get: {
           tags: ["products"],

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -1012,6 +1012,14 @@
       .pol-role-list { border-right: 0; border-bottom: 1px solid var(--border); max-height: none; }
     }
 
+    /* Subjects sub-tab — three stacked sections */
+    .pol-subjects-section { padding: var(--sp-3) var(--sp-4); }
+    .pol-subjects-section + .pol-subjects-section { border-top: 1px solid var(--border); }
+    .pol-subjects-section h3 { margin: 0 0 var(--sp-2); font-size: 13px; font-weight: 600; display: flex; align-items: baseline; gap: var(--sp-2); }
+    .pol-subjects-section h3 .pol-subjects-count { font-size: 11px; opacity: .65; font-weight: 400; }
+    .pol-subjects-section h3 .pol-subjects-source { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 10.5px; opacity: .55; margin-left: auto; }
+    .pol-subjects-empty { font-size: 12px; opacity: .65; padding: var(--sp-2) 0; }
+
     /* Sticky dry-run bar — pinned at the top of the policies page */
     .pol-probe-bar { position: sticky; top: 0; z-index: 5; background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: var(--sp-3); margin-bottom: var(--sp-3); box-shadow: 0 1px 2px rgba(0,0,0,.04); }
     .pol-probe-grid { display: grid; grid-template-columns: repeat(5, 1fr) auto; gap: var(--sp-3); align-items: end; }
@@ -2096,17 +2104,16 @@ curl -X PUT http://localhost:3000/api/enterprise/catalog \
         </div>
       </div>
 
-      <!-- Subjects sub-tab — placeholder for Slice H -->
+      <!-- Subjects sub-tab — three sections (Users / API keys /
+           OIDC groups). Read-only this slice. -->
       <div class="card pol-pane" id="pol-pane-subjects" role="tabpanel" hidden>
-        <div class="card-header"><h2>Subjects</h2></div>
-        <div class="content" style="padding: var(--sp-4);">
-          <p class="t-sm" style="opacity:.85;line-height:1.5;max-width:640px">
-            Subjects are the principals an OMCP deployment recognises — local users
-            (<code>OMCP_USERS_FILE</code>), API-key names (<code>OMCP_API_KEYS</code>),
-            and OIDC groups seen at sign-in. The Subjects table aggregates them in the
-            next slice.
-          </p>
-        </div>
+        <div class="card-header"><h2>Subjects
+          <button class="info" aria-label="About subjects"
+            data-title="Subjects"
+            data-info="The principals an OMCP deployment recognises: local users (basic auth via OMCP_USERS_FILE), bearer-token names from OMCP_API_KEYS, and OIDC groups the operator mapped to roles via OMCP_OIDC_ROLE_MAP. Slice H lands binding edits; this view is read-only."
+            onclick="infoPop(this)">?</button>
+        </h2></div>
+        <div id="pol-subjects-body" class="content"><div class="empty">Loading…</div></div>
       </div>
 
       <!-- Kept for back-compat — the legacy snapshot lives here but
@@ -2497,6 +2504,87 @@ function polSetTab(name) {
   document.querySelectorAll('.pol-pane').forEach((p) => {
     p.hidden = p.id !== 'pol-pane-' + name;
   });
+  // Lazy-load Subjects on first visit — it has its own endpoint
+  // so deferring the fetch keeps the page-enter cost low.
+  if (name === 'subjects') polLoadSubjects();
+}
+
+// Cache the subjects payload so re-entering the tab doesn't refetch.
+let POL_SUBJECTS = null;
+async function polLoadSubjects() {
+  const body = document.getElementById('pol-subjects-body');
+  if (!body) return;
+  if (POL_SUBJECTS) {
+    polRenderSubjects(POL_SUBJECTS);
+    return;
+  }
+  try {
+    const r = await fetch('/api/subjects');
+    if (!r.ok) {
+      body.innerHTML = '<div class="empty">Subjects view requires the <code>users:delete</code> permission (admin role).</div>';
+      return;
+    }
+    POL_SUBJECTS = await r.json();
+    polRenderSubjects(POL_SUBJECTS);
+  } catch (e) {
+    body.innerHTML = '<div class="empty">Subjects unavailable: ' + escHtml(String(e && e.message || e)) + '</div>';
+  }
+}
+function polRenderSubjects(j) {
+  const body = document.getElementById('pol-subjects-body');
+  if (!body) return;
+  const sources = j.sources || {};
+  const usersHtml = (j.users || []).map((u) => `
+    <tr>
+      <td><code>${escHtml(u.username)}</code></td>
+      <td>${escHtml(u.name)}</td>
+      <td>${(u.roles || []).map((r) => `<span class="pill">${escHtml(r)}</span>`).join(' ') || '<span class="t-sm" style="opacity:.5">—</span>'}</td>
+      <td>${escHtml(u.tenant || 'default')}</td>
+    </tr>`).join('');
+  const apiKeysHtml = (j.apiKeys || []).map((k) => `
+    <tr>
+      <td><code>${escHtml(k.name)}</code></td>
+      <td>${escHtml(k.tenant || 'default')}</td>
+      <td>${k.productId ? `<code>${escHtml(k.productId)}</code>` : '<span class="t-sm" style="opacity:.5">—</span>'}</td>
+      <td>${k.bypassRedaction ? '<span class="pill" style="background:var(--warning-soft);color:var(--warning)">bypass</span>' : '<span class="t-sm" style="opacity:.5">—</span>'}</td>
+      <td>${k.allowedSources && k.allowedSources.length ? k.allowedSources.map((s) => `<code class="t-sm">${escHtml(s)}</code>`).join(' ') : '<span class="t-sm" style="opacity:.5">(all)</span>'}</td>
+    </tr>`).join('');
+  const groupsHtml = (j.oidcGroups || []).map((g) => `
+    <tr>
+      <td><code>${escHtml(g.claim)}</code></td>
+      <td><span class="pill">${escHtml(g.role)}</span></td>
+    </tr>`).join('');
+  const usersTbl = usersHtml
+    ? `<table class="data-table" style="width:100%"><thead><tr><th>Username</th><th>Name</th><th>Roles</th><th>Tenant</th></tr></thead><tbody>${usersHtml}</tbody></table>`
+    : `<div class="pol-subjects-empty">${sources.users ? 'No users in <code>' + escHtml(sources.users) + '</code>.' : 'No local-user file configured — set <code>OMCP_USERS_FILE</code> to enable basic-mode logins.'}</div>`;
+  const apiKeysTbl = apiKeysHtml
+    ? `<table class="data-table" style="width:100%"><thead><tr><th>Name</th><th>Tenant</th><th>Product</th><th>Bypass</th><th>Sources</th></tr></thead><tbody>${apiKeysHtml}</tbody></table>`
+    : `<div class="pol-subjects-empty">${sources.apiKeys ? 'No credentials in <code>OMCP_API_KEYS</code>.' : 'No API-key credentials configured — set <code>OMCP_API_KEYS</code> to gate the <code>/mcp</code> transport with bearer tokens.'}</div>`;
+  const groupsTbl = groupsHtml
+    ? `<table class="data-table" style="width:100%"><thead><tr><th>Group / claim</th><th>Maps to role</th></tr></thead><tbody>${groupsHtml}</tbody></table>`
+    : `<div class="pol-subjects-empty">${sources.oidcGroups ? 'No mappings in <code>OMCP_OIDC_ROLE_MAP</code>.' : 'No OIDC group mapping configured — set <code>OMCP_OIDC_ROLE_MAP</code> when running under <code>OMCP_AUTH=oidc</code>.'}</div>`;
+  body.innerHTML = `
+    <div class="pol-subjects-section">
+      <h3>Users
+        <span class="pol-subjects-count">${(j.users || []).length}</span>
+        <span class="pol-subjects-source">${sources.users ? escHtml(sources.users) : 'OMCP_USERS_FILE'}</span>
+      </h3>
+      ${usersTbl}
+    </div>
+    <div class="pol-subjects-section">
+      <h3>API keys
+        <span class="pol-subjects-count">${(j.apiKeys || []).length}</span>
+        <span class="pol-subjects-source">OMCP_API_KEYS</span>
+      </h3>
+      ${apiKeysTbl}
+    </div>
+    <div class="pol-subjects-section">
+      <h3>OIDC groups
+        <span class="pol-subjects-count">${(j.oidcGroups || []).length}</span>
+        <span class="pol-subjects-source">OMCP_OIDC_ROLE_MAP</span>
+      </h3>
+      ${groupsTbl}
+    </div>`;
 }
 
 // Resources × actions catalogue, kept in sync with VALID_RESOURCES +
@@ -2602,6 +2690,10 @@ async function loadPolicies() {
     const j = await r.json();
     polRenderEngineBanner(j);
     POL_SNAPSHOT = j;
+    // Invalidate subjects cache on each policy reload so the next
+    // Subjects tab visit fetches fresh data (env vars / users file
+    // may have changed since last visit).
+    POL_SUBJECTS = null;
     // Default sub-tab = Roles.
     if (!document.querySelector('.pol-subtab[data-active="true"]')) {
       polSetTab('roles');


### PR DESCRIPTION
Slice G of the UI/UX rework — the third k8s-shaped RBAC view (who the deployment knows about).

## What's new

### Server: \`GET /api/subjects\` (admin-only, users:delete)
Three independent arrays + a \`sources\` block:

| Source | Env var |
|---|---|
| \`users\` | \`OMCP_USERS_FILE\` (basic-mode local users) — \`passwordHash\` dropped |
| \`apiKeys\` | \`OMCP_API_KEYS\` names — bearer token dropped |
| \`oidcGroups\` | \`OMCP_OIDC_ROLE_MAP\` keys → roles |

\`sources\` block tells the admin exactly which env var drives each list (or null when unset). IO + JSON-parse failures are logged but don't 500 — empty arrays surface instead. OpenAPI entry + documented-routes guard extended.

### UI
- \`polLoadSubjects()\` lazy-loader (cached, invalidated on every \`loadPolicies\`).
- Three sections with count badges + per-section env-var hint in the header.
- Empty-state copy per section explains exactly which env var to set.

## Backwards-compat

Zero changes to existing endpoints / payloads. Pure addition.

## Test plan

- [x] Local stack: /api/subjects returns the three-array shape with all-null sources block (demo configures none)
- [x] 26/26 unit + openapi tests green
- [x] 1 new playwright test hits the endpoint directly + drives the UI for section headings + empty-state copy
- [x] Reviewer-agent green (token + passwordHash leak surface analysed, escHtml on every interpolated user string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)