### PR TITLE
docs(p2): query_traces + postmortems operator docs + 2.x→3.0 nav

### DIFF
--- a/docs/federation.md
+++ b/docs/federation.md
@@ -13,6 +13,14 @@ talk to.
 
 ## Configuring upstreams
 
+!!! note "Env-only configuration today"
+    Upstreams are configured exclusively via `OMCP_FEDERATION_UPSTREAMS` —
+    there is no `/api/federation` runtime-management endpoint yet
+    (planned as a v3.x increment). To change the upstream set, edit
+    the env / Helm value and restart the gateway. Tool calls and
+    metrics already in flight survive the restart on a sticky-
+    ingress / multi-replica deployment.
+
 Set `OMCP_FEDERATION_UPSTREAMS` to a comma-separated list of
 `name=url` pairs. Each name must start with a letter and use only
 `[a-z0-9_-]`. The URL must end at the upstream's Streamable HTTP

--- a/docs/postmortems.md
+++ b/docs/postmortems.md
@@ -1,0 +1,126 @@
+# `generate_postmortem` — auto-generated incident reports
+
+The eleventh MCP tool, shipped in v3.0. Stitches the gateway's
+existing primitives — anomaly history, trace summaries, topology
+blast-radius, log highlights — into a single markdown report a
+human reads in one shot.
+
+## When to use
+
+- After an incident, when you (or the on-call agent) want one
+  document instead of poking five tools by hand.
+- For a "context handoff" — pasted into a Slack thread or ticket
+  the next shift picks up.
+- As LLM context for retro / blameless-postmortem prep.
+
+## Prerequisites
+
+The tool degrades gracefully — every section either renders or
+explicitly states "no data". For a full report you want:
+
+- **Anomaly history sink active** — wire
+  `OMCP_ANOMALY_HISTORY_REMOTE_WRITE` (see
+  [anomaly-history.md](anomaly-history.md)) AND ensure
+  `/api/info.governance.anomalyHistoryActive` reports `true`.
+- **At least one traces-capable connector** — see
+  [`query_traces`](query-traces.md). Without one the "Related
+  traces" section says so explicitly.
+- **A topology provider** for blast-radius (Kubernetes connector
+  ships with one out of the box).
+- **A logs connector** (Loki by default).
+
+A report is still useful with only metrics + topology.
+
+## Schema
+
+```jsonc
+{
+  "name": "generate_postmortem",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "service":  { "type": "string", "description": "Suspected root-cause service." },
+      "duration": { "type": "string", "description": "Window length, e.g. '1h', '6h'. Default '1h'." },
+      "format":   { "type": "string", "description": "'markdown' (default) or 'json'." }
+    },
+    "required": ["service"]
+  }
+}
+```
+
+## Output
+
+Default `markdown`. The structured JSON shape is identical to the
+markdown body but parseable — useful if you want to render in a
+custom UI.
+
+The markdown body always contains these sections, in order:
+
+1. **Synopsis** — one paragraph: window, peak score, blast-radius
+   size, error-trace count.
+2. **Anomaly timeline** — capped at 20 rows (the full timeline
+   lives in the JSON shape).
+3. **Blast radius at peak** — capped at 30 nodes.
+4. **Contributing signals (ranked)** — top 10 signals by mean score.
+5. **Related traces** — up to 10 traces, error traces called out.
+6. **Log highlights** — present only when log highlights were
+   extracted.
+7. **Suggested follow-ups** — derived from the failure modes
+   (critical-peak threshold, blast-radius size, log-pattern
+   presence).
+
+## Example
+
+```bash
+SESSION=...  # from /mcp initialize
+
+curl -sS http://localhost:3000/mcp \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  -H "mcp-session-id: $SESSION" \
+  --data '{
+    "jsonrpc":"2.0", "id":1, "method":"tools/call",
+    "params": {
+      "name":"generate_postmortem",
+      "arguments":{"service":"checkout","duration":"6h"}
+    }
+  }' | jq -r '.result.content[0].text'
+```
+
+## RBAC
+
+The tool calls `enforceEntitledAccess(ctx, {tool: "generate_postmortem", service})`
+which routes through the standard per-credential
+`OMCP_KEY_PRODUCTS` allow-list + Product binding. Bind the tool
+into the Product(s) you want to expose. See
+[access-control.md](access-control.md) and
+[products.md](products.md).
+
+## Persistence
+
+P6 of the production-readiness sprint will add
+`POST /api/postmortems` storage so a generated report survives
+the agent session. Until then the markdown is returned only to the
+caller — paste it into your ticket / wiki / Slack at the call
+site.
+
+## Failure modes the tool handles
+
+| Situation | Report behaviour |
+|---|---|
+| Anomaly-history sink not configured | Synopsis says "no scores recorded" + follow-up suggests enabling `OMCP_ANOMALY_HISTORY_REMOTE_WRITE` |
+| No traces-capable connector | "Related traces" section is omitted with a note |
+| Topology provider down | "Blast radius" section is omitted with a note |
+| Logs connector returns empty | "Log highlights" section is omitted entirely |
+
+Every section is independently optional so a half-configured
+deployment still produces SOMETHING useful instead of failing.
+
+## Related
+
+- [`query_traces`](query-traces.md) — drill into a specific
+  trace ID surfaced in the report.
+- [`get_anomaly_history`](anomaly-history.md) — replay the raw
+  scores the timeline is built from.
+- [`get_blast_radius`](topology-vocabulary.md) — interrogate the
+  blast-radius graph for a specific resource id.

