### PR TITLE
feat(audit): pluggable sinks + Webhook delivery (Phase F4a)

### DIFF
--- a/docs/audit-sinks.md
+++ b/docs/audit-sinks.md
@@ -1,0 +1,121 @@
+# Audit sinks — mirror the audit chain to external systems
+
+The management-plane audit log writes a tamper-evident hash-chained
+JSONL file (`OMCP_MGMT_AUDIT_FILE`). For compliance workflows that
+need the same stream in Splunk, an Elastic SIEM, an OTLP collector
+that forwards to a log store, or any HTTP receiver, the gateway also
+fans every chained entry out to one or more **sinks**.
+
+> The on-disk JSONL chain is always the authoritative master. Sinks
+> are mirrors — they receive entries after they have already been
+> chained and persisted locally. A sick receiver never breaks the
+> chain or blocks the management plane.
+
+## Built-in sinks
+
+### Webhook (`webhook`)
+
+POSTs each entry as a JSON body to a configured URL.
+
+| Env | Meaning |
+|---|---|
+| `OMCP_AUDIT_WEBHOOK_URL` | Receiver URL. Setting this enables the sink. |
+| `OMCP_AUDIT_WEBHOOK_TOKEN` | Bearer token put on every request (`Authorization: Bearer ...`). |
+| `OMCP_AUDIT_WEBHOOK_DLQ` | File path for entries that exhausted retries. Empty = drop after final retry (still logged). |
+
+Retries: 5 attempts total with exponential backoff between attempts
+(1s → 2s → 4s → 8s, capped at 30s). Per-attempt request timeout 5s.
+
+Failures that exhaust retries land in the dead-letter file (one JSON
+line per entry) so an operator can replay them after the receiver
+recovers:
+
+```bash
+cat $OMCP_AUDIT_WEBHOOK_DLQ | while read line; do
+  curl -sS -X POST -H "content-type: application/json" \
+    -H "authorization: Bearer $OMCP_AUDIT_WEBHOOK_TOKEN" \
+    --data "$line" "$OMCP_AUDIT_WEBHOOK_URL"
+done
+```
+
+### Helm chart
+
+```yaml
+audit:
+  file: /var/lib/observability-mcp/audit.jsonl
+  webhook:
+    enabled: true
+    url: "https://splunk.example.com/services/collector/event"
+    # Prefer existingSecret in production:
+    existingSecret: "splunk-hec-token"
+    deadLetterFile: /var/lib/observability-mcp/audit-dlq.jsonl
+```
+
+When `existingSecret` is set, the chart mounts the `token` key from
+the referenced Secret into `OMCP_AUDIT_WEBHOOK_TOKEN`. Otherwise the
+chart renders a Secret from `audit.webhook.token`.
+
+## Receiver contract
+
+Every POST body is a single chained `AuditEntry`:
+
+```json
+{
+  "ts": "2026-06-05T20:14:00.000Z",
+  "seq": 42,
+  "actor": { "sub": "alice", "name": "alice" },
+  "tenant": "default",
+  "resource": "sources",
+  "action": "write",
+  "method": "POST",
+  "path": "/api/sources",
+  "status": 200,
+  "ip": "10.0.0.7",
+  "prevHash": "...",
+  "hash": "..."
+}
+```
+
+The receiver should:
+
+- Return any 2xx for success.
+- Return 4xx for permanent failures (the gateway still retries — the
+  client doesn't know the difference between 4xx-typo and 4xx-deliberate).
+  Long-term 4xx errors land in the DLQ after the retry budget.
+- Be idempotent on `(actor.sub, seq, hash)` — retries can deliver the
+  same entry more than once.
+
+## Verifying the chain end-to-end
+
+The DLQ + receiver-side store can be cross-checked against the local
+JSONL master:
+
+```bash
+# Sequence numbers present in the local master:
+jq -r .seq < /var/lib/observability-mcp/audit.jsonl | sort -n > local.seq
+
+# Sequence numbers present in the SIEM (Splunk example):
+splunk search 'index=audit | stats values(seq)' > siem.seq
+
+diff local.seq siem.seq
+```
+
+Any gap is either an in-flight request (most-recent few entries) or a
+sink failure worth investigating.
+
+## Currently-shipped sinks
+
+- ✅ `JsonlFileSink` — the existing on-disk master (always on when a
+  file is configured).
+- ✅ `WebhookSink` — described above.
+- ⏳ `S3CompatibleSink` — hourly rollup to S3 / MinIO. Planned; until
+  it lands an operator can wire a webhook receiver that batches and
+  uploads.
+
+## Failure mode
+
+If a sink throws synchronously at startup the gateway logs and skips
+that sink — it never refuses to boot because a sink misconfigured.
+At runtime, a sink that throws for a single entry logs the failure
+and continues; the JSONL master always succeeds (or the in-memory
+ring fills, depending on configuration).

--- a/helm/observability-mcp/templates/deployment.yaml
+++ b/helm/observability-mcp/templates/deployment.yaml
@@ -115,6 +115,25 @@ spec:
             - name: OMCP_OTEL_SERVICE_VERSION
               value: {{ include "observability-mcp.imageTag" . | quote }}
             {{- end }}
+            {{- if .Values.audit.file }}
+            - name: OMCP_MGMT_AUDIT_FILE
+              value: {{ .Values.audit.file | quote }}
+            {{- end }}
+            {{- if .Values.audit.webhook.enabled }}
+            - name: OMCP_AUDIT_WEBHOOK_URL
+              value: {{ .Values.audit.webhook.url | quote }}
+            {{- if .Values.audit.webhook.deadLetterFile }}
+            - name: OMCP_AUDIT_WEBHOOK_DLQ
+              value: {{ .Values.audit.webhook.deadLetterFile | quote }}
+            {{- end }}
+            {{- if or .Values.audit.webhook.token .Values.audit.webhook.existingSecret }}
+            - name: OMCP_AUDIT_WEBHOOK_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.audit.webhook.existingSecret | default (printf "%s-audit-webhook" (include "observability-mcp.fullname" .)) }}
+                  key: token
+            {{- end }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/helm/observability-mcp/templates/secret-audit-webhook.yaml
+++ b/helm/observability-mcp/templates/secret-audit-webhook.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.audit.webhook.enabled .Values.audit.webhook.token (not .Values.audit.webhook.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "observability-mcp.fullname" . }}-audit-webhook
+  labels:
+    {{- include "observability-mcp.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  token: {{ .Values.audit.webhook.token | quote }}
+{{- end }}

--- a/helm/observability-mcp/values.schema.json
+++ b/helm/observability-mcp/values.schema.json
@@ -74,6 +74,24 @@
         "serviceName": { "type": "string" }
       }
     },
