### PR TITLE
feat(p6): Postmortems persistence + UI tab

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -103,6 +103,7 @@ import { queryLogsHandler } from "./tools/query-logs.js";
 import { queryTracesHandler } from "./tools/query-traces.js";
 import { getAnomalyHistoryHandler } from "./tools/get-anomaly-history.js";
 import { generatePostmortemHandler } from "./tools/generate-postmortem.js";
+import { PostmortemStore } from "./postmortem/store.js";
 import { AnomalyHistory, fromEnv as anomalyHistoryFromEnv } from "./analysis/history.js";
 import { getServiceHealthHandler, setHealthThresholds } from "./tools/get-service-health.js";
 import { detectAnomaliesHandler } from "./tools/detect-anomalies.js";
@@ -2000,6 +2001,96 @@ async function main() {
       scimStorePath,
     );
   }
+
+  // Phase P6: Postmortems persistence. /api/postmortems lets the
+  // UI list / open / regenerate / delete previously-generated
+  // reports. Opt-in via OMCP_POSTMORTEMS_FILE (default
+  // /tmp/postmortems.jsonl). When the env is left at its default
+  // the demo still works — operators who want survival across
+  // restarts mount a PVC at the same path and set the env to it.
+  const postmortemStore = new PostmortemStore(
+    process.env.OMCP_POSTMORTEMS_FILE?.trim() || "/tmp/postmortems.jsonl",
+  );
+  await postmortemStore.load();
+
+  // GET /api/postmortems — list (newest-first), tenant-scoped.
+  app.get("/api/postmortems", need("services", "read"), async (req, res) => {
+    const sess = (req as AuthedRequest).session;
+    const tenant = sess?.tenant || "default";
+    const entries = postmortemStore.list(tenant);
+    res.json({
+      total: entries.length,
+      entries: entries.map((e) => ({
+        id: e.id,
+        ts: e.ts,
+        createdBy: e.createdBy,
+        service: e.report.service,
+        window: e.report.window,
+        synopsis: e.report.synopsis,
+      })),
+    });
+  });
+
+  // GET /api/postmortems/:id — full report (markdown + sections).
+  app.get("/api/postmortems/:id", need("services", "read"), async (req, res) => {
+    const sess = (req as AuthedRequest).session;
+    const tenant = sess?.tenant || "default";
+    const id = String(req.params.id ?? "");
+    const entry = postmortemStore.get(id, tenant);
+    if (!entry) {
+      res.status(404).json({ error: `Postmortem ${id} not found` });
+      return;
+    }
+    res.json(entry);
+  });
+
+  // POST /api/postmortems — regenerate via the tool handler +
+  // persist. Body: { service, duration?, format? }. Returns the
+  // stored entry with its id.
+  app.post("/api/postmortems", need("services", "write"), async (req, res) => {
+    const body = (req.body ?? {}) as { service?: string; duration?: string };
+    if (!body.service || typeof body.service !== "string") {
+      res.status(400).json({ error: "service is required" });
+      return;
+    }
+    const sess = (req as AuthedRequest).session;
+    const tenant = sess?.tenant || "default";
+    const createdBy = sess?.sub || sess?.name || "unknown";
+    try {
+      // Force JSON so we get the structured report shape back from
+      // the tool, not just the markdown body. We persist the full
+      // structured report; the markdown lives inside `report.markdown`.
+      const ctx: RequestContext = { ...defaultContext(), tenant, principalId: createdBy };
+      const result = await generatePostmortemHandler(
+        registry,
+        { service: body.service, duration: body.duration, format: "json" },
+        ctx,
+      );
+      const text = result?.content?.[0]?.text;
+      if (!text) {
+        res.status(500).json({ error: "generate_postmortem returned no content" });
+        return;
+      }
+      const report = JSON.parse(text);
+      const stored = await postmortemStore.append({ report, createdBy, tenant });
+      res.status(201).json(stored);
+    } catch (e) {
+      console.warn(`[postmortems] regen failed:`, e);
+      res.status(500).json({ error: (e as Error)?.message || "internal error" });
+    }
+  });
+
+  // DELETE /api/postmortems/:id — admin-gated.
+  app.delete("/api/postmortems/:id", need("services", "delete"), async (req, res) => {
+    const sess = (req as AuthedRequest).session;
+    const tenant = sess?.tenant || "default";
+    const ok = await postmortemStore.delete(String(req.params.id ?? ""), tenant);
+    if (!ok) {
+      res.status(404).json({ error: `Postmortem ${req.params.id} not found` });
+      return;
+    }
+    res.status(204).end();
+  });
 
   // Connectors currently loaded into this server (builtin + filesystem
   // plugins), with manifest metadata — drives the UI "Connectors" page.