--- a/docs/query-traces.md
+++ b/docs/query-traces.md
@@ -1,0 +1,134 @@
+# `query_traces` — distributed traces tool
+
+The ninth MCP tool, shipped in v3.0. Fans out across every
+connector implementing the optional `queryTraces` capability,
+merges the returned spans, recomputes p50 / p95 over the merged
+set, and returns ranked trace summaries the agent can drill into.
+
+## When to use
+
+- Drilling into a latency spike a metric flagged.
+- Answering "show me the 5 slowest checkout-service traces in the
+  last 15 minutes" without remembering the backend query language.
+- Pairing with `get_blast_radius` and `query_logs` for a full
+  incident triage.
+
+For the metrics/logs pieces of an incident use the matching
+`query_metrics` / `query_logs` tools.
+
+## Prerequisites
+
+At least one configured source whose connector implements
+`queryTraces`. As of v3.0 that means an OTLP-shaped Tempo
+deployment via the bundled `tempo` connector (P3 in the
+production-readiness sprint adds the actual `queryTraces`
+implementation to the plugin; until P3 lands the tool returns
+empty even when Tempo is configured — track via
+`/api/info.governance.tracesCapabilityCount`).
+
+You can verify the gateway sees at least one provider:
+
+```bash
+curl -s http://localhost:3000/api/info | jq '.governance.tracesCapabilityCount'
+# expect: > 0 once a queryTraces-capable connector is configured
+```
+
+## Schema
+
+```jsonc
+{
+  "name": "query_traces",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "service":    { "type": "string", "description": "Service name to search for." },
+      "duration":   { "type": "string", "description": "Window length, e.g. '15m', '1h'. Default '15m'." },
+      "filter":     { "type": "string", "description": "Backend-native filter (TraceQL on Tempo, tag query on Jaeger). Optional." },
+      "limit":      { "type": "number", "description": "Soft cap on returned trace summaries. Default 50." },
+      "errorsOnly": { "type": "boolean", "description": "If true, restrict to traces carrying at least one error span." }
+    },
+    "required": ["service"]
+  }
+}
+```
+
+## Output shape
+
+```jsonc
+{
+  "service": "checkout",
+  "duration": "15m",
+  "sources": ["tempo-prod"],
+  "summary": {
+    "total":          12,
+    "errorCount":     2,
+    "p50DurationMs":  410,
+    "p95DurationMs":  1180
+  },
+  "traces": [
+    {
+      "traceId":     "1a2b3c…",
+      "rootName":    "POST /checkout",
+      "rootService": "checkout",
+      "durationMs":  1240,
+      "spanCount":   17,
+      "hasError":    false
+    }
+  ],
+  "errors": ["tempo-staging: connect ECONNREFUSED"]  // only present on partial-failure
+}
+```
+
+`sources` is the flat list of source names whose connectors
+returned. `summary` aggregates over the (capped) merged set —
+the percentiles are NOT the source-of-truth backend p95 for SLO
+reporting; query the backend directly for that. `errors`
+appears only on partial-failure runs (one connector errored,
+others succeeded).
+
+## Example call
+
+```bash
+curl -sS http://localhost:3000/mcp \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  -H "mcp-session-id: $SESSION" \
+  --data '{
+    "jsonrpc":"2.0", "id":1, "method":"tools/call",
+    "params": {
+      "name":"query_traces",
+      "arguments":{"service":"checkout","duration":"15m","errorsOnly":true}
+    }
+  }'
+```
+
+## RBAC
+
+The tool calls `enforceEntitledAccess(ctx, {tool: "query_traces", service})`
+which routes through the same per-credential `OMCP_KEY_PRODUCTS`
+allow-list + Product binding the existing data-query tools use.
+Bind the tool into the Product(s) you want to expose. See
+[access-control.md](access-control.md) and
+[products.md](products.md).
+
+## Troubleshooting
+
+- **Empty `traces` against a working Tempo** — usually means the
+  active connector implements `queryMetrics` (topology) but not
+  `queryTraces`. Check `/api/info.governance.tracesCapabilityCount`.
+- **`p50_ms` looks too low** — by design: percentiles are computed
+  AFTER the merge across the (capped) returned set, not over the
+  full backend population. Use the source-of-truth backend for SLO
+  reports.
+- **Auth 403 with permission appearing in policy** — the tool
+  enforces tenant scoping; verify the calling identity's tenant
+  matches the connector's tenant binding (`sources.yaml`).
+
+## Related
+
+- [`get_anomaly_history`](anomaly-history.md) — pair with replayed
+  scores to see whether a slow trace correlates with a known
+  anomaly window.
+- [`generate_postmortem`](postmortems.md) — bundles
+  `query_traces` output into the markdown report so the post-mortem
+  carries concrete trace IDs.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,12 +104,15 @@ nav:
       - Comparison: comparison.md
   - Observability Intelligence:
       - Anomaly history: anomaly-history.md