+    "audit": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "file": { "type": "string" },
+        "webhook": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "url": { "type": "string" },
+            "token": { "type": "string" },
+            "existingSecret": { "type": "string" },
+            "deadLetterFile": { "type": "string" }
+          }
+        }
+      }
+    },
     "plugins": {
       "type": "object",
       "additionalProperties": false,

--- a/helm/observability-mcp/values.yaml
+++ b/helm/observability-mcp/values.yaml
@@ -163,6 +163,30 @@ otel:
   # Override resource service.name (otherwise defaults to
   # "observability-mcp").
   serviceName: ""
+
+# Audit-log external sinks. The on-disk JSONL chain (configured via
+# auditFile / OMCP_MGMT_AUDIT_FILE) stays the authoritative master.
+# These sinks mirror every chained entry to an external system so
+# SIEM / archive / compliance pipelines can consume the same stream
+# without reading the local file. See docs/audit-sinks.md.
+audit:
+  # Persistent JSONL master file. When unset the audit log lives in
+  # an in-memory ring (500 entries) — fine for the demo, not for
+  # compliance.
+  file: ""
+  webhook:
+    enabled: false
+    # POST URL — every chained entry becomes one POST with the
+    # entry's JSON body.
+    url: ""
+    # Bearer token put on every request. For real deployments
+    # reference a Secret via existingSecret.
+    token: ""
+    existingSecret: ""
+    # File path for entries that exhausted retries — the operator
+    # can replay them once the receiver recovers. Empty disables DLQ
+    # (entries are then dropped after the final retry, logged).
+    deadLetterFile: ""
   # - name: MCP_LOG_LEVEL
   #   value: info
   # - name: OMCP_AUTH

--- a/mcp-server/src/audit/log.ts
+++ b/mcp-server/src/audit/log.ts
@@ -19,6 +19,7 @@
 
 import { createHash } from "node:crypto";
 import { appendFile, readFile } from "node:fs/promises";
+import type { AuditSink } from "./sinks/types.js";
 
 export interface AuditEntry {
   /** RFC-3339 UTC timestamp. */
@@ -53,6 +54,11 @@ export interface AuditLogConfig {
   file?: string;
   /** How many recent entries to keep in memory regardless of file mode. */
   inMemoryCap?: number;
+  /** Mirror every chained entry to one or more external sinks
+   * (Splunk/SIEM webhook, S3 archive, ...). The on-disk JSONL chain
+   * stays the authoritative master — sinks are best-effort mirrors
+   * and never block record(). */
+  sinks?: AuditSink[];
 }
 
 export const DEFAULT_IN_MEMORY_CAP = 500;
@@ -61,6 +67,7 @@ const GENESIS_HASH = "0".repeat(64);
 export class AuditLog {
   private readonly cap: number;
   private readonly file: string | undefined;
+  private readonly sinks: AuditSink[];
   private ring: AuditEntry[] = [];
   private lastHash: string = GENESIS_HASH;
   private seq = 0;
@@ -70,6 +77,7 @@ export class AuditLog {
   constructor(cfg: AuditLogConfig = {}) {
     this.cap = cfg.inMemoryCap ?? DEFAULT_IN_MEMORY_CAP;
     this.file = cfg.file;
+    this.sinks = cfg.sinks ?? [];
   }
 
   /**
@@ -128,7 +136,40 @@ export class AuditLog {
         }),
       );
     }
+    // Fan out to any external sinks (webhook, archive, ...). Sinks
+    // are mirrors: failures are swallowed inside the sink so a sick
+    // SIEM never takes down the gateway. The JSONL master remains
+    // the authoritative chain.
+    for (const sink of this.sinks) {
+      // Intentionally not awaited: record() must stay fast and
+      // independent of receiver health.
+      sink.write(entry).catch((err: unknown) => {
+        console.warn(
+          "AuditLog: sink %s write failed: %s",
+          sink.name,
+          err instanceof Error ? err.message : String(err),
+        );
+      });
+    }
     return entry;
+  }
+
+  /** Flush every configured sink. Called from SIGTERM and tests. */
+  async flushSinks(): Promise<void> {
+    await this.writeQueue;
+    await Promise.all(
+      this.sinks.map((s) =>
+        s.flush
+          ? s.flush().catch((err: unknown) =>
+              console.warn(
+                "AuditLog: sink %s flush failed: %s",
+                s.name,
+                err instanceof Error ? err.message : String(err),
+              ),
+            )
+          : Promise.resolve(),
+      ),
+    );
   }
 
   /** Snapshot of the in-memory ring (most recent last). */

--- a/mcp-server/src/audit/sinks/types.ts
+++ b/mcp-server/src/audit/sinks/types.ts
@@ -1,0 +1,19 @@
+import type { AuditEntry } from "../log.js";
+
+/**
+ * A destination that receives every chained audit entry. The on-disk
+ * JSONL chain stays the authoritative master (so the hash chain is
+ * never split-brain across sinks); sinks are mirrors for SIEM /
+ * archive / webhook fan-out.
+ *
+ * write() must NEVER throw — sinks log+swallow internally. A sink that
+ * dies must not take down the management plane.
+ */
+export interface AuditSink {
+  /** Stable identifier, used in logs and env selection. */
+  readonly name: string;
+  /** Persist one chained entry. Best-effort; failures are logged. */
+  write(entry: AuditEntry): Promise<void>;
+  /** Flush any buffered state. Called on SIGTERM and in tests. */
+  flush?(): Promise<void>;
+}

--- a/mcp-server/src/audit/sinks/webhook.test.ts
+++ b/mcp-server/src/audit/sinks/webhook.test.ts
@@ -1,0 +1,176 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { WebhookSink } from "./webhook.js";
+import type { AuditEntry } from "../log.js";
+
+function sampleEntry(seq = 1): AuditEntry {
+  return {
+    ts: "2026-06-05T20:00:00.000Z",
+    seq,
+    actor: { sub: "alice", name: "alice" },
+    tenant: "default",
+    resource: "sources",
+    action: "write",
+    method: "POST",
+    path: "/api/sources",
+    status: 200,
+    prevHash: "0".repeat(64),
+    hash: "ff".repeat(32),
+  };
+}
+
+function tmpDLQ(): string {
+  return join(mkdtempSync(join(tmpdir(), "webhook-dlq-")), "dlq.jsonl");
+}
+
+function fakeFetchSequence(
+  statuses: Array<{ ok: boolean; status?: number; text?: string }>,
+): { fetchImpl: typeof fetch; calls: { count: number } } {
+  let i = 0;
+  const calls = { count: 0 };
+  const fetchImpl = (async () => {
+    calls.count++;
+    const next = statuses[Math.min(i, statuses.length - 1)];
+    i++;
+    return {
+      ok: next.ok,
+      status: next.status ?? (next.ok ? 200 : 500),
+      statusText: next.ok ? "OK" : "Server Error",
+      text: async () => next.text ?? "",
+    } as Response;
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+test("WebhookSink: happy path POSTs once and flushes cleanly", async () => {
+  const { fetchImpl, calls } = fakeFetchSequence([{ ok: true }]);
+  const sink = new WebhookSink({
+    url: "https://example.com/audit",
+    fetchImpl,
+    sleepImpl: async () => undefined,
+  });
+  await sink.write(sampleEntry());
+  await sink.flush();
+  assert.equal(calls.count, 1);
+});
+
+test("WebhookSink: retries with backoff on 500, succeeds on attempt 3", async () => {
+  const { fetchImpl, calls } = fakeFetchSequence([
+    { ok: false, status: 500 },
+    { ok: false, status: 503 },
+    { ok: true },
+  ]);
+  let sleeps = 0;
+  const sink = new WebhookSink({
+    url: "https://example.com/audit",
+    fetchImpl,
+    sleepImpl: async () => {
+      sleeps++;
+    },
+    initialBackoffMs: 10,
+    maxBackoffMs: 100,
+    maxAttempts: 5,
+  });
+  await sink.write(sampleEntry());
+  await sink.flush();
+  assert.equal(calls.count, 3);
+  assert.equal(sleeps, 2, "slept once between each failed attempt and the next");
+});
+
+test("WebhookSink: exhausts retries and writes to DLQ", async () => {
+  const { fetchImpl, calls } = fakeFetchSequence([{ ok: false, status: 500 }]);
+  const dlq = tmpDLQ();
+  const sink = new WebhookSink({
+    url: "https://example.com/audit",
+    fetchImpl,
+    sleepImpl: async () => undefined,
+    initialBackoffMs: 1,
+    maxAttempts: 3,
+    deadLetterFile: dlq,
+  });
+  await sink.write(sampleEntry(42));
+  await sink.flush();
+  assert.equal(calls.count, 3, "tried maxAttempts times");
+  assert.ok(existsSync(dlq), "DLQ file written");
+  const written = readFileSync(dlq, "utf8");
+  assert.match(written, /"seq":42/);
+});
+
+test("WebhookSink: write() does not throw even when underlying request fails", async () => {
+  const fetchImpl = (async () => {
+    throw new Error("network down");
+  }) as unknown as typeof fetch;
+  const sink = new WebhookSink({
+    url: "https://example.com/audit",
+    fetchImpl,
+    sleepImpl: async () => undefined,
+    maxAttempts: 2,
+    initialBackoffMs: 1,
+  });
+  // The contract: write() returns successfully (does NOT throw) even
+  // when delivery fails — the failure is logged and DLQ-handled.
+  await assert.doesNotReject(async () => {
+    await sink.write(sampleEntry());
+    await sink.flush();
+  });
+});
+
+test("WebhookSink: bearer token forwarded as Authorization header", async () => {
+  let seenAuth: string | undefined;
+  const fetchImpl = (async (_url: string, init: RequestInit) => {
+    const headers = init.headers as Record<string, string>;
+    seenAuth = headers["authorization"];
+    return { ok: true, status: 200, statusText: "OK", text: async () => "" } as Response;
+  }) as unknown as typeof fetch;
+  const sink = new WebhookSink({
+    url: "https://example.com/audit",
+    token: "secret-abc",
+    fetchImpl,
+    sleepImpl: async () => undefined,
+  });
+  await sink.write(sampleEntry());
+  await sink.flush();
+  assert.equal(seenAuth, "Bearer secret-abc");
+});
+
+test("WebhookSink: write order is preserved across retries (serialized queue)", async () => {
+  const seen: number[] = [];
+  let nextOk = false;
+  const fetchImpl = (async (_url: string, init: RequestInit) => {
+    const body = JSON.parse(init.body as string);
+    seen.push(body.seq);
+    const wasOk = nextOk;
+    nextOk = !wasOk; // alternate: first fails, second ok, etc.
+    return {
+      ok: wasOk,
+      status: wasOk ? 200 : 500,
+      statusText: "x",
+      text: async () => "",
+    } as Response;
+  }) as unknown as typeof fetch;
+  const sink = new WebhookSink({
+    url: "https://example.com/audit",
+    fetchImpl,
+    sleepImpl: async () => undefined,
+    initialBackoffMs: 1,
+    maxAttempts: 4,
+  });
+  // Fire two writes concurrently; they must be delivered in order
+  // because the internal queue serializes them.
+  const p1 = sink.write(sampleEntry(1));
+  const p2 = sink.write(sampleEntry(2));
+  await Promise.all([p1, p2]);
+  await sink.flush();
+  // First entry's POSTs should all precede the second entry's POSTs.
+  const firstIdx = seen.indexOf(1);
+  const secondIdx = seen.indexOf(2);
+  assert.ok(firstIdx >= 0 && secondIdx > firstIdx, `order broken: ${seen.join(",")}`);
+});
+
+test("WebhookSink: throws on missing url", () => {
+  assert.throws(() => new WebhookSink({ url: "" }), /url is required/);
+});

--- a/mcp-server/src/audit/sinks/webhook.ts
+++ b/mcp-server/src/audit/sinks/webhook.ts
@@ -1,0 +1,153 @@
+// WebhookSink: POST every audit entry to an HTTP endpoint (Splunk
+// HEC, generic SIEM ingestor, or any service that accepts a JSON
+// body). Retries with exponential backoff; entries that exhaust their
+// retries land in a dead-letter file on disk so an operator can
+// replay them once the receiver recovers.
+//
+// The sink runs entirely in-process — no queue daemon, no broker, no
+// extra runtime dep. Suitable for the OSS single-binary deployment.
+
+import { appendFile } from "node:fs/promises";
+import type { AuditEntry } from "../log.js";
+import type { AuditSink } from "./types.js";
+
+export interface WebhookSinkOptions {
+  /** Receiver URL. Required. */
+  url: string;
+  /** Optional bearer token mounted into the Authorization header. */
+  token?: string;
+  /** Additional headers to merge into every request. */
+  headers?: Record<string, string>;
+  /** Initial backoff before the first retry (ms). Default 1_000. */
+  initialBackoffMs?: number;
+  /** Cap on individual-retry sleep (ms). Default 30_000. */
+  maxBackoffMs?: number;
+  /** Total attempts (including the first). Default 5. */
+  maxAttempts?: number;
+  /** Path to write entries that exhausted retries. Optional. */
+  deadLetterFile?: string;
+  /** Inject a fetch impl for tests; defaults to globalThis.fetch. */
+  fetchImpl?: typeof fetch;
+  /** Inject a sleep impl for tests; defaults to setTimeout-based. */
+  sleepImpl?: (ms: number) => Promise<void>;
+  /** Per-attempt request timeout (ms). Default 5_000. */
+  requestTimeoutMs?: number;
+}
+
+export class WebhookSink implements AuditSink {
+  readonly name = "webhook";
+  private readonly url: string;
+  private readonly token?: string;
+  private readonly headers: Record<string, string>;
+  private readonly initialBackoffMs: number;
+  private readonly maxBackoffMs: number;
+  private readonly maxAttempts: number;
+  private readonly deadLetterFile?: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly sleepImpl: (ms: number) => Promise<void>;
+  private readonly requestTimeoutMs: number;
+  /** Outbound writes are queued so retries on one entry don't reorder
+   * later entries arriving in parallel. */
+  private writeQueue: Promise<void> = Promise.resolve();
+
+  constructor(opts: WebhookSinkOptions) {
+    if (!opts.url) throw new Error("WebhookSink: url is required");
+    this.url = opts.url;
+    this.token = opts.token;
+    this.headers = opts.headers ?? {};
+    this.initialBackoffMs = opts.initialBackoffMs ?? 1_000;
+    this.maxBackoffMs = opts.maxBackoffMs ?? 30_000;
+    this.maxAttempts = opts.maxAttempts ?? 5;
+    this.deadLetterFile = opts.deadLetterFile;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.sleepImpl =
+      opts.sleepImpl ??
+      ((ms: number) => new Promise((r) => setTimeout(r, ms).unref()));
+    this.requestTimeoutMs = opts.requestTimeoutMs ?? 5_000;
+  }
+
+  async write(entry: AuditEntry): Promise<void> {
+    this.writeQueue = this.writeQueue.then(() =>
+      this.attemptWithRetries(entry).catch((err) => {
+        // Final exhaustion path already wrote to DLQ if configured;
+        // log here so the operator sees the symptom even without DLQ.
+        console.warn(
+          "WebhookSink: dropping entry seq=%d after %d attempts: %s",
+          entry.seq,
+          this.maxAttempts,
+          err instanceof Error ? err.message : String(err),
+        );
+      }),
+    );
+    // Returning before the request completes keeps record() latency
+    // independent of webhook receiver health.
+    return Promise.resolve();
+  }
+
+  async flush(): Promise<void> {
+    await this.writeQueue;
+  }
+
+  private async attemptWithRetries(entry: AuditEntry): Promise<void> {
+    let backoff = this.initialBackoffMs;
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= this.maxAttempts; attempt++) {
+      try {
+        await this.attemptOnce(entry);
+        return;
+      } catch (err) {
+        lastErr = err;
+        if (attempt === this.maxAttempts) break;
+        await this.sleepImpl(backoff);
+        backoff = Math.min(backoff * 2, this.maxBackoffMs);
+      }
+    }
+    if (this.deadLetterFile) {
+      try {
+        await appendFile(
+          this.deadLetterFile,
+          JSON.stringify(entry) + "\n",
+          "utf8",
+        );
+      } catch (writeErr) {
+        console.warn(
+          "WebhookSink: DLQ write failed: %s",
+          writeErr instanceof Error ? writeErr.message : String(writeErr),
+        );
+      }
+    }
+    throw lastErr instanceof Error
+      ? lastErr
+      : new Error(String(lastErr ?? "webhook delivery failed"));
+  }
+
+  private async attemptOnce(entry: AuditEntry): Promise<void> {
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      ...this.headers,
+    };
+    if (this.token) headers["authorization"] = `Bearer ${this.token}`;
+
+    const ctl = new AbortController();
+    const t = setTimeout(() => ctl.abort(), this.requestTimeoutMs).unref?.();
+    try {
+      const res = await this.fetchImpl(this.url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(entry),
+        signal: ctl.signal,
+      });
+      if (!res.ok) {
+        // Read+discard so the connection releases. Limit body so a
+        // misbehaving receiver can't make the gateway page in MB of
+        // text per failure.
+        const snippet = (await res.text().catch(() => "")).slice(0, 200);
+        throw new Error(
+          `webhook returned ${res.status} ${res.statusText}: ${snippet}`,
+        );
+      }
+    } finally {
+      if (typeof t === "object" && t) clearTimeout(t);
+    }
+  }
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -65,6 +65,8 @@ import { loadPolicyFromFile, writePolicyFile, PolicyLoadError, VALID_RESOURCES, 
 import { OpaPolicyEngine } from "./auth/policy/opa.js";
 import { AuditLog } from "./audit/log.js";
 import { buildAuditMiddleware } from "./audit/middleware.js";
+import { WebhookSink } from "./audit/sinks/webhook.js";
+import type { AuditSink } from "./audit/sinks/types.js";
 import { buildBypassBreadcrumb, buildBypassAuditParams } from "./audit/redaction-bypass.js";
 import { readCatalogFile, CatalogStore } from "./catalog/loader.js";
 import { readProductsFile, ProductsStore, validateProduct, writeProductsFile, ProductsLoadError } from "./products/loader.js";
@@ -910,8 +912,36 @@ async function main() {
   // request. Writes JSONL to disk when OMCP_MGMT_AUDIT_FILE is set;
   // otherwise an in-memory ring of the last 500 entries keeps the
   // /api/audit endpoint useful in the demo / single-user case.
-  const mgmtAudit = new AuditLog({ file: process.env.OMCP_MGMT_AUDIT_FILE });
+  // External audit sinks — opt-in via env. Each chained entry is
+  // mirrored to every configured sink; the on-disk JSONL master
+  // remains the source of truth (the hash chain is never split).
+  const auditSinks: AuditSink[] = [];
+  if (process.env.OMCP_AUDIT_WEBHOOK_URL) {
+    auditSinks.push(
+      new WebhookSink({
+        url: process.env.OMCP_AUDIT_WEBHOOK_URL,
+        token: process.env.OMCP_AUDIT_WEBHOOK_TOKEN,
+        deadLetterFile: process.env.OMCP_AUDIT_WEBHOOK_DLQ,
+      }),
+    );
+    console.log(
+      "AuditLog: webhook sink enabled -> %s%s",
+      process.env.OMCP_AUDIT_WEBHOOK_URL,
+      process.env.OMCP_AUDIT_WEBHOOK_DLQ
+        ? ` (DLQ: ${process.env.OMCP_AUDIT_WEBHOOK_DLQ})`
+        : "",
+    );
+  }
+  const mgmtAudit = new AuditLog({
+    file: process.env.OMCP_MGMT_AUDIT_FILE,
+    sinks: auditSinks,
+  });
   await mgmtAudit.bootstrap();
+  process.on("SIGTERM", () => {
+    mgmtAudit
+      .flushSinks()
+      .catch((err) => console.warn("AuditLog flushSinks failed:", err));
+  });
   const audit = (resource: string, action: string) =>
     buildAuditMiddleware({ audit: mgmtAudit, resource, action });
 


### PR DESCRIPTION
## Summary
- Adds an \`AuditSink\` interface that fans every chained audit entry out to one or more external receivers. The on-disk JSONL master stays the authoritative chain — sinks are mirrors, sink failures are swallowed inside the sink so a sick receiver never breaks the management plane.
- Ships the \`WebhookSink\`: POSTs each entry to \`OMCP_AUDIT_WEBHOOK_URL\` with optional Bearer token, retries up to 5 times with capped exponential backoff (1s → 2s → 4s → 8s, max 30s), falls back to a JSONL dead-letter file on the operator's chosen path. Per-attempt request timeout 5s.
- Helm: new \`audit.webhook\` values block; chart renders a Secret for inline tokens or accepts \`existingSecret\` reference.
- Docs: full [\`docs/audit-sinks.md\`](./docs/audit-sinks.md) with env reference, receiver contract, DLQ replay snippet, and reconciliation hint.

## Scope split
- \`S3CompatibleSink\` (planned in F4) is intentionally NOT in this PR — split to follow-up F4b so this change stays focused and reviewable. Until then operators can wire a webhook receiver that batches and uploads.

## Test plan
- [x] Unit tests: 620/620 pass (613 baseline + 7 new \`WebhookSink\` tests: happy path, retries-then-success, exhaustion-to-DLQ, error swallowing, bearer-token forwarding, write-order under concurrency, missing-url rejection).
- [x] Build (\`tsc\`) clean.
- [x] \`helm template\` renders 0 \`OMCP_AUDIT_*\` env by default and the full set + Secret when \`audit.webhook.enabled=true\`.
- [x] Backwards compat: default install identical to pre-F4 deployment.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)