### PR TITLE
feat(security): default-on plugin signature verification (Phase F1)

### DIFF
--- a/docs/airgapped-deployment.md
+++ b/docs/airgapped-deployment.md
@@ -120,7 +120,7 @@ All three are **off by default** and fail-closed: set `ENABLE_UI_INSTALL=true` *
 
 ### Verifying plugin provenance
 
-Provenance verification is **offline and built in** — no `cosign`, no Fulcio/Rekor, no network (an airgapped site cannot reach a transparency log). The server checks a local trust root with Node's built-in crypto: a plugin loads only when its `manifest.json` `integrity` (sha256 of the entry file) matches *and* the detached `manifest.json.sig` verifies against `PLUGIN_TRUST_ROOT`. Enable with `VERIFY_PLUGINS=true` (filesystem plugins) — see [`docs/plugin-architecture.md`](plugin-architecture.md#verification-airgapped-trust-root) for producing the artifacts. Runtime install/upload is *always* verified regardless of `VERIFY_PLUGINS`.
+Provenance verification is **offline and built in** — no `cosign`, no Fulcio/Rekor, no network (an airgapped site cannot reach a transparency log). The server checks a local trust root with Node's built-in crypto: a plugin loads only when its `manifest.json` `integrity` (sha256 of the entry file) matches *and* the detached `manifest.json.sig` verifies against `PLUGIN_TRUST_ROOT`. Verification is **on by default** since v2.0 (`VERIFY_PLUGINS` defaults to `true`); see [`docs/plugin-architecture.md`](plugin-architecture.md#verification-airgapped-trust-root) for producing the artifacts. Runtime install/upload is *always* verified regardless of `VERIFY_PLUGINS`.
 
 ## Configuration without the Web UI
 

--- a/docs/offline.md
+++ b/docs/offline.md
@@ -33,8 +33,10 @@ external call to boot or serve health, this fails.
 ## Running fully air-gapped
 
 - No runtime `npm install` (dependencies are baked into the image).
-- Plugin tarballs can be baked in; set `PLUGIN_REQUIRE_SIGNATURE=true` to
-  reject anything unsigned.
+- Plugin tarballs can be baked in. Signature verification is **on by
+  default** (`VERIFY_PLUGINS=true` since v2.0) — provide `PLUGIN_TRUST_ROOT`
+  so the bundled plugins load. To intentionally accept unsigned plugins
+  for a development workflow, set `VERIFY_PLUGINS=false`.
 - Leave `PROMETHEUS_URL` / `LOKI_URL` empty and add sources later via the Web
   UI or `config/sources.yaml` — the server starts healthy with no sources.
 

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -135,10 +135,10 @@ Because the signature covers the manifest and the manifest pins the entry-file h
 
 | Setting | Env | Default | Meaning |
 |---------|-----|---------|---------|
-| Verify  | `VERIFY_PLUGINS` | off | When `true/1/yes`, filesystem plugins are gated. |
-| Trust root | `PLUGIN_TRUST_ROOT` | — | Path to the PEM public key. |
+| Verify  | `VERIFY_PLUGINS` | **on** (since v2.0) | When unset, `true/1/yes` filesystem plugins are gated. Set `false/0/no/off` to opt out (loads unsigned filesystem plugins — not recommended in production). |
+| Trust root | `PLUGIN_TRUST_ROOT` | — | Path to the PEM public key. Required when verify is on AND filesystem plugins are present; otherwise the loader logs and skips them. |
 
-**Fail-closed.** With `VERIFY_PLUGINS=true` and no/invalid trust root, *no* filesystem plugin loads (builtin Prometheus/Loki, part of the trusted image, are never gated, so the server stays functional). Any plugin missing a manifest, signature, or failing either check is skipped with a logged reason — it is never loaded "best effort".
+**Fail-closed.** With verify on and no/invalid trust root, *no* filesystem plugin loads (builtin Prometheus/Loki, part of the trusted image, are never gated, so the server stays functional). Any plugin missing a manifest, signature, or failing either check is skipped with a logged reason — it is never loaded "best effort". To intentionally run unsigned filesystem plugins (dev workflow only), set `VERIFY_PLUGINS=false`.
 
 Producing the artifacts (offline, from the connector dir):
 

