### PR TITLE
fix(ci): docs workflow deploys on manual dispatch too

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,7 +43,7 @@ jobs:
         # follow-up cleans up those links so we can flip to strict.
         run: mkdocs build
       - name: Upload Pages artifact
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: site
@@ -51,7 +51,7 @@ jobs:
   deploy:
     name: Deploy to Pages
     needs: build
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,39 @@ jobs:
         # in the published site are warnings, not failures. A
         # follow-up cleans up those links so we can flip to strict.
         run: mkdocs build
+      - name: Merge Helm chart-releaser repo into site/
+        # We switched Pages source from the gh-pages branch to a
+        # workflow-driven deploy so MkDocs could serve from /. The
+        # chart-releaser workflow still pushes index.yaml + chart
+        # tarballs to gh-pages, and operators rely on the same URL
+        # for `helm repo add observability-mcp https://thotischner.github.io/observability-mcp`.
+        # Copy those files into the MkDocs output BEFORE upload so
+        # both surfaces live side by side under the same Pages site:
+        #   /                 → MkDocs landing
+        #   /index.yaml       → Helm repo index
+        #   /<chart>-X.Y.Z.tgz → chart tarballs
+        # mkdocs's own index.html stays in place (it was written
+        # first and copy never overwrites it because cp -n skips
+        # existing). The gh-pages root index.html is the chart-
+        # releaser auto-generated listing — fine to drop.
+        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        run: |
+          set -euo pipefail
+          if git fetch --depth 1 origin gh-pages 2>/dev/null; then
+            git worktree add /tmp/ghpages FETCH_HEAD
+            # copy *.tgz, *.tgz.prov, index.yaml — skip index.html
+            # (mkdocs landing wins) and the chart-releaser-noise.
+            shopt -s nullglob
+            for f in /tmp/ghpages/*.tgz /tmp/ghpages/*.tgz.prov /tmp/ghpages/index.yaml; do
+              [ -f "$f" ] || continue
+              cp -n "$f" site/
+              echo "  preserved $(basename "$f")"
+            done
+            git worktree remove --force /tmp/ghpages || true
+            echo "::notice::Helm repo files preserved alongside docs site"
+          else
+            echo "::notice::No gh-pages branch yet — nothing to preserve"
+          fi
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,6 +82,7 @@ See [configuration](configuration.md) for the full schema and
 
 ## Next steps
 
+- [Install via Helm](install-helm.md) — production install on Kubernetes
 - [Access control](access-control.md) — RBAC, OIDC, audit
 - [Federation](federation.md) — proxy upstream MCP servers
 - [Horizontal scaling](horizontal-scaling.md) — multi-replica HA

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ Drop the snippet into Claude Desktop / Cursor / any MCP client; the eight observ
 ## What's where
 
 - **[Getting started](getting-started.md)** — install, configure, first tool call.
+- **[Install via Helm](install-helm.md)** — `helm repo add` + values + signature verification.
 - **[Configuration](configuration.md)** — `sources.yaml`, env vars, hot-reload.
 - **[Topology vocabulary](topology-vocabulary.md)** — the shared graph language every connector speaks.
 - **[Federation](federation.md)** — fan tools out from upstream MCP gateways.

--- a/docs/install-helm.md
+++ b/docs/install-helm.md
@@ -1,0 +1,134 @@
+# Install via Helm
+
+The chart lives at the same Pages URL as these docs — so the same
+host that serves the documentation also serves the Helm repo
+index.
+
+## Add the repo
+
+```bash
+helm repo add observability-mcp https://thotischner.github.io/observability-mcp
+helm repo update
+```
+
+Look up the latest version:
+
+```bash
+helm search repo observability-mcp -l | head -5
+```
+
+## Install
+
+```bash
+helm install obs observability-mcp/observability-mcp \
+  --namespace observability --create-namespace
+```
+
+The default values bring up a single-replica gateway in
+anonymous-auth mode — fine for a private cluster + quick eval. For
+anything shared see the hardening notes below.
+
+## Common values
+
+```bash
+helm install obs observability-mcp/observability-mcp \
+  --namespace observability --create-namespace \
+  --set sources.prometheusUrl=http://kube-prometheus-stack-prometheus:9090 \
+  --set sources.lokiUrl=http://loki:3100 \
+  --set ingress.enabled=true \
+  --set ingress.hosts[0].host=observability-mcp.example.com \
+  --set auth.enabled=true \
+  --set auth.token=$(openssl rand -hex 24)
+```
+
+Everything the chart accepts: see
+[`helm/observability-mcp/values.yaml`](https://github.com/ThoTischner/observability-mcp/blob/main/helm/observability-mcp/values.yaml)
+in the repo (also `helm show values observability-mcp/observability-mcp`).
+The chart ships with `values.schema.json` so Helm validates input
+types before render.
+
+## Verify the chart signature (optional)
+
+The chart packages are GPG-signed. The signing key fingerprint is
+documented in
+[`Chart.yaml` annotations](https://github.com/ThoTischner/observability-mcp/blob/main/helm/observability-mcp/Chart.yaml).
+Verify before install:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc \
+  | gpg --import
+
+helm fetch observability-mcp/observability-mcp --prov
+helm verify observability-mcp-*.tgz
+```
+
+The OCI variant (see below) is additionally **cosign-signed**.
+
+## Install from OCI (alternative)
+
+The same chart is published to GHCR as an OCI artifact, signed by
+cosign with keyless OIDC:
+
+```bash
+helm install obs oci://ghcr.io/thotischner/charts/observability-mcp \
+  --version 2.0.0 \
+  --namespace observability --create-namespace
+
+# Verify the cosign signature
+cosign verify ghcr.io/thotischner/charts/observability-mcp:2.0.0 \
+  --certificate-identity-regexp 'https://github.com/ThoTischner/observability-mcp' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+## Capabilities you turn on with values
+
+| Value | What it enables | Docs |
+|---|---|---|
+| `auth.enabled: true` | API-key auth | [auth-basic.md](auth-basic.md) |
+| `oidc.enabled: true` | OIDC SSO + sessions | [auth-oidc.md](auth-oidc.md) |
+| `airgapped: true` | Egress-deny NetworkPolicy + `OMCP_AIRGAPPED` | [airgapped-deployment.md](airgapped-deployment.md) |
+| `anomalyHistory.enabled: true` | TSDB-backed anomaly history sink | [anomaly-history.md](anomaly-history.md) |
+| `redis.enabled: true` | Shared session store for multi-replica HA | [horizontal-scaling.md](horizontal-scaling.md) |
+| `serviceMonitor.enabled: true` | Prometheus Operator scrape config | [self-observability.md](self-observability.md) |
+| `plugins.image: ghcr.io/thotischner/observability-mcp-plugins:latest` (default) | Bundled signed connectors | [plugin-architecture.md](plugin-architecture.md) |
+| `plugins.uiInstall: true` | Web UI / API plugin install endpoints | [plugin-architecture.md](plugin-architecture.md) |
+
+## Upgrade
+
+```bash
+helm repo update
+helm upgrade obs observability-mcp/observability-mcp \
+  --namespace observability --reuse-values
+```
+
+For breaking changes between major versions consult the matching
+migration guide:
+
+- [1.x → 2.0](migrations/1.x-to-2.0.md)
+- [2.x → 3.0](migrations/2.x-to-3.0.md)
+
+## Uninstall
+
+```bash
+helm uninstall obs --namespace observability
+```
+
+The PVC for plugin persistence (if enabled) is kept by default —
+delete it explicitly with `kubectl delete pvc -n observability -l
+app.kubernetes.io/name=observability-mcp` if you want a clean
+slate.
+
+## Troubleshooting
+
+- **`/readyz` 503 forever** — Express listener never came up;
+  usually a malformed `sources.config`. `kubectl logs` the pod and
+  look for the first error in startup.
+- **`ImagePullBackOff`** — your cluster needs to reach `ghcr.io`,
+  or set `image.repository` to your internal mirror.
+- **Plugins not loading** — the PluginLoader logs
+  `plugin <name> rejected: <reason>` at startup. Filter
+  `kubectl logs` for `plugin`.
+- **`helm repo add` 404 on index.yaml** — the published Pages site
+  carries both the MkDocs docs AND the Helm repo index at the
+  same URL. If your client gets a 404, something's wrong with the
+  docs-publish step — open an issue.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
   - Home: index.md
   - Getting Started:
       - getting-started.md
+      - Install via Helm: install-helm.md
       - MCP Inspector quickstart: quickstart-inspector.md
       - Dev loop: dev-loop.md
       - configuration.md


### PR DESCRIPTION
Manual workflow_dispatch ran only the build and skipped the Pages deploy because of the `event_name == 'push'` filter. Extending the gate so a manual re-run can replace the legacy gh-pages content with the MkDocs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)