### PR TITLE
docs(site): MkDocs Material site + GitHub Pages workflow (Phase F17)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,62 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v6.0.0
+        with:
+          python-version: '3.12'
+      - name: Install MkDocs + Material + plugins
+        run: |
+          python -m pip install --upgrade pip
+          pip install "mkdocs>=1.6,<2" "mkdocs-material>=9.5,<10" "pymdown-extensions>=10,<11"
+      - name: Build site
+        # `mkdocs build` without --strict so cross-repo links (to
+        # ../CHANGELOG.md, ../enterprise/, etc.) that won't resolve
+        # in the published site are warnings, not failures. A
+        # follow-up cleans up those links so we can flip to strict.
+        run: mkdocs build
+      - name: Upload Pages artifact
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to Pages
+    needs: build
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ connectors/*/manifest.json.sig
 experiments/
 docker-compose.override.yml
 .benchmark/
+site/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ question instead of juggling N vendor servers and their query languages.*
 
 ---
 
+📖 **Full documentation site:** <https://thotischner.github.io/observability-mcp/>
+
 ## Why it matters — measured, not asserted
 
 On a real Kubernetes-platform-team question ("which other pods share a node with

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,88 @@
+# Getting started
+
+## Run the demo
+
+```bash
+docker compose --profile demo up --build
+```
+
+That brings up:
+
+- a single-node k3s cluster with three chaos-able example services
+  (`api-gateway`, `payment-service`, `order-service`)
+- Prometheus + Loki scraping the cluster
+- the gateway pre-wired against k3s + Prometheus + Loki
+- an optional autonomous detection agent (also part of the demo
+  profile)
+
+Land on <http://localhost:3000>. The Web UI Dashboard tab is the
+first thing to look at; Sources / Services / Health / Topology fill
+in as the cluster warms up.
+
+## Speak MCP from the command line
+
+```bash
+# Initialize handshake
+curl -sS http://localhost:3000/mcp \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
+
+# tools/list (use the mcp-session-id header from the initialize response)
+SESSION=...
+curl -sS http://localhost:3000/mcp \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  -H "mcp-session-id: $SESSION" \
+  --data '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+```
+
+The full conformance harness — including every method the gateway
+should respond to — lives at
+[`mcp-server/src/conformance/mcp-2025-11-25.test.ts`](https://github.com/ThoTischner/observability-mcp/blob/main/mcp-server/src/conformance/mcp-2025-11-25.test.ts).
+
+## Connect an MCP client
+
+For Claude Desktop / Cursor / any MCP client that loads a config:
+
+```jsonc
+{
+  "mcpServers": {
+    "observability": {
+      "url": "http://localhost:3000/mcp",
+      "headers": { "Authorization": "Bearer <key>" }
+    }
+  }
+}
+```
+
+(Anonymous-auth mode accepts any non-empty bearer token. Configure
+`OMCP_API_KEYS` for real deployments — see
+[access control](access-control.md).)
+
+## Wire your own backends
+
+Edit `mcp-server/config/sources.yaml` (or use the Sources tab in the
+Web UI; both update the same file and hot-reload):
+
+```yaml
+sources:
+  - name: prod-prom
+    type: prometheus
+    url: https://prometheus.your-cluster.internal/
+    enabled: true
+  - name: prod-loki
+    type: loki
+    url: https://loki.your-cluster.internal/
+    enabled: true
+```
+
+See [configuration](configuration.md) for the full schema and
+[connectors](connectors.md) for the per-backend specifics.
+
+## Next steps
+
+- [Access control](access-control.md) — RBAC, OIDC, audit
+- [Federation](federation.md) — proxy upstream MCP servers
+- [Horizontal scaling](horizontal-scaling.md) — multi-replica HA
+- [Hardening](hardening.md) — security defaults

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,47 @@
+# observability-mcp
+
+**A topology-aware MCP control plane for AI agents.** One self-hosted gateway:
+
+- **observability tools** — `query_metrics`, `query_logs`, `query_traces`, `get_service_health`, `detect_anomalies`, `get_topology`, `get_blast_radius`, `get_anomaly_history`
+- **federation** — proxy other MCP servers under one stable endpoint
+- **governance** — RBAC, audit chain, tenancy, redaction, products, virtual servers
+- **transports** — Streamable HTTP, stdio, WebSocket
+- **air-gapped** — no runtime npm, signed plugins, offline-verifiable
+
+## Try it in 30 seconds
+
+```bash
+docker compose --profile demo up --build
+open http://localhost:3000
+```
+
+The demo brings up a k3s cluster, Prometheus + Loki scraping it, and the gateway pre-wired against the lot. The web UI lands on the Dashboard.
+
+## Plug an agent into it
+
+```jsonc
+{
+  "mcpServers": {
+    "observability": {
+      "url": "http://localhost:3000/mcp",
+      "headers": { "Authorization": "Bearer <key>" }
+    }
+  }
+}
+```
+
+Drop the snippet into Claude Desktop / Cursor / any MCP client; the eight observability tools become visible on `tools/list`.
+
+## What's where
+
+- **[Getting started](getting-started.md)** — install, configure, first tool call.
+- **[Configuration](configuration.md)** — `sources.yaml`, env vars, hot-reload.
+- **[Topology vocabulary](topology-vocabulary.md)** — the shared graph language every connector speaks.
+- **[Federation](federation.md)** — fan tools out from upstream MCP gateways.
+- **[Access control](access-control.md)** — RBAC, OIDC SSO, audit, redaction.
+- **[Hardening](hardening.md)** — CSRF / SSRF posture; the security defaults.
+- **[Migration guide](migrations/1.x-to-2.0.md)** — upgrading from 1.x.
+
+## What ships in v2.0
+
+See the [v2.0 CHANGELOG entry](https://github.com/ThoTischner/observability-mcp/blob/main/CHANGELOG.md#200--2026-06-06) — federation, multi-replica HA, WebSocket transport, OIDC vendor presets, plugin lifecycle hooks, pluggable audit sinks, OTel self-tracing, MCP 2025-11-25 conformance, virtual servers, CSRF + SSRF hardening, plugin signature default-on.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,112 @@
+site_name: observability-mcp
+site_description: Topology-aware MCP control plane for AI agents (Prometheus / Loki / Tempo / Kubernetes / Federation)
+site_url: https://thotischner.github.io/observability-mcp/
+repo_url: https://github.com/ThoTischner/observability-mcp
+repo_name: ThoTischner/observability-mcp
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  language: en
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.indexes
+    - navigation.top
+    - content.code.copy
+    - content.action.edit
+    - search.suggest
+    - search.highlight
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle: { icon: material/brightness-auto, name: System theme }
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle: { icon: material/brightness-7, name: Dark mode }
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle: { icon: material/brightness-4, name: Light mode }
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - footnotes
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+plugins:
+  - search
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - getting-started.md
+      - configuration.md
+      - troubleshooting.md
+  - Core Concepts:
+      - Topology vocabulary: topology-vocabulary.md
+      - Tenancy: tenancy.md
+      - Plugin architecture: plugin-architecture.md
+      - Transports: transports.md
+  - Deployment:
+      - Air-gapped: airgapped-deployment.md
+      - Offline operation: offline.md
+      - Horizontal scaling: horizontal-scaling.md
+      - Self-observability: self-observability.md
+      - Security: security.md
+      - Hardening: hardening.md
+  - Connectors:
+      - Overview: connectors.md
+      - Prometheus: prometheus.md
+      - Loki: loki.md
+      - Kubernetes: kubernetes.md
+      - Topology providers: topology-providers.md
+      - Federation: federation.md
+  - Access Control:
+      - Overview: access-control.md
+      - Basic auth: auth-basic.md
+      - OIDC: auth-oidc.md
+      - SSO providers:
+          - GitHub: auth-oidc-providers/github.md
+          - Google: auth-oidc-providers/google.md
+          - Microsoft Entra ID: auth-oidc-providers/microsoft-entra.md
+          - Okta: auth-oidc-providers/okta.md
+      - Auth + TLS: auth-and-tls.md
+      - Policy engines: policy-engines.md
+      - Products: products.md
+      - Redaction: redaction.md
+  - Audit & Compliance:
+      - Audit sinks: audit-sinks.md
+      - MCP conformance: mcp-conformance.md
+      - Comparison: comparison.md
+  - Observability Intelligence:
+      - Anomaly history: anomaly-history.md
+      - Astronomy-shop benchmark: benchmark-astronomy-shop.md
+  - Reference:
+      - Demo agent: agent.md
+      - Entitlement gate: enterprise-gate.md
+  - Migrations:
+      - 1.x → 2.0: migrations/1.x-to-2.0.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/ThoTischner/observability-mcp


### PR DESCRIPTION
## Summary
Publishes the 37 \`docs/*.md\` pages to a Material-themed site at <https://thotischner.github.io/observability-mcp/>.

- **\`mkdocs.yml\`** with Material theme, dark/light/system palette, instant nav, edit-this-page links, standard pymdownx extensions, and a 9-section nav covering every doc (Getting Started / Core Concepts / Deployment / Connectors / Access Control / Audit & Compliance / Observability Intelligence / Reference / Migrations).
- **\`docs/index.md\`** landing page with 30-second demo + MCP client snippet + signpost to each section.
- **\`docs/getting-started.md\`** condenses the README "Try it" flow into a docs-friendly first read.
- **\`.github/workflows/docs.yml\`** builds on every push/PR touching docs / mkdocs.yml / the workflow itself; deploys to GitHub Pages on push-to-main. Pinned action SHAs, concurrency group, minimal Pages-OIDC permissions, build/deploy split so PR builds don't try to deploy.
- README hero gets a 1-line link to the published site.
- \`.gitignore\` excludes the local \`site/\` build output.

## Scope split — deferred to F17b
\`--strict\` is intentionally **off** — 14 pre-existing cross-repo warnings (links to \`../CHANGELOG.md\`, \`../enterprise/\`, …) become non-blocking. A follow-up F17b cleans those up so we can flip to \`--strict\`.

## Test plan
- [x] \`mkdocs build\` succeeds locally with 4 INFO + 14 WARNING entries (all pre-existing cross-repo links). Site renders correctly.
- [x] All 9 nav sections + their entries point at real \`docs/\` files.
- [x] Reviewer-agent gate cleared (one pre-push fix: renamed an "Enterprise gate" nav label to "Entitlement gate" to comply with the CLAUDE.md no-"Enterprise"-string-in-UI rule).
- [ ] CI green; first push-to-main publishes the site.

## After merge
The first push-to-main fires the deploy workflow; the GitHub Pages settings need to be set to "Source: GitHub Actions" if they aren't already (one-time admin click in repo Settings → Pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)