### PR TITLE
feat(policy): batch dry-run + CSV export (Phase F16a)

### DIFF
--- a/mcp-server/src/auth/policy/batch-dry-run.test.ts
+++ b/mcp-server/src/auth/policy/batch-dry-run.test.ts
@@ -1,0 +1,196 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  evaluateBatch,
+  batchResultToCsv,
+  DEFAULT_BATCH_LIMITS,
+  type BatchDryRunRequest,
+} from "./batch-dry-run.js";
+import type { PolicyEngine } from "./engine.js";
+
+class FakeEngine implements PolicyEngine {
+  // Allow when the roles array contains "admin", or
+  // when ((resource, action) is (sources, read) for any role).
+  evaluate(roles: string[] | undefined, resource: never, action: never): { allowed: boolean; reason?: string } {
+    if (roles?.includes("admin")) return { allowed: true, reason: "admin role" };
+    if (resource === "sources" && action === "read") return { allowed: true, reason: "public read" };
+    return { allowed: false, reason: `denied: roles=${(roles ?? []).join(",")} can't ${action} on ${resource}` };
+  }
+  roles(): Record<string, unknown> {
+    return { admin: {}, viewer: {} };
+  }
+  kind(): string {
+    return "fake";
+  }
+}
+
+const VALID_RES = new Set(["sources", "services", "settings"]);
+const VALID_ACT = new Set(["read", "write", "delete"]);
+
+function req(overrides: Partial<BatchDryRunRequest> = {}): BatchDryRunRequest {
+  return {
+    subjects: [{ key: "alice", roles: ["viewer"] }],
+    resources: ["sources"],
+    actions: ["read"],
+    ...overrides,
+  };
+}
+
+test("evaluateBatch: empty request → empty matrix + zero totals", async () => {
+  const r = await evaluateBatch(new FakeEngine(), { subjects: [], resources: [], actions: [] }, VALID_RES, VALID_ACT);
+  assert.deepEqual(r.matrix, {});
+  assert.deepEqual(r.totals, { cells: 0, allow: 0, deny: 0 });
+  assert.deepEqual(r.dropped, []);
+});
+
+test("evaluateBatch: 1×1×1 returns one verdict cell", async () => {
+  const r = await evaluateBatch(new FakeEngine(), req(), VALID_RES, VALID_ACT);
+  assert.equal(r.matrix.alice.sources.read.allowed, true);
+  assert.equal(r.matrix.alice.sources.read.reason, "public read");
+  assert.equal(r.totals.cells, 1);
+  assert.equal(r.totals.allow, 1);
+  assert.equal(r.totals.deny, 0);
+});
+
+test("evaluateBatch: full 2×2×2 matrix populated end-to-end", async () => {
+  const r = await evaluateBatch(
+    new FakeEngine(),
+    {
+      subjects: [
+        { key: "alice", roles: ["viewer"] },
+        { key: "bob", roles: ["admin"] },
+      ],
+      resources: ["sources", "services"],
+      actions: ["read", "delete"],
+    },
+    VALID_RES,
+    VALID_ACT,
+  );
+  assert.equal(r.totals.cells, 8);
+  assert.equal(r.matrix.alice.sources.read.allowed, true);   // public read
+  assert.equal(r.matrix.alice.services.read.allowed, false); // viewer can't read services
+  assert.equal(r.matrix.bob.services.delete.allowed, true);  // admin
+});
+
+test("evaluateBatch: unknown resource → dropped + matrix omits it", async () => {
+  const r = await evaluateBatch(
+    new FakeEngine(),
+    req({ resources: ["sources", "totally-bogus"] }),
+    VALID_RES,
+    VALID_ACT,
+  );
+  assert.equal(r.dropped.length, 1);
+  assert.equal(r.dropped[0].kind, "resource");
+  assert.equal(r.dropped[0].value, "totally-bogus");
+  // Matrix has only the surviving resource
+  assert.deepEqual(Object.keys(r.matrix.alice), ["sources"]);
+});
+
+test("evaluateBatch: unknown action → dropped", async () => {
+  const r = await evaluateBatch(
+    new FakeEngine(),
+    req({ actions: ["read", "blow-up"] }),
+    VALID_RES,
+    VALID_ACT,
+  );
+  assert.equal(r.dropped.some((d) => d.kind === "action" && d.value === "blow-up"), true);
+});
+
+test("evaluateBatch: deduplicates repeated inputs", async () => {
+  const r = await evaluateBatch(
+    new FakeEngine(),
+    {
+      subjects: [
+        { key: "alice", roles: ["viewer"] },
+        { key: "alice", roles: ["admin"] }, // dropped because key already seen
+      ],
+      resources: ["sources", "sources", "services"],
+      actions: ["read", "read", "delete"],
+    },
+    VALID_RES,
+    VALID_ACT,
+  );
+  // alice runs once, with the first-seen roles array (viewer); 1 subject × 2 resources × 2 actions = 4 cells.
+  assert.equal(Object.keys(r.matrix).length, 1);
+  assert.equal(r.totals.cells, 4);
+});
+
+test("evaluateBatch: malformed subject (missing roles) dropped with note", async () => {
+  const r = await evaluateBatch(
+    new FakeEngine(),
+    {
+      subjects: [
+        { key: "alice", roles: ["viewer"] },
+        { key: "broken" } as never, // no roles → drop
+      ],
+      resources: ["sources"],
+      actions: ["read"],
+    },
+    VALID_RES,
+    VALID_ACT,
+  );
+  assert.equal(Object.keys(r.matrix).length, 1);
+  assert.ok(r.dropped.some((d) => d.kind === "subject" && d.value === "broken"));
+});
+
+test("evaluateBatch: cap enforcement truncates oversize lists, notes in dropped", async () => {
+  const subjects = Array.from({ length: 5 }, (_, i) => ({ key: `s${i}`, roles: ["viewer"] }));
+  const resources = Array.from({ length: 3 }, (_, i) => `sources`); // dedup → 1
+  const r = await evaluateBatch(
+    new FakeEngine(),
+    { subjects, resources, actions: ["read"] },
+    VALID_RES,
+    VALID_ACT,
+    { maxSubjects: 2, maxResources: 5, maxActions: 5 },
+  );
+  // truncated to 2 subjects × 1 resource × 1 action
+  assert.equal(r.totals.cells, 2);
+  assert.ok(r.dropped.some((d) => d.kind === "cap" && d.value.startsWith("subjects=")));
+});
+
+test("evaluateBatch: per-subject tenant is threaded into engine.evaluate", async () => {
+  let lastTenant: string | undefined;
+  class TenantTracker implements PolicyEngine {
+    evaluate(_roles: string[] | undefined, _r: never, _a: never, ctx?: { tenant?: string }): { allowed: boolean } {
+      lastTenant = ctx?.tenant;
+      return { allowed: true };
+    }
+    roles() { return {}; }
+    kind() { return "tracker"; }
+  }
+  await evaluateBatch(
+    new TenantTracker(),
+    {
+      subjects: [{ key: "alice", roles: ["viewer"], tenant: "acme" }],
+      resources: ["sources"],
+      actions: ["read"],
+    },
+    VALID_RES,
+    VALID_ACT,
+  );
+  assert.equal(lastTenant, "acme");
+});
+
+test("batchResultToCsv: produces the documented header + escapes commas and quotes", async () => {
+  const r = await evaluateBatch(
+    new FakeEngine(),
+    {
+      subjects: [{ key: 'alice,senior "lead"', roles: ["viewer"] }],
+      resources: ["sources"],
+      actions: ["read"],
+    },
+    VALID_RES,
+    VALID_ACT,
+  );
+  const csv = batchResultToCsv(r);
+  assert.match(csv.split("\n")[0], /^subject,resource,action,allowed,reason$/);
+  // Quoted because of comma + embedded quotes doubled
+  assert.match(csv, /"alice,senior ""lead"""/);
+});
+
+test("DEFAULT_BATCH_LIMITS matches the documented 100×100×10 cap", () => {
+  assert.equal(DEFAULT_BATCH_LIMITS.maxSubjects, 100);
+  assert.equal(DEFAULT_BATCH_LIMITS.maxResources, 100);
+  assert.equal(DEFAULT_BATCH_LIMITS.maxActions, 10);
+});