--- a/mcp-server/src/postmortem/store.test.ts
+++ b/mcp-server/src/postmortem/store.test.ts
@@ -1,0 +1,131 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, statSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { PostmortemStore } from "./store.js";
+import type { PostmortemReport } from "./synthesizer.js";
+
+function tmpStore(): string {
+  return join(mkdtempSync(join(tmpdir(), "pmstore-")), "postmortems.jsonl");
+}
+
+function fakeReport(service = "payment"): PostmortemReport {
+  return {
+    service,
+    window: "1h",
+    fromIso: "2026-06-06T00:00:00.000Z",
+    toIso: "2026-06-06T01:00:00.000Z",
+    synopsis: "test",
+    markdown: "# Test",
+    sections: {
+      timeline: [],
+      blastRadius: { nodes: [], edgeCount: 0 },
+      topTraces: [],
+      contributingSignals: [],
+      followUps: [],
+      logHighlights: [],
+    },
+  };
+}
+
+test("PostmortemStore: load() on missing file → empty list", async () => {
+  const s = new PostmortemStore(tmpStore());
+  await s.load();
+  assert.deepEqual(s.list(), []);
+});
+
+test("PostmortemStore: append issues UUID + ISO ts, persists JSONL", async () => {
+  const path = tmpStore();
+  const s = new PostmortemStore(path);
+  await s.load();
+  const stored = await s.append({ report: fakeReport(), createdBy: "alice", tenant: "default" });
+  assert.match(stored.id, /^[0-9a-f-]{36}$/);
+  assert.match(stored.ts, /^\d{4}-\d{2}-\d{2}T/);
+  assert.equal(stored.report.service, "payment");
+  // disk format is one JSON per line
+  const raw = readFileSync(path, "utf8");
+  assert.equal(raw.split("\n").filter((l) => l).length, 1);
+  assert.equal(statSync(path).mode & 0o777, 0o600);
+});
+
+test("PostmortemStore: list() returns newest-first", async () => {
+  const s = new PostmortemStore(tmpStore());
+  await s.load();
+  await s.append({ report: fakeReport("a"), createdBy: "u", tenant: "t" });
+  await new Promise((r) => setTimeout(r, 5));
+  await s.append({ report: fakeReport("b"), createdBy: "u", tenant: "t" });
+  const out = s.list();
+  assert.equal(out[0].report.service, "b");
+  assert.equal(out[1].report.service, "a");
+});
+
+test("PostmortemStore: list(tenant) scopes correctly", async () => {
+  const s = new PostmortemStore(tmpStore());
+  await s.load();
+  await s.append({ report: fakeReport("a"), createdBy: "u", tenant: "alpha" });
+  await s.append({ report: fakeReport("b"), createdBy: "u", tenant: "beta" });
+  assert.equal(s.list("alpha").length, 1);
+  assert.equal(s.list("alpha")[0].report.service, "a");
+});
+
+test("PostmortemStore: get() by id, tenant-scoped", async () => {
+  const s = new PostmortemStore(tmpStore());
+  await s.load();
+  const e = await s.append({ report: fakeReport(), createdBy: "u", tenant: "alpha" });
+  assert.equal(s.get(e.id)?.id, e.id);
+  assert.equal(s.get(e.id, "alpha")?.id, e.id);
+  // wrong tenant → undefined
+  assert.equal(s.get(e.id, "beta"), undefined);
+  assert.equal(s.get("nope"), undefined);
+});
+
+test("PostmortemStore: delete() rewrites file + scoped by tenant", async () => {
+  const path = tmpStore();
+  const s = new PostmortemStore(path);
+  await s.load();
+  const e1 = await s.append({ report: fakeReport("a"), createdBy: "u", tenant: "alpha" });
+  await s.append({ report: fakeReport("b"), createdBy: "u", tenant: "beta" });
+  // wrong tenant → no-op
+  assert.equal(await s.delete(e1.id, "beta"), false);
+  assert.equal(s.list().length, 2);
+  // correct tenant → removed
+  assert.equal(await s.delete(e1.id, "alpha"), true);
+  assert.equal(s.list().length, 1);
+  // disk reflects the rewrite
+  const raw = readFileSync(path, "utf8");
+  assert.equal(raw.split("\n").filter((l) => l).length, 1);
+});
+
+test("PostmortemStore: delete() missing id → false", async () => {
+  const s = new PostmortemStore(tmpStore());
+  await s.load();
+  assert.equal(await s.delete("nope"), false);
+});
+
+test("PostmortemStore: round-trip through disk (load after append sees entries)", async () => {
+  const path = tmpStore();
+  const a = new PostmortemStore(path);
+  await a.load();
+  await a.append({ report: fakeReport("a"), createdBy: "u", tenant: "default" });
+  await a.append({ report: fakeReport("b"), createdBy: "u", tenant: "default" });
+  const b = new PostmortemStore(path);
+  await b.load();
+  assert.equal(b.list().length, 2);
+});
+
+test("PostmortemStore: load skips corrupt lines", async () => {
+  const path = tmpStore();
+  // Hand-write a file with one good + one garbage line
+  const a = new PostmortemStore(path);
+  await a.load();
+  await a.append({ report: fakeReport(), createdBy: "u", tenant: "default" });
+  const fs = await import("node:fs/promises");
+  await fs.appendFile(path, "{not valid json\n");
+  const b = new PostmortemStore(path);
+  await b.load();
+  // Good entry survived; corrupt line ignored.
+  assert.equal(b.list().length, 1);
+  assert.ok(existsSync(path));
+});