+      - Distributed traces (query_traces): query-traces.md
+      - Auto-postmortems (generate_postmortem): postmortems.md
       - Astronomy-shop benchmark: benchmark-astronomy-shop.md
   - Reference:
       - Demo agent: agent.md
       - Entitlement gate: enterprise-gate.md
   - Migrations:
       - 1.x → 2.0: migrations/1.x-to-2.0.md
+      - 2.x → 3.0: migrations/2.x-to-3.0.md
 
 extra:
   social:


### PR DESCRIPTION
## Summary
Closes the "shipped but invisible in docs" gap for v3.0 tools.

- **\`docs/query-traces.md\`** — full operator page (when to use, prerequisites, schema, output shape, example, RBAC, troubleshooting).
- **\`docs/postmortems.md\`** — same for \`generate_postmortem\` plus a failure-mode table covering each missing prerequisite.
- **\`docs/federation.md\`** — admonition that runtime mgmt is env-only (no \`/api/federation\` API yet).
- **\`mkdocs.yml\`** — three new nav entries (traces + postmortems under Observability Intelligence, 2.x→3.0 under Migrations).

Reviewer-agent caught several pre-push mismatches with shipped code (limit default, filter semantics, output shape, RBAC scheme); all fixed before push.

## Test plan
- [x] \`mkdocs build\` clean (same pre-existing warnings, no new broken links).
- [x] Reviewer-agent gate cleared on re-review.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)