### PR TITLE
feat(p1): activate dead-but-shipped tools + governance flags

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -703,7 +703,9 @@ async function main() {
     },
     async (args) => {
       await enforceEntitledAccess(ctx, { tool: "detect_anomalies", source: (args as any)?.source, service: (args as any)?.service });
-      return withToolMetrics("detect_anomalies", () => detectAnomaliesHandler(registry, args, ctx));
+      // P1: pass the anomaly-history sink so detected scores flow
+      // into the TSDB and `get_anomaly_history` returns real data.
+      return withToolMetrics("detect_anomalies", () => detectAnomaliesHandler(registry, args, ctx, anomalyHistory));
     }
   );
 
@@ -1363,6 +1365,16 @@ async function main() {
         redaction: REDACTION_ENABLED,
         trustProxy: !!(process.env.OMCP_TRUST_PROXY && process.env.OMCP_TRUST_PROXY !== "false"),
         toolRatePerMin: resolveToolRatePerMin(process.env.OMCP_TOOL_RATE_PER_MIN),
+        // P1: posture flags so dashboards can alert when a shipped
+        // capability is configured but doing nothing useful.
+        anomalyHistoryActive: anomalyHistory.isEnabled(),
+        tracesCapabilityCount: registry
+          .getAll()
+          .filter((c) => typeof c.queryTraces === "function").length,
+        pluginsVerified: !/^(0|false|no|off)$/i.test(process.env.VERIFY_PLUGINS ?? "true"),
+        scimEnabled: !!process.env.OMCP_SCIM_TOKEN,
+        federationUpstreams: (process.env.OMCP_FEDERATION_UPSTREAMS ?? "")
+          .split(",").map((s) => s.trim()).filter(Boolean).length,
       },
       plugins: loader.list().map((p) => ({
         name: p.name,

--- a/mcp-server/src/tools/detect-anomalies.ts
+++ b/mcp-server/src/tools/detect-anomalies.ts
@@ -43,10 +43,28 @@ const KEY_METRICS = ["cpu", "memory", "error_rate", "latency_p99", "request_rate
 const CRITICAL_LOG_PATTERN =
   /\b(out\s?of\s?memory|oom|outofmemory|heap (usage|exhaust)|memory leak|panic|fatal|deadlock|segfault|stack overflow|cannot allocate)\b/i;
 
+// Optional dependency. When provided, every metric-derived anomaly
+// score is mirrored to the TSDB sink so `get_anomaly_history` can
+// replay it later. Wiring this lives at the call site in index.ts
+// — keeping the handler pure-injectable means unit tests don't need
+// a fake sink.
+export interface AnomalyHistorySink {
+  record(entry: {
+    ts: string;
+    service: string;
+    tenant: string;
+    score: number;
+    method: string;
+    severity: string;
+    signal?: string;
+  }): Promise<void> | void;
+}
+
 export async function detectAnomaliesHandler(
   registry: ConnectorRegistry,
   args: { service?: string; duration?: string; sensitivity?: string },
-  ctx: RequestContext = defaultContext()
+  ctx: RequestContext = defaultContext(),
+  history?: AnomalyHistorySink
 ) {
   const duration = args.duration || "10m";
   const threshold = SENSITIVITY_THRESHOLDS[args.sensitivity || "medium"] || 2.0;
@@ -89,9 +107,10 @@ export async function detectAnomaliesHandler(
             const deviationPercent = anomaly.baselineValue === 0
               ? 100
               : Math.round(((anomaly.recentValue - anomaly.baselineValue) / anomaly.baselineValue) * 100);
+            const severityLabel = Math.abs(anomaly.score) >= 6 ? "high" : Math.abs(anomaly.score) >= 4 ? "medium" : "low";
             allAnomalies.push({
               metric,
-              severity: Math.abs(anomaly.score) >= 6 ? "high" : Math.abs(anomaly.score) >= 4 ? "medium" : "low",
+              severity: severityLabel,
               description: `${metric}: ${anomaly.reason}`,
               currentValue: anomaly.recentValue,
               baselineValue: anomaly.baselineValue,
@@ -99,6 +118,24 @@ export async function detectAnomaliesHandler(
               source: connector.name,
               service: serviceName,
             });
+            // Phase P1: mirror the score to the TSDB sink (no-op if no
+            // sink wired). Best-effort — a slow / down sink must never
+            // block the detector loop, which is why we don't await.
+            if (history) {
+              try {
+                void history.record({
+                  ts: new Date().toISOString(),
+                  service: serviceName,
+                  tenant: ctx.tenant || "default",
+                  score: Math.abs(anomaly.score),
+                  method: anomaly.method === "seasonal" ? "seasonality"
+                        : anomaly.method === "robust-z" ? "mad"
+                        : anomaly.method,
+                  severity: severityLabel === "high" ? "critical" : severityLabel === "medium" ? "warn" : "info",
+                  signal: metric,
+                });
+              } catch { /* swallow — best-effort */ }
+            }
           }
         } catch {
           // Skip metrics that don't exist for this service

--- a/mcp-server/src/tools/topology.test.ts
+++ b/mcp-server/src/tools/topology.test.ts
@@ -238,3 +238,53 @@ describe("get_blast_radius tool", () => {
     assert.equal(apiBucket.ownershipRootKind, "deployment");
   });
 });
+
+// --- Multi-source merge (Phase P1 wiring) ----------------------------
+// `aggregateTopology` now delegates to `mergeTopologies` when 2+
+// snapshots are present so the same logical workload reported by
+// e.g. Kubernetes + a cloud connector collapses into one node.
+// Single-snapshot calls pass through unchanged (guarded so we don't
+// mis-merge intra-source siblings that share an `app:` label).
+
+describe("aggregateTopology — multi-source merger (P1 wire)", () => {
+  it("collapses cross-source duplicates that share a canonical label", async () => {
+    // Source A (k8s): one Deployment "checkout" in prod
+    const aRes: Resource[] = [
+      { id: "k8s:deployment:prod/checkout", kind: "deployment", name: "checkout", source: "k8s",
+        labels: { "app.kubernetes.io/name": "checkout" } },
+    ];
+    // Source B (trace provider): the same logical service
+    const bRes: Resource[] = [
+      { id: "tempo:service:checkout", kind: "trace_service", name: "checkout", source: "tempo",
+        labels: { "service.name": "checkout" } },
+    ];
+
+    const loader = new PluginLoader();
+    const reg = new ConnectorRegistry(loader);
+    const connA = new FakeTopologyConnector(aRes, []);
+    const connB = new FakeTopologyConnector(bRes, []);
+    await connA.connect({ name: "k8s", type: "fake", url: "", enabled: true });
+    await connB.connect({ name: "tempo", type: "fake", url: "", enabled: true });
+    const loaderInternal = loader as unknown as { connectors: Map<string, unknown> };
+    loaderInternal.connectors.set("fake-a", { name: "fake-a", source: "builtin", factory: () => connA });
+    loaderInternal.connectors.set("fake-b", { name: "fake-b", source: "builtin", factory: () => connB });
+    await reg.addSource({ name: "k8s", type: "fake-a", url: "", enabled: true });
+    await reg.addSource({ name: "tempo", type: "fake-b", url: "", enabled: true });
+
+    const out = parseTool(await getTopologyHandler(reg, {}));
+    // 2 sources reported in summary
+    assert.equal(out.sources.length, 2);
+    // But ONE resource after merge (deployment + trace_service of the
+    // same canonical name collapse via MERGEABLE_KIND_PAIRS).
+    assert.equal(out.resources.length, 1);
+    assert.equal(out.resources[0].name, "checkout");
+  });
+
+  it("single-source passes through unchanged (no intra-source merging)", async () => {
+    // The existing 4-pod fixture has two pods sharing `app: api`.
+    // With a single snapshot the merger must NOT collapse them.
+    const reg = await makeRegistry();
+    const out = parseTool(await getTopologyHandler(reg, {}));
+    assert.equal(out.resources.length, fixture().resources.length);
+  });
+});

--- a/mcp-server/src/tools/topology.ts
+++ b/mcp-server/src/tools/topology.ts
@@ -15,8 +15,9 @@
 
 import type { ConnectorRegistry } from "../connectors/registry.js";
 import { isTopologyProvider } from "../connectors/interface.js";
-import type { Resource, Edge } from "../types.js";
+import type { Resource, Edge, TopologySnapshot } from "../types.js";
 import { defaultContext, type RequestContext } from "../context.js";
+import { mergeTopologies } from "../topology/merge.js";
 
 // --- Shared helpers ----------------------------------------------------
 
@@ -28,8 +29,7 @@ interface AggregatedTopology {
 
 export async function aggregateTopology(registry: ConnectorRegistry, tenant?: string): Promise<AggregatedTopology> {
   const sources: AggregatedTopology["sources"] = [];
-  const resources: Resource[] = [];
-  const edges: Edge[] = [];
+  const snapshots: TopologySnapshot[] = [];
   // Tenant-scoped when a tenant is supplied (call sites at the MCP
   // tool layer pass ctx.tenant); undefined preserves the original
   // global behaviour for internal / non-request callers.
@@ -45,13 +45,31 @@ export async function aggregateTopology(registry: ConnectorRegistry, tenant?: st
         resources: snap.resources.length,
         edges: snap.edges.length,
       });
-      resources.push(...snap.resources);
-      edges.push(...snap.edges);
+      snapshots.push(snap);
     } catch {
       // A misbehaving connector must not poison the agent's view of the graph.
     }
   }
-  return { sources, resources, edges };
+  // P1: run the snapshots through mergeTopologies so workloads
+  // surfaced by more than one provider (e.g. the same Deployment
+  // observed by both Kubernetes + a service-mesh connector) collapse
+  // into a single canonical node and edges are rewritten to match.
+  //
+  // ONLY engages for multi-source topologies — with a single snapshot
+  // the merger would mis-group intra-source siblings that happen to
+  // share a canonical label (e.g. two pod replicas with
+  // `app.kubernetes.io/name=api`). The merger is designed for
+  // cross-provider de-duplication, not intra-provider.
+  if (snapshots.length <= 1) {
+    const only = snapshots[0];
+    return {
+      sources,
+      resources: only?.resources ?? [],
+      edges: only?.edges ?? [],
+    };
+  }
+  const merged = mergeTopologies(snapshots);
+  return { sources, resources: merged.resources, edges: merged.edges };
 }
 
 /**


### PR DESCRIPTION
## Summary
Three v3.0 capabilities were wired in but doing nothing useful at runtime. P1 connects them:

- **\`detect_anomalies → AnomalyHistory.record()\`** — metric anomalies now mirror their score into the TSDB sink so \`get_anomaly_history\` actually returns data. Best-effort fire-and-forget so a slow sink can't block detection.
- **\`aggregateTopology → mergeTopologies\`** — multi-source topologies now collapse the same workload reported by 2+ providers (e.g. k8s Deployment + a trace_service for the same name). Single-source case is **intentionally guarded** to pass through unchanged so intra-provider replicas sharing \`app:\` labels don't mis-collapse.
- **\`/api/info.governance\`** gains five posture flags: \`anomalyHistoryActive\`, \`tracesCapabilityCount\`, \`pluginsVerified\`, \`scimEnabled\`, \`federationUpstreams\`. External dashboards can alert when a configured capability isn't doing anything.

## Test plan
- [x] Unit tests: 787/787 (+2 new — cross-source merge positive, single-source passthrough regression guard).
- [x] Build (\`tsc\`) clean.
- [x] Reviewer-agent gate cleared.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)