--- a/helm/observability-mcp/README.md
+++ b/helm/observability-mcp/README.md
@@ -38,7 +38,7 @@ helm install obs-mcp ./helm/observability-mcp \
 | `podSecurityContext.runAsNonRoot` | `true` | Hardened defaults |
 | `plugins.image` | `ghcr.io/thotischner/observability-mcp-plugins:latest` | Official signed connector bundle; an init container extracts it into `/app/plugins` (no registry access from the main pod). Connectors stay inert until a matching source is configured. `""` disables it (builtin Prometheus/Loki only) |
 | `plugins.paths` | `[]` | Subdirs of `/plugins` to extract (empty = all) |
-| `plugins.verify.enabled` | `false` | Fail-closed connector verification (`VERIFY_PLUGINS`) — builtin Prometheus/Loki are never gated |
+| `plugins.verify.enabled` | `true` | Fail-closed connector verification (`VERIFY_PLUGINS`) — builtin Prometheus/Loki are never gated. Set to `false` to load unsigned filesystem plugins (not recommended for production) |
 | `plugins.verify.trustRootPem` | `""` | PEM public key trust root (rendered into a Secret) |
 | `plugins.verify.existingSecret` | `""` | Instead reference a Secret with key `trust-root.pem` |
 | `plugins.uiInstall.enabled` | `false` | Enable the fail-closed Web UI / API connector install + upload endpoints (`ENABLE_UI_INSTALL`). Requires a trust root (`plugins.verify.trustRootPem`/`existingSecret`) |

--- a/helm/observability-mcp/templates/_helpers.tpl
+++ b/helm/observability-mcp/templates/_helpers.tpl
@@ -48,12 +48,18 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{/*
-A plugin trust root is required whenever fail-closed verification is on
-(verify.enabled) OR the runtime UI/upload install endpoints are enabled
-(uiInstall.enabled — the server refuses to install unverified code).
+Mount a trust-root Secret only when the operator has actually
+provided one (inline PEM or existingSecret reference). Since v2.0
+plugins.verify.enabled is default-on; without a PEM the loader
+gracefully falls back to builtins, so a Secret mount would only
+break pod scheduling on a non-existent volume. uiInstall.enabled
+also requires a trust root, but values.yaml documents that as a
+precondition — without one the operator gets a clear runtime
+rejection from ENABLE_UI_INSTALL instead of a missing-Secret
+schedule failure.
 */}}
 {{- define "observability-mcp.needsTrustRoot" -}}