--- a/mcp-server/src/postmortem/store.ts
+++ b/mcp-server/src/postmortem/store.ts
@@ -1,0 +1,131 @@
+// PostmortemStore — file-backed JSONL persistence for
+// generate_postmortem output.
+//
+// Design notes:
+//   - One JSON object per line (append-only). Cheap to tail, cheap
+//     to scan, surives crashes mid-write (the partial line is just
+//     ignored on load).
+//   - load() reads the whole file into an in-memory array (in
+//     practice operators don't accumulate thousands; the tool
+//     produces one report per incident).
+//   - delete() rewrites the file atomically (tmp + rename). Same
+//     pattern as the SCIM store from F21.
+//
+// The schema is intentionally narrow — we store what the tool's
+// PostmortemReport already returns plus an id, ts, and createdBy.
+
+import { readFile, writeFile, mkdir, rename, appendFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import type { PostmortemReport } from "./synthesizer.js";
+
+export interface StoredPostmortem {
+  id: string;
+  /** RFC-3339 timestamp of when the report was generated. */
+  ts: string;
+  /** Subject identity that called generate_postmortem. */
+  createdBy: string;
+  /** Tenant the report belongs to. */
+  tenant: string;
+  /** The shipped report shape — service + window + synopsis +
+   *  markdown + sections. */
+  report: PostmortemReport;
+}
+
+export class PostmortemStore {
+  private readonly path: string;
+  private entries: StoredPostmortem[] = [];
+  private bootstrapped: Promise<void> | null = null;
+
+  constructor(path: string) {
+    this.path = path;
+  }
+
+  async load(): Promise<void> {
+    if (this.bootstrapped) return this.bootstrapped;
+    this.bootstrapped = (async () => {
+      try {
+        const raw = await readFile(this.path, "utf8");
+        const out: StoredPostmortem[] = [];
+        for (const line of raw.split("\n")) {
+          const t = line.trim();
+          if (!t) continue;
+          try {
+            const obj = JSON.parse(t) as StoredPostmortem;
+            if (obj && typeof obj.id === "string") out.push(obj);
+          } catch {
+            // Partial / corrupt line — skip, don't fail load. The
+            // operator can purge by re-saving with delete().
+          }
+        }
+        this.entries = out;
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+          this.entries = [];
+          return;
+        }
+        console.warn(`[postmortem-store] failed to load ${this.path}: ${(err as Error).message} — starting empty`);
+        this.entries = [];
+      }
+    })();
+    return this.bootstrapped;
+  }
+
+  /** List entries, newest-first. Optionally scoped to a tenant. */
+  list(tenant?: string): StoredPostmortem[] {
+    const src = tenant ? this.entries.filter((e) => e.tenant === tenant) : this.entries;
+    return src.slice().sort((a, b) => b.ts.localeCompare(a.ts));
+  }
+
+  get(id: string, tenant?: string): StoredPostmortem | undefined {
+    const e = this.entries.find((x) => x.id === id);
+    if (!e) return undefined;
+    if (tenant && e.tenant !== tenant) return undefined;
+    return e;
+  }
+
+  /** Append a freshly-generated report. Returns the stored entry
+   *  with its assigned id + ts. */
+  async append(input: {
+    report: PostmortemReport;
+    createdBy: string;
+    tenant: string;
+  }): Promise<StoredPostmortem> {
+    const entry: StoredPostmortem = {
+      id: randomUUID(),
+      ts: new Date().toISOString(),
+      createdBy: input.createdBy,
+      tenant: input.tenant,
+      report: input.report,
+    };
+    this.entries.push(entry);
+    await mkdir(dirname(this.path), { recursive: true }).catch(() => undefined);
+    // Append-only — atomic enough for a JSONL (one write = one
+    // syscall; partial writes are skipped on load).
+    await appendFile(this.path, JSON.stringify(entry) + "\n", { mode: 0o600 });
+    return entry;
+  }
+
+  /** Delete one entry by id. Atomic rewrite. Returns whether
+   *  anything was removed. */
+  async delete(id: string, tenant?: string): Promise<boolean> {
+    const before = this.entries.length;
+    this.entries = this.entries.filter((e) => {
+      if (e.id !== id) return true;
+      if (tenant && e.tenant !== tenant) return true;
+      return false;
+    });
+    if (this.entries.length === before) return false;
+    await this.rewrite();
+    return true;
+  }
+
+  private async rewrite(): Promise<void> {
+    await mkdir(dirname(this.path), { recursive: true }).catch(() => undefined);
+    const body = this.entries.map((e) => JSON.stringify(e)).join("\n") + (this.entries.length ? "\n" : "");
+    const tmp = `${this.path}.tmp`;
+    await writeFile(tmp, body, { mode: 0o600 });
+    await rename(tmp, this.path);
+  }
+}

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -1402,6 +1402,7 @@
           <button class="nav-btn" data-page="services" title="Services" onclick="showPage('services')"><span class="nav-ico">⊞</span><span class="nav-label">Services</span></button>
           <button class="nav-btn" data-page="health" title="Health" onclick="showPage('health')"><span class="nav-ico">✚</span><span class="nav-label">Health</span></button>
           <button class="nav-btn" data-page="topology" title="Topology" onclick="showPage('topology')"><span class="nav-ico">◇</span><span class="nav-label">Topology</span></button>
