### PR TITLE
fix(ci): docker-login GHCR before cosign sign in helm-release

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -145,6 +145,17 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io \
             -u "${{ github.actor }}" --password-stdin
+      - name: Log in to GHCR (docker config — cosign reads this)
+        # cosign signs by pushing the signature artifact next to the
+        # chart in the same OCI registry. It reads credentials from
+        # ~/.docker/config.json, NOT helm's registry config — so the
+        # helm-login above isn't enough on its own. Without this the
+        # cosign sign step 401s on the signature blob upload.
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Install cosign
         # Pin matches docker-publish.yml — sigstore/cosign-installer v4.1.2.
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2


### PR DESCRIPTION
## Why

The \`helm-release\` workflow on the v3.0 merge to main failed:

\`\`\`
Error: signing [ghcr.io/thotischner/charts/observability-mcp@sha256:1af0ce...]:
  failed to upload layer: POST https://ghcr.io/v2/.../blobs/uploads/:
  UNAUTHORIZED: unauthenticated: User cannot be authenticated with the token provided.
\`\`\`

\`cosign sign\` pushes the signature blob next to the chart artifact in GHCR. It reads credentials from \`~/.docker/config.json\` — NOT helm's registry config. The existing \`helm registry login\` step writes only to helm's config so cosign falls back to anonymous and 401s.

## Fix
Add \`docker/login-action\` ahead of the cosign install + sign step.

## Test plan
- [x] No code change
- [ ] CI green on this PR
- [ ] On merge: helm-release workflow's cosign step authenticates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)