### PR TITLE
feat(p5): first-class Helm scim: value block + Secret template

### DIFF
--- a/docs/scim-provisioning.md
+++ b/docs/scim-provisioning.md
@@ -21,6 +21,26 @@ export OMCP_SCIM_GROUP_ROLE_MAP="admins:admin,sre:operator,readers:viewer"
 The store file is created on first write with `mode 0600`. Atomic
 tmp+rename keeps it consistent.
 
+## Helm install (since Phase P5)
+
+The chart ships a first-class `scim:` value block — no `extraEnv`
+contortions needed:
+
+```yaml
+scim:
+  enabled: true
+  storePath: /var/lib/observability-mcp/scim.json
+  token: <bearer the IdP sends>          # OR reference existingSecret instead
+  existingSecret: ""                     # name of a Secret with key `token`
+  groupRoleMap: "admins:admin,sre:operator,readers:viewer"
+```
+
+A matching Secret template renders when `enabled=true` AND `token`
+is set AND `existingSecret` is empty — pick `existingSecret` over
+inline `token` for production so the value never enters the rendered
+manifest. Mount a PVC at `storePath` if you want provisioned state
+to survive pod restarts.
+
 ## Endpoints
 
 Mounted at `/scim/v2/`. All endpoints require

--- a/helm/observability-mcp/templates/deployment.yaml
+++ b/helm/observability-mcp/templates/deployment.yaml
@@ -127,6 +127,21 @@ spec:
             - name: OMCP_AIRGAPPED
               value: "true"
             {{- end }}
+            {{- if .Values.scim.enabled }}
+            - name: OMCP_SCIM_STORE
+              value: {{ .Values.scim.storePath | quote }}
+            {{- if .Values.scim.groupRoleMap }}
+            - name: OMCP_SCIM_GROUP_ROLE_MAP
+              value: {{ .Values.scim.groupRoleMap | quote }}
+            {{- end }}
+            {{- if or .Values.scim.token .Values.scim.existingSecret }}
+            - name: OMCP_SCIM_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.scim.existingSecret | default (printf "%s-scim" (include "observability-mcp.fullname" .)) }}
+                  key: token
+            {{- end }}
+            {{- end }}
             {{- if .Values.anomalyHistory.enabled }}
             - name: OMCP_ANOMALY_HISTORY_REMOTE_WRITE
               value: {{ .Values.anomalyHistory.remoteWriteUrl | quote }}

--- a/helm/observability-mcp/templates/secret-scim.yaml
+++ b/helm/observability-mcp/templates/secret-scim.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.scim.enabled .Values.scim.token (not .Values.scim.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "observability-mcp.fullname" . }}-scim
+  labels:
+    {{- include "observability-mcp.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  token: {{ .Values.scim.token | quote }}
+{{- end }}

--- a/helm/observability-mcp/values.schema.json
+++ b/helm/observability-mcp/values.schema.json
@@ -115,6 +115,17 @@
         "existingSecret": { "type": "string" }
       }
     },
+    "scim": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "storePath": { "type": "string" },
+        "token": { "type": "string" },
+        "existingSecret": { "type": "string" },
+        "groupRoleMap": { "type": "string" }
+      }
+    },
     "audit": {
       "type": "object",
       "additionalProperties": false,

--- a/helm/observability-mcp/values.yaml
+++ b/helm/observability-mcp/values.yaml
@@ -216,6 +216,27 @@ otel:
 # anomaly score the detector produces is written to a Prometheus
 # remote-write endpoint as omcp_anomaly_score{service=...}. See
 # docs/anomaly-history.md.
+# SCIM 2.0 provisioning — enables /scim/v2/* endpoints so an IdP
+# (Microsoft Entra ID, Okta) can push Users + Groups directly into
+# the gateway. Off by default; setting `enabled: true` requires
+# either `token: "<value>"` or `existingSecret: "<secret-name>"`
+# (a Secret with key `token`). The store path defaults to
+# /var/lib/observability-mcp/scim.json — mount a persistent volume
+# at that path if you want the provisioned state to survive pod
+# restarts (otherwise it lives only as long as the pod). Optionally
+# map SCIM groups to gateway RBAC roles via groupRoleMap
+# ("admins:admin,sre:operator,readers:viewer").
+# See docs/scim-provisioning.md.
+scim:
+  enabled: false
+  storePath: /var/lib/observability-mcp/scim.json
+  # Bearer token the IdP sends in the Authorization header. For
+  # real deployments reference a Secret via existingSecret.
+  token: ""
+  existingSecret: ""
+  # Comma-separated SCIM-group-name:gateway-role-name pairs.
+  groupRoleMap: ""
+
 anomalyHistory:
   enabled: false
   # Prometheus remote-write URL (any TSDB that accepts the format —


### PR DESCRIPTION
## Summary
SCIM 2.0 shipped in v3.0 but the chart had no \`scim:\` block — operators had to thread the token through \`extraEnv\`. This adds the proper Helm surface.

- \`values.yaml\` — new top-level \`scim: { enabled, storePath, token, existingSecret, groupRoleMap }\`. Default off, backwards-compatible.
- \`values.schema.json\` — \`additionalProperties: false\` so typos fail at install-time.
- \`templates/secret-scim.yaml\` — renders only when \`enabled\` AND \`token\` AND not \`existingSecret\`.
- \`templates/deployment.yaml\` — env block: \`OMCP_SCIM_STORE\` always when enabled, \`OMCP_SCIM_GROUP_ROLE_MAP\` only when set, \`OMCP_SCIM_TOKEN\` from a Secret keyref when either inline-token or existingSecret.
- \`docs/scim-provisioning.md\` — new "Helm install" section with values example.

## Test plan
- [x] \`helm lint\` clean.
- [x] \`helm template --set scim.enabled=true --set scim.token=t\` renders Secret + env correctly.
- [x] Reviewer-agent gate cleared.
- [x] All four gate scenarios verified (disabled / enabled+token / enabled+existingSecret / enabled-only).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)