+          <button class="nav-btn" data-page="postmortems" title="Postmortems" onclick="showPage('postmortems')"><span class="nav-ico">◷</span><span class="nav-label">Postmortems</span></button>
         </div>
       </div>
       <div class="rail-grp" data-grp="catalog">
@@ -1899,6 +1900,44 @@ curl -X PUT http://localhost:3000/api/enterprise/policy \
             <button class="btn btn-ghost btn-sm" onclick="closeDrawer()">Cancel</button>
             <button class="btn btn-primary btn-sm" onclick="entSaveRbac()">Save policy</button>
           </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ===== Observability: Postmortems (P6 — persisted reports) ===== -->
+    <div class="page" id="page-postmortems">
+      <div class="page-head">
+        <div class="ph-left">
+          <div class="breadcrumb">Console / Observability / <b>Postmortems</b></div>
+          <h1>Postmortems</h1>
+        </div>
+        <div class="ph-actions">
+          <button class="btn btn-primary btn-sm" onclick="pmOpenNew()">+ Generate</button>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-header"><h2>Generated reports
+          <button class="info" aria-label="About postmortems"
+            data-title="Postmortems"
+            data-info="Persisted output of the generate_postmortem MCP tool. Each entry stitches anomaly history + traces + blast-radius + log highlights into one markdown report for a service. RBAC: viewers list, operators regenerate, admins delete."
+            onclick="infoPop(this)">?</button>
+        </h2></div>
+        <div class="content">
+          <div id="pm-list-body"><div class="empty">Loading…</div></div>
+        </div>
+      </div>
+
+      <div class="card" id="pm-detail-card" hidden>
+        <div class="card-header"><h2 id="pm-detail-title">Report</h2>
+          <span style="flex:1"></span>
+          <button class="btn btn-ghost btn-sm" onclick="pmCloseDetail()">Close</button>
+          <button class="btn btn-sm" id="pm-detail-regen" onclick="pmRegenerate()" hidden>Regenerate</button>
+          <button class="btn btn-sm btn-danger" id="pm-detail-delete" onclick="pmDelete()" hidden>Delete</button>
+        </div>
+        <div class="content">
+          <div id="pm-detail-meta" class="muted" style="margin-bottom:8px;font-size:12px"></div>
+          <pre id="pm-detail-md" style="white-space:pre-wrap;font-family:var(--mono);font-size:12px;background:var(--bg);padding:12px;border:1px solid var(--border);border-radius:4px;max-height:540px;overflow:auto"></pre>
         </div>
       </div>
     </div>
