### PR TITLE
release: v3.0.0 (Phase F23) — FINAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,108 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.0.0] — 2026-06-06
+
+Major release. v3.0 is the **moat-extension sprint** on top of the
+v2.0 foundation: more MCP tools, more provider depth, more
+operator visibility, and a CI proof of the air-gapped story.
+
+Migrating from 2.x is **purely additive** — every new capability
+is opt-in via env / Helm value. See
+[`docs/migrations/2.x-to-3.0.md`](docs/migrations/2.x-to-3.0.md).
+
+### Added — new MCP tools
+
+- **`query_traces(service, duration, filter?, limit?, errorsOnly?)`** —
+  ninth MCP tool. Fans out across every connector implementing the
+  new `queryTraces` capability (Tempo / Jaeger). Returns ranked
+  trace summaries with a globally-recomputed p50/p95 over the
+  merged set. Closes the metrics/logs/**traces** triangle.
+- **`get_anomaly_history(service, duration, method?)`** — tenth
+  tool. Replays historical anomaly scores written to the TSDB by
+  the new `AnomalyHistory` sink. Default off; opt-in via
+  `OMCP_ANOMALY_HISTORY_REMOTE_WRITE`. Powers the auto-postmortem
+  feature below.
+- **`generate_postmortem(service, duration, format?)`** — eleventh
+  tool. Stitches the gateway's existing primitives — anomaly
+  history, trace summaries, topology blast-radius, log highlights —
+  into a single markdown report a human or LLM reads in one shot.
+
+### Added — capabilities
+
+- **Multi-cloud topology foundation** — new merger module
+  collapses Resources that come from multiple providers (k8s
+  Deployment + ECS service + Tempo trace_service for the same
+  logical workload) into one canonical node via explicit
+  `canonicalName` override / `CANONICAL_LABEL_KEYS` match /
+  kind-compatibility table. 8 new reserved kinds in the topology
+  vocabulary. Concrete cloud-provider connectors land as
+  filesystem plugins in v3.x increments.
+- **Anomaly history TSDB sink** — every chained anomaly score
+  mirrored to a Prometheus remote-write endpoint via the new
+  `AnomalyHistory` writer. JSON-shaped WriteRequest payload (any
+  TSDB-receiving collector ingests it).
+- **Batch policy dry-run** — `POST /api/policy/dry-run-batch`
+  evaluates every (subject × resource × action) cell against the
+  active engine and returns a matrix the UI heat-map will render.
+  CSV export via `Accept: text/csv`.
+- **MkDocs Material documentation site** at
+  <https://thotischner.github.io/observability-mcp/>. Every push to
+  main republishes.
+- **MCP Inspector quickstart** — new `omcp inspector-config`
+  subcommand emits a config the official Inspector consumes in
+  one line. Opens the gateway in an interactive explorer with
+  zero handwritten config.
+- **SCIM 2.0 Users + Groups provisioning** — Microsoft Entra ID
+  and Okta push directory state into `/scim/v2/*` directly. Bearer
+  auth via `OMCP_SCIM_TOKEN`. Group→role mapping via
+  `OMCP_SCIM_GROUP_ROLE_MAP`.
+- **Plugin SDK published as `@thotischner/observability-mcp-sdk`** —
+  standalone npm package plugin authors depend on without cloning
+  the gateway. Scaffolder CLI:
+  `npx @thotischner/observability-mcp-sdk create-connector my-conn`.
+
+### Added — operator surface
+
+- **Verifiable-offline CI** — new `.github/workflows/airgapped.yml`
+  boots the demo stack with iptables egress blocked on the
+  mcp-server container, then asserts /healthz, no-CDN-in-UI, MCP
+  handshake, and a tool call all work. Future regression that
+  adds a phone-home / CDN font / telemetry beacon fails at PR
+  time.
+- **Helm `airgapped: true`** value renders an egress-deny
+  NetworkPolicy (allow DNS + same-namespace + operator allowlist)
+  and sets `OMCP_AIRGAPPED=true` in the container env.
+
+### Deferred to v3.x (incremental)
+
+- Concrete AWS / GCP / Consul / Istio / Linkerd topology-provider
+  connectors (F14a foundation ships; F14b–f are the providers).
+- Detector-side hook that fills the anomaly-history buffer from
+  the live `detect_anomalies` path (F15b — writer + tool already
+  live).
+- UI "Batch evaluate" panel in the Policies tab (F16b — API is
+  fully usable today).
+- F17b strict-mode mkdocs build (clean up the 14 cross-repo links
+  flagged as warnings).
+- Playground UI tab that mirrors Inspector inline (F18b — the
+  real Inspector via `omcp inspector-config` is the supported
+  path today).
+- `/api/postmortems` persistence, UI Postmortems tab, custom
+  template engine (F19b/c — tool is fully usable today).
+- npm-workspace setup so the SDK package becomes the canonical
+  source and mcp-server depends on it instead of vendoring
+  (F20b — current setup uses a CI parity check).
+- SCIM filter/search, member[] add/remove patch ops,
+  Redis-backed store, UI Provisioning sub-tab, full SCIM 2.0
+  compliance suite (F21b/c — push-only Entra+Okta work today).
+
+### Backwards compatibility
+
+Every v3.0 capability is opt-in via env or Helm value. The
+default single-replica anonymous-auth Docker-compose demo runs
+identically on 2.x and 3.0. No behaviour flips required.
+
 ## [2.0.0] — 2026-06-06
 
 Major release. v2.0 closes the remaining adoption-blocking gaps so a

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,31 @@ Where the project is going at a thematic level. For the connector-plugin enginee
 
 Items here are **directions, not promises** — order will shift based on what users actually need. If something here matters to you, open a Discussion or an Issue.
 
+## v3.0 — shipped 2026-06-06
+
+The moat-extension sprint on top of v2.0. See
+[CHANGELOG.md](CHANGELOG.md) for per-capability detail.
+
+- ✅ `query_traces` + `get_anomaly_history` + `generate_postmortem` MCP tools (8 → 11)
+- ✅ Multi-cloud topology merger foundation + 8 reserved kinds (concrete cloud-provider connectors land as filesystem plugins in v3.x)
+- ✅ Anomaly history TSDB sink + replay tool
+- ✅ Batch policy dry-run + CSV export
+- ✅ MkDocs Material documentation site at <https://thotischner.github.io/observability-mcp/>
+- ✅ MCP Inspector quickstart (`omcp inspector-config`)
+- ✅ SCIM 2.0 Users + Groups provisioning (Entra + Okta push)
+- ✅ Plugin SDK published as `@thotischner/observability-mcp-sdk` + scaffolder CLI
+- ✅ Verifiable-offline CI workflow (iptables-egress-blocked smoke test)
+- ✅ Helm `airgapped: true` with egress-deny NetworkPolicy
+
+## v4.x — next (open for community input)
+
+The v3.x increments listed in [CHANGELOG.md](CHANGELOG.md) get
+shipped first. Beyond that, the field is open — see the
+[After-F23 candidates](#after-f23--candidates-for-the-next-sprint)
+section of the [hub-parity sprint plan](https://github.com/ThoTischner/observability-mcp/tree/main/.claude/plans)
+for the menu we'll pull from. Vote with thumbs-up emoji on the
+Discussion threads if any of them matters to you.
+
 ## v2.0 — shipped 2026-06-06
 
 The v2.0 release closed the remaining adoption-blocking gaps so a

--- a/docs/migrations/2.x-to-3.0.md
+++ b/docs/migrations/2.x-to-3.0.md
@@ -1,0 +1,113 @@
+# Migrating from 2.x to 3.0
+
+v3.0 is a major version bump, but the migration is **purely
+additive** — every new capability is opt-in via env or Helm value.
+A vanilla `docker compose --profile demo up` runs identically on
+2.x and 3.0. No behaviour flips required.
+
+## tl;dr
+
+| You are running… | Required action |
+|---|---|
+| The OSS demo (`docker compose --profile demo up`) | None — defaults unchanged. |
+| `helm install obs ./helm/observability-mcp` (defaults) | None — chart still ships single-replica + no Redis + no SCIM. |
+| Any custom Helm values from 2.x | None. Three new value blocks (`airgapped`, `anomalyHistory`, no other touched) are off by default. |
+| A plugin author importing from `@thotischner/observability-mcp/sdk` | Switch to `@thotischner/observability-mcp-sdk` (new dedicated SDK package). Both work; the dedicated one is recommended going forward. |
+
+## New opt-in capabilities
+
+| Env / Value | What it does | Docs |
+|---|---|---|
+| `OMCP_ANOMALY_HISTORY_REMOTE_WRITE=<url>` | Mirror anomaly scores to TSDB. Enables `get_anomaly_history` MCP tool. | [anomaly-history.md](../anomaly-history.md) |
+| `OMCP_SCIM_TOKEN=<token>` + `OMCP_SCIM_STORE=<path>` | SCIM 2.0 provisioning at `/scim/v2/*` (Entra/Okta push). | [scim-provisioning.md](../scim-provisioning.md) |
+| `OMCP_SCIM_GROUP_ROLE_MAP="admins:admin,sre:operator"` | Map SCIM-provisioned groups to RBAC roles. | – |
+| `airgapped: true` (Helm) | Egress-deny NetworkPolicy + `OMCP_AIRGAPPED=true`. | [airgapped-deployment.md](../airgapped-deployment.md) |
+| `airgappedExtraEgress: [...]` (Helm) | Operator's allow-listed egress destinations when airgapped. | [airgapped-deployment.md](../airgapped-deployment.md) |
+| `anomalyHistory.enabled: true` (Helm) | TSDB sink wired via Helm values. | [anomaly-history.md](../anomaly-history.md) |
+
+## New MCP tools
+
+The tool registry grows from 8 → 11:
+
+- `query_traces(service, duration, filter?, limit?, errorsOnly?)`
+- `get_anomaly_history(service, duration, method?)`
+- `generate_postmortem(service, duration, format?)`
+
+Existing tool surface is unchanged. Per-credential `OMCP_KEY_PRODUCTS`
+allow-lists keep working — bind the new tools into your Products
+explicitly if you want them visible to scoped consumers.
+
+## New endpoints
+
+- `POST /api/policy/dry-run-batch` — batch policy evaluation, returns matrix or CSV.
+- `/scim/v2/*` — SCIM 2.0 Users + Groups + discovery (opt-in via `OMCP_SCIM_TOKEN`).
+
+## New / changed CLI
+
+- `omcp inspector-config` — emit an MCP Inspector config for the local gateway.
+- `omcp-sdk-create-connector <name>` (from the new SDK package) — scaffold a connector skeleton.
+
+## New CI surface
+
+The repo adds the **airgapped** CI workflow that boots the demo
+stack with iptables egress blocked. Forks should expect this job
+to appear on every PR; it's mandatory for merge.
+
+## Plugin SDK package
+
+`@thotischner/observability-mcp-sdk` 3.0.0 is now the canonical
+source for plugin authors. The in-tree `mcp-server/src/sdk/`
+remains in sync via a CI parity check.
+
+```bash
+npm install @thotischner/observability-mcp-sdk
+# Or scaffold a new connector:
+npx @thotischner/observability-mcp-sdk create-connector my-connector
+```
+
+## Chart bumps
+
+- `mcp-server` 2.0.0 → **3.0.0**
+- Helm chart 1.0.0 → **2.0.0** (appVersion `3.0.0`)
+- SDK package — first 3.0.0 publish
+
+## Verifying the upgrade
+
+```bash
+# 1. /api/conformance still claims MCP 2025-11-25
+curl -s http://localhost:3000/api/conformance | jq '.revisions'
+
+# 2. Tool surface now includes the three new tools
+TOKEN=any-non-empty-bearer  # anonymous-auth demo accepts anything
+curl -sS http://localhost:3000/mcp \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  --data '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  | jq '.result.tools[].name'
+# expect: list_sources, list_services, query_metrics, query_logs,
+#         query_traces, get_service_health, detect_anomalies,
+#         get_anomaly_history, generate_postmortem,
+#         get_topology, get_blast_radius
+
+# 3. Inspector quickstart still works
+npx @thotischner/observability-mcp inspector-config | jq .
+```
+
+## Rollback
+
+In-place downgrade to 2.x is supported. The new opt-in values
+(`airgapped`, `anomalyHistory.*`, `OMCP_SCIM_*`,
+`OMCP_ANOMALY_HISTORY_*`) are silently ignored by 2.x. On-disk
+schemas (audit JSONL, products.yaml, sources.yaml, DCR store, the
+new `scim.json`) are forward-compatible — a 2.x server reading a
+3.0-written file ignores fields it doesn't know.
+
+## After the upgrade
+
+The v3.x incremental follow-ups live in
+[CHANGELOG.md](../../CHANGELOG.md) under "Deferred to v3.x
+(incremental)". The next planned major (v4.x) is up for grabs —
+[Issue tracker](https://github.com/ThoTischner/observability-mcp/issues)
+and [Discussions](https://github.com/ThoTischner/observability-mcp/discussions)
+are open.

--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,11 +4,11 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 1.0.0
+version: 2.0.0
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
-appVersion: "2.0.0"
+appVersion: "3.0.0"
 
 home: https://github.com/ThoTischner/observability-mcp
 sources:

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp-sdk",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Plugin SDK for observability-mcp — types + Zod schemas + lifecycle-hook helpers for authoring connectors and post-tool hooks.",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## 🎉 v3.0.0 — final phase of the hub-parity sprint

Bundles the v3.0 sprint (F13–F22): three new MCP tools, multi-cloud topology foundation, anomaly history sink, batch policy dry-run, MkDocs site, MCP Inspector quickstart, SCIM 2.0 provisioning, plugin SDK npm package, verifiable-offline CI, Helm airgapped mode.

### What v3.0 ships (F13–F22)

| | Capability | PR |
|---|---|---|
| F13 | \`query_traces\` MCP tool | #368 |
| F14a | Multi-cloud topology merger foundation | #369 |
| F15a | TSDB-backed anomaly history + \`get_anomaly_history\` tool | #370 |
| F16a | Batch policy dry-run + CSV export | #371 |
| F17 | MkDocs Material site + Pages workflow | #372 |
| F18a | \`omcp inspector-config\` CLI + dev-loop docs | #373 |
| F19a | \`generate_postmortem\` MCP tool | #375 |
| F20a | \`@thotischner/observability-mcp-sdk\` npm package | #376 |
| F21a | SCIM 2.0 Users + Groups provisioning | #377 |
| F22 | Verifiable-offline CI + Helm airgapped lockdown | #378 |

### Versions
- \`mcp-server\` 2.0.0 → **3.0.0**
- helm chart 1.0.0 → **2.0.0** (appVersion **3.0.0**)
- \`@thotischner/observability-mcp-sdk\` 2.0.0 → **3.0.0**

### Backwards compat
Every v3.0 capability is opt-in via env or Helm value. The default OSS demo runs identically on 2.x and 3.0 — **no behaviour flips required**.

Full migration guide: [\`docs/migrations/2.x-to-3.0.md\`](docs/migrations/2.x-to-3.0.md).

## Test plan
- [x] Unit tests: 785/785 (775 pass + 10 conformance skipped).
- [x] \`helm lint helm/observability-mcp\` clean.
- [x] Build (\`tsc\`) clean.
- [x] Reviewer-agent gate cleared.
- [ ] CI green on the release branch (including the verifiable-offline job from F22).
- [ ] On merge: publish workflows fire for docker / npm / helm OCI / helm Pages / MkDocs site.
- [ ] Tag \`sdk-v3.0.0\` after release-merge publishes the SDK to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)