--- a/mcp-server/src/auth/policy/batch-dry-run.test.ts
+++ b/mcp-server/src/auth/policy/batch-dry-run.test.ts
@@ -17,8 +17,8 @@ class FakeEngine implements PolicyEngine {
     if (resource === "sources" && action === "read") return { allowed: true, reason: "public read" };
     return { allowed: false, reason: `denied: roles=${(roles ?? []).join(",")} can't ${action} on ${resource}` };
   }
-  roles(): Record<string, unknown> {
-    return { admin: {}, viewer: {} };
+  roles(): string[] {
+    return ["admin", "viewer"];
   }
   kind(): string {
     return "fake";
@@ -156,7 +156,7 @@ test("evaluateBatch: per-subject tenant is threaded into engine.evaluate", async
       lastTenant = ctx?.tenant;
       return { allowed: true };
     }
-    roles() { return {}; }
+    roles(): string[] { return []; }
     kind() { return "tracker"; }
   }
   await evaluateBatch(

--- a/mcp-server/src/auth/policy/batch-dry-run.test.ts
+++ b/mcp-server/src/auth/policy/batch-dry-run.test.ts
@@ -17,6 +17,9 @@ class FakeEngine implements PolicyEngine {
     if (resource === "sources" && action === "read") return { allowed: true, reason: "public read" };
     return { allowed: false, reason: `denied: roles=${(roles ?? []).join(",")} can't ${action} on ${resource}` };
   }
+  list(): never[] {
+    return []; // not exercised by these tests
+  }
   roles(): string[] {
     return ["admin", "viewer"];
   }
@@ -156,6 +159,7 @@ test("evaluateBatch: per-subject tenant is threaded into engine.evaluate", async
       lastTenant = ctx?.tenant;
       return { allowed: true };
     }
+    list(): never[] { return []; }
     roles(): string[] { return []; }
     kind() { return "tracker"; }
   }

--- a/mcp-server/src/auth/policy/batch-dry-run.ts
+++ b/mcp-server/src/auth/policy/batch-dry-run.ts
@@ -1,0 +1,193 @@
+// Batch policy dry-run — Phase F16.
+//
+// The existing single-call dry-run probe (`GET /api/policy?roles=…
+// &resource=…&action=…`) is great for "why did this one call fail"
+// but doesn't scale to a security-review session reviewing a
+// proposed role change. F16 adds a batch variant that evaluates
+// every (subject × resource × action) combination in one pass and
+// returns a matrix the UI can render as a heat-map.
+//
+// The handler stays out of the route file — pure compute is easier
+// to unit-test and easier to reuse from a CI policy-diff job later.
+
+import type { PolicyEngine } from "./engine.js";
+
+export interface BatchSubject {
+  /** Human-readable identifier echoed in the response (UI heat-map
+   *  row label). Usually `<name>@<tenant>` or a group name. */
+  key: string;
+  /** Roles the subject would have at evaluation time. */
+  roles: string[];
+  /** Tenant the subject is acting under. Optional; defaults to the
+   *  caller's session tenant at the handler level. */
+  tenant?: string;
+}
+
+export interface BatchDryRunRequest {
+  subjects: BatchSubject[];
+  /** Resources to probe — should match VALID_RESOURCES on the
+   *  active engine. Unknown resources are dropped with a note. */
+  resources: string[];
+  /** Actions to probe — should match VALID_ACTIONS. */
+  actions: string[];
+}
+
+export interface BatchCellVerdict {
+  allowed: boolean;
+  reason?: string;
+}
+
+export interface BatchDryRunResult {
+  /** result[subjectKey][resource][action] = { allowed, reason } */
+  matrix: Record<string, Record<string, Record<string, BatchCellVerdict>>>;
+  /** Anything the handler skipped: bad resource, bad action, too
+   *  many cells, etc. Helps the operator fix the next batch quickly. */
+  dropped: Array<{ kind: "resource" | "action" | "subject" | "cap"; value: string; reason: string }>;
+  /** Summary counts to power the UI's headline stats. */
+  totals: {
+    cells: number;
+    allow: number;
+    deny: number;
+  };
+}
+
+export interface BatchLimits {
+  maxSubjects: number;
+  maxResources: number;
+  maxActions: number;
+}
+
+export const DEFAULT_BATCH_LIMITS: BatchLimits = {
+  maxSubjects: 100,
+  maxResources: 100,
+  maxActions: 10,
+};
+
+/**
+ * Run a batch dry-run against the policy engine. The engine is
+ * called once per cell — for the BuiltinPolicyEngine this is pure
+ * compute and cheap; for the OPA engine it's one Rego query per
+ * cell. The handler caps the matrix so a careless caller can't DoS
+ * an external OPA.
+ */
+export async function evaluateBatch(
+  engine: PolicyEngine,
+  req: BatchDryRunRequest,
+  validResources: ReadonlySet<string>,
+  validActions: ReadonlySet<string>,
+  limits: BatchLimits = DEFAULT_BATCH_LIMITS,
+): Promise<BatchDryRunResult> {
+  const dropped: BatchDryRunResult["dropped"] = [];
+
+  // De-duplicate inputs; preserve first-seen order.
+  const seenSubjectKeys = new Set<string>();
+  const subjects: BatchSubject[] = [];
+  for (const s of req.subjects ?? []) {
+    if (!s || typeof s.key !== "string" || !Array.isArray(s.roles)) {
+      dropped.push({ kind: "subject", value: String(s?.key ?? "<malformed>"), reason: "missing key or roles[]" });
+      continue;
+    }
+    if (seenSubjectKeys.has(s.key)) continue;
+    seenSubjectKeys.add(s.key);
+    subjects.push(s);
+  }
+  const resources = unique(req.resources ?? []).filter((r) => {
+    if (!validResources.has(r)) {
+      dropped.push({ kind: "resource", value: r, reason: "not in active engine's VALID_RESOURCES" });
+      return false;
+    }
+    return true;
+  });
+  const actions = unique(req.actions ?? []).filter((a) => {
+    if (!validActions.has(a)) {
+      dropped.push({ kind: "action", value: a, reason: "not in active engine's VALID_ACTIONS" });
+      return false;
+    }
+    return true;
+  });
+
+  // Cap enforcement — favour clear-cap-error over partial silent results.
+  if (subjects.length > limits.maxSubjects) {
+    dropped.push({ kind: "cap", value: `subjects=${subjects.length}`, reason: `truncated to ${limits.maxSubjects} (cap)` });
+    subjects.length = limits.maxSubjects;
+  }
+  if (resources.length > limits.maxResources) {
+    dropped.push({ kind: "cap", value: `resources=${resources.length}`, reason: `truncated to ${limits.maxResources} (cap)` });
+    resources.length = limits.maxResources;
+  }
+  if (actions.length > limits.maxActions) {
+    dropped.push({ kind: "cap", value: `actions=${actions.length}`, reason: `truncated to ${limits.maxActions} (cap)` });
+    actions.length = limits.maxActions;
+  }
+
+  const matrix: BatchDryRunResult["matrix"] = {};
+  let allowCount = 0;
+  let denyCount = 0;
+  for (const s of subjects) {
+    matrix[s.key] = {};
+    for (const r of resources) {
+      matrix[s.key][r] = {};
+      for (const a of actions) {
+        const verdict = await Promise.resolve(
+          engine.evaluate(
+            s.roles,
+            r as never,
+            a as never,
+            s.tenant ? { tenant: s.tenant } : undefined,
+          ),
+        );
+        matrix[s.key][r][a] = {
+          allowed: verdict.allowed,
+          reason: verdict.reason,
+        };
+        if (verdict.allowed) allowCount += 1;
+        else denyCount += 1;
+      }
+    }
+  }
+
+  return {
+    matrix,
+    dropped,
+    totals: {
+      cells: subjects.length * resources.length * actions.length,
+      allow: allowCount,
+      deny: denyCount,
+    },
+  };
+}
+
+function unique<T>(xs: T[]): T[] {
+  const seen = new Set<T>();
+  const out: T[] = [];
+  for (const x of xs) {
+    if (seen.has(x)) continue;
+    seen.add(x);
+    out.push(x);
+  }
+  return out;
+}
+
+/** Turn a batch result into CSV — `subject,resource,action,allowed,reason`. */
+export function batchResultToCsv(result: BatchDryRunResult): string {
+  const lines = ["subject,resource,action,allowed,reason"];
+  for (const [subject, perResource] of Object.entries(result.matrix)) {
+    for (const [resource, perAction] of Object.entries(perResource)) {
+      for (const [action, verdict] of Object.entries(perAction)) {
+        lines.push([
+          csvEscape(subject),
+          csvEscape(resource),
+          csvEscape(action),
+          verdict.allowed ? "allow" : "deny",
+          csvEscape(verdict.reason ?? ""),
+        ].join(","));
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
+function csvEscape(v: string): string {
+  if (/[",\n\r]/.test(v)) return `"${v.replace(/"/g, '""')}"`;
+  return v;
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -63,6 +63,7 @@ import { registerOidcRoutes } from "./auth/oidc/endpoints.js";
 import { BuiltinPolicyEngine, type PolicyEngine } from "./auth/policy/engine.js";
 import { loadPolicyFromFile, writePolicyFile, PolicyLoadError, VALID_RESOURCES, VALID_ACTIONS } from "./auth/policy/loader.js";
 import { OpaPolicyEngine } from "./auth/policy/opa.js";
+import { evaluateBatch, batchResultToCsv } from "./auth/policy/batch-dry-run.js";
 import { AuditLog } from "./audit/log.js";
 import { buildAuditMiddleware } from "./audit/middleware.js";
 import { WebhookSink } from "./audit/sinks/webhook.js";
@@ -1460,6 +1461,32 @@ async function main() {
         ? "DEFAULT_POLICY shipped with this build. Set OMCP_RBAC_POLICY_FILE to override."
         : `policy loaded from ${policyEngine.kind()}; restart to reload.`,
     });
+  });
+
+  // Phase F16: batch policy dry-run. Evaluates every
+  // (subject × resource × action) cell against the active engine and
+  // returns a matrix the UI heat-map renders. Gated identically to
+  // the single-call dry-run on GET /api/policy. Capped at 100×100×10
+  // cells per request — a single OPA query per cell is cheap on the
+  // BuiltinPolicyEngine but a careless caller could hose an external
+  // OPA, so the limit fences that. Operators get CSV via
+  // Accept: text/csv for ticket attachments.
+  app.post("/api/policy/dry-run-batch", need("users", "delete"), audit("policy", "read"), async (req, res) => {
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const subjects = Array.isArray(body.subjects) ? body.subjects : [];
+    const resources = Array.isArray(body.resources) ? body.resources : [];
+    const actions = Array.isArray(body.actions) ? body.actions : [];
+    const result = await evaluateBatch(
+      policyEngine,
+      { subjects, resources, actions } as never,
+      VALID_RESOURCES as unknown as Set<string>,
+      VALID_ACTIONS as unknown as Set<string>,
+    );
+    if (req.headers["accept"]?.toString().includes("text/csv")) {
+      res.type("text/csv").send(batchResultToCsv(result));
+      return;
+    }
+    res.json(result);
   });
 
   // --- /api/subjects — aggregated principals catalogue ------------------


### PR DESCRIPTION
## Summary
\`POST /api/policy/dry-run-batch\` evaluates every (subject × resource × action) cell against the active policy engine and returns a matrix the UI heat-map can render. Gated identically to the single-call dry-run on \`GET /api/policy\` (\`need users:delete\`), audit-tagged \`policy/read\`.

- **\`evaluateBatch\` handler**: pure compute (engine.evaluate per cell), sync/async-engine-tolerant. Drops unknown resources/actions/malformed subjects with a \`kind\`-tagged note in the response. Dedupes inputs. Caps at **100×100×10 cells** per request (protects an external OPA from a careless caller); oversize lists truncated with \`kind:"cap"\` notes.
- **Per-subject \`tenant\`** threaded into \`engine.evaluate\`'s context so OPA \`input.tenant\` rules fire correctly per row.
- **CSV export** via \`Accept: text/csv\` — \`subject,resource,action,allowed,reason\` with proper double-quote escaping for comma/quote/newline values. Ticket-attachable.

## Scope split
UI heat-map panel in the Policies tab lands as **F16b**. The API is fully usable today via \`curl\` + ticket-attachable CSV.

## Backwards compat
\`GET /api/policy\` single-call dry-run untouched. The new endpoint is purely additive.

## Test plan
- [x] Unit tests: 749/749 (739 pass + 10 conformance skipped). 11 new tests covering empty input, 1×1×1, full 2×2×2, unknown-resource/action/subject drops, dedup, cap enforcement, tenant threading into \`engine.evaluate\`, CSV header + escape correctness.
- [x] Build (\`tsc\`) clean.
- [x] Reviewer-agent gate cleared.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)