-{{- if or .Values.plugins.verify.enabled .Values.plugins.uiInstall.enabled -}}true{{- end -}}
+{{- if or .Values.plugins.verify.trustRootPem .Values.plugins.verify.existingSecret -}}true{{- end -}}
 {{- end -}}
 
 {{/*

--- a/helm/observability-mcp/templates/deployment.yaml
+++ b/helm/observability-mcp/templates/deployment.yaml
@@ -85,10 +85,12 @@ spec:
                   name: {{ include "observability-mcp.authSecretName" . }}
                   key: token
             {{- end }}
-            {{- if .Values.plugins.verify.enabled }}
+            # Always render the flag explicitly so a Helm override of
+            # plugins.verify.enabled wins over the server's default-on
+            # behaviour. Quoted so "false" reaches the container as the
+            # literal string the loader recognises as an opt-out.
             - name: VERIFY_PLUGINS
-              value: "true"
-            {{- end }}
+              value: {{ .Values.plugins.verify.enabled | quote }}
             {{- if include "observability-mcp.needsTrustRoot" . }}
             - name: PLUGIN_TRUST_ROOT
               value: /app/trust/trust-root.pem

--- a/helm/observability-mcp/values.yaml
+++ b/helm/observability-mcp/values.yaml
@@ -174,8 +174,12 @@ plugins:
   paths: []
   # Fail-closed signature + integrity verification (VERIFY_PLUGINS).
   # Builtin connectors are part of the trusted image and are never gated.
+  # Default ON since v2.0 — to load unsigned filesystem plugins set
+  # enabled=false explicitly. Without a trust root configured, no
+  # filesystem plugins load (only builtins), which is the safe default
+  # for any cluster that did not opt into signed plugin distribution.
   verify:
-    enabled: false
+    enabled: true
     # PEM public key used as the trust root. Provide it inline (rendered
     # into a Secret) OR point existingSecret at a Secret that has the
     # key `trust-root.pem`.

--- a/mcp-server/src/connectors/loader.test.ts
+++ b/mcp-server/src/connectors/loader.test.ts
@@ -30,7 +30,6 @@ function withEnv(overrides: Record<string, string | undefined>, fn: () => void):
 test("PluginLoader: VERIFY_PLUGINS defaults to ON when env var unset", () => {
   withEnv({ VERIFY_PLUGINS: undefined, PLUGIN_TRUST_ROOT: undefined }, () => {
     const loader = new PluginLoader({ pluginsDir: tmp() });
-    // @ts-expect-error access private field for verification
     assert.equal(loader["verify"], true, "verify default should be true (fail-closed)");
   });
 });
@@ -38,7 +37,6 @@ test("PluginLoader: VERIFY_PLUGINS defaults to ON when env var unset", () => {
 test("PluginLoader: VERIFY_PLUGINS=false opts out explicitly", () => {
   withEnv({ VERIFY_PLUGINS: "false" }, () => {
     const loader = new PluginLoader({ pluginsDir: tmp() });
-    // @ts-expect-error access private field for verification
     assert.equal(loader["verify"], false);
   });
 });
@@ -47,7 +45,6 @@ test("PluginLoader: VERIFY_PLUGINS=0 / no / off also opt out", () => {
   for (const v of ["0", "no", "off", "FALSE", "Off"]) {
     withEnv({ VERIFY_PLUGINS: v }, () => {
       const loader = new PluginLoader({ pluginsDir: tmp() });
-      // @ts-expect-error
       assert.equal(loader["verify"], false, `value ${v} should disable verify`);
     });
   }
@@ -57,7 +54,6 @@ test("PluginLoader: VERIFY_PLUGINS=true / 1 / yes keep verify on", () => {
   for (const v of ["true", "1", "yes", "TRUE", "Yes"]) {
     withEnv({ VERIFY_PLUGINS: v }, () => {
       const loader = new PluginLoader({ pluginsDir: tmp() });
-      // @ts-expect-error
       assert.equal(loader["verify"], true);
     });
   }
@@ -66,12 +62,10 @@ test("PluginLoader: VERIFY_PLUGINS=true / 1 / yes keep verify on", () => {
 test("PluginLoader: opts.verify overrides env var", () => {
   withEnv({ VERIFY_PLUGINS: "false" }, () => {
     const onLoader = new PluginLoader({ pluginsDir: tmp(), verify: true });
-    // @ts-expect-error
     assert.equal(onLoader["verify"], true);
   });
   withEnv({ VERIFY_PLUGINS: "true" }, () => {
     const offLoader = new PluginLoader({ pluginsDir: tmp(), verify: false });
-    // @ts-expect-error
     assert.equal(offLoader["verify"], false);
   });
 });

--- a/mcp-server/src/connectors/loader.test.ts
+++ b/mcp-server/src/connectors/loader.test.ts
@@ -1,0 +1,88 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { PluginLoader } from "./loader.js";
+
+function tmp(): string {
+  return mkdtempSync(join(tmpdir(), "loader-default-"));
+}
+
+function withEnv(overrides: Record<string, string | undefined>, fn: () => void): void {
+  const saved: Record<string, string | undefined> = {};
+  for (const k of Object.keys(overrides)) {
+    saved[k] = process.env[k];
+    if (overrides[k] === undefined) delete process.env[k];
+    else process.env[k] = overrides[k];
+  }
+  try {
+    fn();
+  } finally {
+    for (const k of Object.keys(saved)) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
+}
+
+test("PluginLoader: VERIFY_PLUGINS defaults to ON when env var unset", () => {
+  withEnv({ VERIFY_PLUGINS: undefined, PLUGIN_TRUST_ROOT: undefined }, () => {
+    const loader = new PluginLoader({ pluginsDir: tmp() });
+    // @ts-expect-error access private field for verification
+    assert.equal(loader["verify"], true, "verify default should be true (fail-closed)");
+  });
+});
+
+test("PluginLoader: VERIFY_PLUGINS=false opts out explicitly", () => {
+  withEnv({ VERIFY_PLUGINS: "false" }, () => {
+    const loader = new PluginLoader({ pluginsDir: tmp() });
+    // @ts-expect-error access private field for verification
+    assert.equal(loader["verify"], false);
+  });
+});
+
+test("PluginLoader: VERIFY_PLUGINS=0 / no / off also opt out", () => {
+  for (const v of ["0", "no", "off", "FALSE", "Off"]) {
+    withEnv({ VERIFY_PLUGINS: v }, () => {
+      const loader = new PluginLoader({ pluginsDir: tmp() });
+      // @ts-expect-error
+      assert.equal(loader["verify"], false, `value ${v} should disable verify`);
+    });
+  }
+});
+
+test("PluginLoader: VERIFY_PLUGINS=true / 1 / yes keep verify on", () => {
+  for (const v of ["true", "1", "yes", "TRUE", "Yes"]) {
+    withEnv({ VERIFY_PLUGINS: v }, () => {
+      const loader = new PluginLoader({ pluginsDir: tmp() });
+      // @ts-expect-error
+      assert.equal(loader["verify"], true);
+    });
+  }
+});
+
+test("PluginLoader: opts.verify overrides env var", () => {
+  withEnv({ VERIFY_PLUGINS: "false" }, () => {
+    const onLoader = new PluginLoader({ pluginsDir: tmp(), verify: true });
+    // @ts-expect-error
+    assert.equal(onLoader["verify"], true);
+  });
+  withEnv({ VERIFY_PLUGINS: "true" }, () => {
+    const offLoader = new PluginLoader({ pluginsDir: tmp(), verify: false });
+    // @ts-expect-error
+    assert.equal(offLoader["verify"], false);
+  });
+});
+
+test("PluginLoader.load(): with verify on + no trust root → builtins still load, filesystem skipped", async () => {
+  withEnv({ VERIFY_PLUGINS: undefined, PLUGIN_TRUST_ROOT: undefined }, async () => {
+    const loader = new PluginLoader({ pluginsDir: tmp() });
+    await loader.load();
+    const names = loader.supportedTypes();
+    assert.ok(names.includes("prometheus"), "prometheus builtin must remain available");
+    assert.ok(names.includes("loki"), "loki builtin must remain available");
+    assert.ok(names.includes("kubernetes"), "kubernetes builtin must remain available");
+  });
+});

--- a/mcp-server/src/connectors/loader.ts
+++ b/mcp-server/src/connectors/loader.ts
@@ -45,9 +45,11 @@ export class PluginLoader {
   private disabled: Set<string>;
 
   // Fail-closed verification for filesystem plugins. Builtins are part
-  // of the trusted image and are never gated. Default off so existing
-  // deployments are unchanged; recommended on in prod/airgapped (the
-  // Helm chart sets it).
+  // of the trusted image and are never gated. Default ON — operators
+  // who want to load unsigned filesystem plugins must opt out with
+  // VERIFY_PLUGINS=false. Without a trust root configured, no
+  // filesystem plugins load (only builtins), so the demo and any
+  // deployment without /app/plugins is unaffected.
   private verify: boolean;
   private trustRootPath?: string;
   private trustRoot?: KeyObject;
@@ -64,7 +66,7 @@ export class PluginLoader {
       .map((s) => s.trim())
       .filter(Boolean);
     this.disabled = new Set([...(opts.disabled ?? []), ...envDisabled]);
-    this.verify = opts.verify ?? /^(1|true|yes)$/i.test(process.env.VERIFY_PLUGINS ?? "");
+    this.verify = opts.verify ?? !/^(0|false|no|off)$/i.test(process.env.VERIFY_PLUGINS ?? "true");
     this.trustRootPath = opts.trustRoot ?? process.env.PLUGIN_TRUST_ROOT;
   }
 


### PR DESCRIPTION
## Summary
- Flips `VERIFY_PLUGINS` default from `false` to `true` so plugin signature verification is on by default. Operators who want unsigned filesystem plugins must opt out with `VERIFY_PLUGINS=false`.
- Helm chart `plugins.verify.enabled` defaults to `true`; deployment template always renders the env var explicitly so a Helm override wins over the server default.
- Backwards compat: deployments without `/app/plugins` or `PLUGIN_TRUST_ROOT` still work — builtin Prometheus/Loki/Kubernetes connectors are never gated and always load.
- Docs updated across `plugin-architecture.md`, `airgapped-deployment.md`, `offline.md`, and helm `README.md` for the new default + the opt-out path.

## Test plan
- [x] `find src -name '*.test.ts' -print0 | xargs -0 npx tsx --test` — 598/598 pass (new `loader.test.ts` adds 6 tests covering default-on, opt-out via `false`/`0`/`no`/`off` (any case), explicit-on values, `opts.verify` override, and the load() path with verify-on + no trust root proving all 3 builtins still register).
- [x] `helm template helm/observability-mcp` renders `VERIFY_PLUGINS=true` by default.
- [x] `helm template helm/observability-mcp --set plugins.verify.enabled=false` renders `VERIFY_PLUGINS=false` (opt-out works through Helm).
- [ ] CI: unit + integration + smoke tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)