@@ -2557,6 +2596,110 @@ function showPage(name) {
   if(name==='access'||name==='products'||name==='audit'||name==='entitlement') loadEnterprise();
   if(name==='products') loadMcpProducts();
   if(name==='policies') loadPolicies();
+  if(name==='postmortems') pmLoadList();
+}
+
+// --- Postmortems tab (P6) -----------------------------------------------
+// Mirrors the generate_postmortem MCP tool into the UI: list persisted
+// entries newest-first, open a detail view rendering the markdown,
+// regenerate (POST /api/postmortems re-runs the tool with the same
+// service+window), delete (admin-only — the API gates).
+
+let PM_LAST_DETAIL = null;
+
+async function pmLoadList() {
+  const body = document.getElementById('pm-list-body');
+  if (!body) return;
+  body.innerHTML = '<div class="empty">Loading…</div>';
+  try {
+    const r = await fetch('/api/postmortems');
+    if (!r.ok) { body.innerHTML = '<div class="empty">HTTP ' + r.status + '</div>'; return; }
+    const j = await r.json();
+    if (!j.entries || j.entries.length === 0) {
+      body.innerHTML = '<div class="empty">No postmortems yet. Click <b>+ Generate</b> to create one for a service.</div>';
+      return;
+    }
+    let html = '<table class="data-table"><thead><tr><th>When</th><th>Service</th><th>Window</th><th>Synopsis</th><th>By</th><th></th></tr></thead><tbody>';
+    for (const e of j.entries) {
+      html += '<tr>'
+        + '<td>' + escHtml(e.ts) + '</td>'
+        + '<td><code>' + escHtml(e.service) + '</code></td>'
+        + '<td>' + escHtml(e.window) + '</td>'
+        + '<td>' + escHtml((e.synopsis || '').slice(0, 120)) + '</td>'
+        + '<td>' + escHtml(e.createdBy) + '</td>'
+        + '<td><button class="btn btn-sm" onclick="pmOpen(\'' + escHtml(e.id) + '\')">Open</button></td>'
+        + '</tr>';
+    }
+    html += '</tbody></table>';
+    body.innerHTML = html;
+  } catch (e) {
+    body.innerHTML = '<div class="empty">' + escHtml('Load failed: ' + (e?.message || e)) + '</div>';
+  }
+}
+
+async function pmOpen(id) {
+  try {
+    const r = await fetch('/api/postmortems/' + encodeURIComponent(id));
+    if (!r.ok) { alert('HTTP ' + r.status); return; }
+    const j = await r.json();
+    PM_LAST_DETAIL = j;
+    const card = document.getElementById('pm-detail-card');
+    const title = document.getElementById('pm-detail-title');
+    const meta = document.getElementById('pm-detail-meta');
+    const md = document.getElementById('pm-detail-md');
+    title.textContent = j.report.service + ' — ' + j.report.window;
+    meta.textContent = j.ts + ' · by ' + j.createdBy + ' · id ' + j.id;
+    md.textContent = j.report.markdown || '';
+    card.hidden = false;
+    document.getElementById('pm-detail-regen').hidden = false;
+    document.getElementById('pm-detail-delete').hidden = false;
+    card.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  } catch (e) { alert('Open failed: ' + (e?.message || e)); }
+}
+
+function pmCloseDetail() {
+  PM_LAST_DETAIL = null;
+  document.getElementById('pm-detail-card').hidden = true;
+}
+
+async function pmOpenNew() {
+  const service = prompt('Service name to generate a postmortem for:');
+  if (!service) return;
+  const duration = prompt('Window (e.g. 1h, 6h):', '1h') || '1h';
+  await pmGenerate(service.trim(), duration.trim());
+}
+
+async function pmGenerate(service, duration) {
+  try {
+    const r = await fetch('/api/postmortems', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ service, duration }),
+    });
+    if (!r.ok) {
+      const text = await r.text();
+      alert('Generate failed: HTTP ' + r.status + (text ? '\n' + text : ''));
+      return;
+    }
+    const stored = await r.json();
+    await pmLoadList();
+    await pmOpen(stored.id);
+  } catch (e) { alert('Generate failed: ' + (e?.message || e)); }
+}
+
+async function pmRegenerate() {
+  if (!PM_LAST_DETAIL) return;
+  await pmGenerate(PM_LAST_DETAIL.report.service, PM_LAST_DETAIL.report.window);
+}
+
+async function pmDelete() {
+  if (!PM_LAST_DETAIL) return;
+  if (!confirm('Delete this postmortem? This cannot be undone.')) return;
+  try {
+    const r = await fetch('/api/postmortems/' + encodeURIComponent(PM_LAST_DETAIL.id), { method: 'DELETE' });
+    if (r.status === 204) { pmCloseDetail(); await pmLoadList(); return; }
+    alert('Delete failed: HTTP ' + r.status);
+  } catch (e) { alert('Delete failed: ' + (e?.message || e)); }
 }
 
 // --- Policies tab (PolicyEngine snapshot + dry-run) ---


### PR DESCRIPTION
## Summary
\`generate_postmortem\` shipped in v3.0 but the markdown disappeared on tab close. P6 closes the persistence + UI gap.

- **\`PostmortemStore\`** (JSONL-backed, mode 0600). Append via \`appendFile\`, delete atomic tmp+rename, corrupt-line tolerant on load, tenant-scoped list/get/delete. 9 unit tests.
- **Four REST routes**: \`GET /api/postmortems\`, \`GET /api/postmortems/:id\`, \`POST /api/postmortems\` (regenerate via tool + persist), \`DELETE /api/postmortems/:id\` (admin-gated). RBAC via the existing \`services:{read,write,delete}\` permissions. Tenant scoping enforced.
- **UI**: new Postmortems tab under Observability rail. List card + Generate button (prompts), detail card with markdown \`<pre>\` + Regenerate + Delete (confirm-gated).
- Configured via \`OMCP_POSTMORTEMS_FILE\` (default \`/tmp/postmortems.jsonl\`).

## Test plan
- [x] Unit tests: 796/796 (+9 store).
- [x] Build clean.
- [x] Reviewer-agent gate cleared.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)