### PR TITLE
feat(p7): federation E2E CI + fixes federation registration crash

### DIFF
--- a/.github/workflows/federation-e2e.yml
+++ b/.github/workflows/federation-e2e.yml
@@ -1,0 +1,49 @@
+name: federation-e2e
+
+# Verifies cross-gateway namespaced tool dispatch end-to-end.
+# Boots two mcp-server instances via docker-compose, wires gateway-b
+# to federate gateway-a as `OMCP_FEDERATION_UPSTREAMS=a=http://gateway-a:3000/mcp`,
+# then asserts gateway-b's MCP tools/list includes the a.-namespaced
+# upstream tools and a sample call dispatches without an error
+# envelope.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  federation-e2e:
+    name: Two-gateway federation smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Build images + boot two gateways
+        working-directory: tests/federation-e2e
+        run: |
+          docker compose build --pull
+          docker compose up -d --wait --wait-timeout 180
+
+      - name: Federation probe (tools/list + sample tools/call)
+        env:
+          B_BASE: http://localhost:13002
+        run: bash tests/federation-e2e/probe.sh
+
+      - name: Dump logs on failure
+        if: failure()
+        working-directory: tests/federation-e2e
+        run: |
+          docker compose logs --no-color --tail=200 gateway-a || true
+          docker compose logs --no-color --tail=200 gateway-b || true
+
+      - name: Tear down
+        if: always()
+        working-directory: tests/federation-e2e
+        run: docker compose down -v

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -782,14 +782,31 @@ async function main() {
   // Product-allow-list gate, so federated tools obey the same policy
   // surface as native ones.
   for (const info of federationRegistry.getNamespacedTools()) {
-    // Upstream's inputSchema is forwarded verbatim. The SDK's
-    // tool() overload signatures don't carry an obvious type for a
-    // dynamic-shape schema, so we cast to `any` at the boundary and
-    // let the upstream contract speak for the validation.
+    // The MCP SDK's tool() signature wants a ZodRawShape (a map of
+    // field-name → Zod type), not a raw JSON Schema. Federated
+    // upstreams expose JSON Schema (the wire-format MCP uses on
+    // tools/list); we transcode to a permissive Zod shape so the
+    // SDK accepts the registration. Per-field types are `z.unknown()`
+    // because the upstream will validate the call args anyway; the
+    // local Zod check is only a "this is the field name set" gate.
+    // P7: this transcoding fixes the registration crash that broke
+    // every federation deploy before the E2E test caught it.
+    const upstreamProps = (info.inputSchema as { properties?: Record<string, unknown> } | undefined)?.properties ?? {};
+    // Every field is z.unknown().optional() — the SDK only uses this
+    // shape to know the field-name set; the upstream re-validates
+    // against its full JSON Schema (incl. its own `required` list)
+    // when the call arrives. Marking all fields optional here keeps
+    // calls with the upstream-defaults flowing through; without it
+    // the SDK rejects any call that omits a field upstream considers
+    // required even if the upstream would accept the omission.
+    const localShape: Record<string, z.ZodOptional<z.ZodUnknown>> = {};
+    for (const k of Object.keys(upstreamProps)) {
+      localShape[k] = z.unknown().optional();
+    }
     (registerTool as unknown as (...args: unknown[]) => unknown)(
       info.namespacedName,
       info.description || `Federated from upstream ${info.sourceName}.`,
-      info.inputSchema ?? {},
+      localShape,
       async (args: unknown) => {
         await enforceEntitledAccess(ctx, { tool: info.namespacedName });
         return withToolMetrics(info.namespacedName, () =>

--- a/tests/federation-e2e/docker-compose.yml
+++ b/tests/federation-e2e/docker-compose.yml
@@ -1,0 +1,43 @@
+# Minimal two-gateway federation scenario for CI:
+#   gateway-a: vanilla mcp-server. No sources configured → built-in
+#              tools (list_sources, get_topology, generate_postmortem,
+#              etc.) are still registered.
+#   gateway-b: mcp-server with gateway-a wired in via
+#              OMCP_FEDERATION_UPSTREAMS. The federation registry
+#              proxies a's tools and namespaces them with the
+#              "a." prefix.
+#
+# CI then hits gateway-b's /mcp endpoint, asserts the namespaced
+# tools appear in tools/list, and calls one to assert dispatch
+# works end-to-end.
+
+services:
+  gateway-a:
+    build:
+      context: ../../mcp-server
+    environment:
+      - OMCP_AUTH=anonymous
+    ports:
+      - "13001:3000"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/healthz"]
+      interval: 3s
+      timeout: 2s
+      retries: 30
+
+  gateway-b:
+    build:
+      context: ../../mcp-server
+    environment:
+      - OMCP_AUTH=anonymous
+      - OMCP_FEDERATION_UPSTREAMS=a=http://gateway-a:3000/mcp
+    ports:
+      - "13002:3000"
+    depends_on:
+      gateway-a:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/healthz"]
+      interval: 3s
+      timeout: 2s
+      retries: 30

--- a/tests/federation-e2e/probe.sh
+++ b/tests/federation-e2e/probe.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Federation E2E probe: hit gateway-b's MCP endpoint, assert that
+# tools/list returns at least one tool with the upstream-a namespace
+# prefix, then call one and assert the response is well-formed.
+#
+# Both gateways must already be up (the workflow runs `docker compose
+# up --wait` before this script).
+
+set -uo pipefail
+
+B="${B_BASE:-http://localhost:13002}"
+
+echo "=== Probing federation against ${B}/mcp ==="
+
+# Initialise a session so we can include the mcp-session-id header
+# on subsequent requests.
+init=$(curl -sS -i -X POST "${B}/mcp" \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"fed-e2e","version":"0"}}}')
+session=$(printf '%s\n' "$init" | awk 'tolower($1)=="mcp-session-id:" {print $2}' | tr -d '\r\n')
+if [ -z "$session" ]; then
+  echo "FAIL: gateway-b did not return a session id from initialize" >&2
+  printf '%s\n' "$init" | head -40
+  exit 1
+fi
+echo "ok: session ${session}"
+
+# tools/list — federation should add a "a."-namespaced tool entry.
+tools=$(curl -sS -X POST "${B}/mcp" \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  -H "mcp-session-id: $session" \
+  --data '{"jsonrpc":"2.0","id":2,"method":"tools/list"}')
+echo "${tools}" | head -c 1200
+echo
+
+if ! echo "$tools" | grep -qE '"name"[[:space:]]*:[[:space:]]*"a\.'; then
+  echo "FAIL: gateway-b tools/list did not include any a.-namespaced upstream tool" >&2
+  exit 1
+fi
+echo "ok: at least one a.-namespaced tool appears in tools/list"
+
+# Pick a known-safe namespaced tool to call: list_services has the
+# smallest blast radius (read-only, no required args, works against
+# an empty sources config).
+call=$(curl -sS -X POST "${B}/mcp" \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  -H "mcp-session-id: $session" \
+  --data '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"a.list_sources","arguments":{}}}')
+echo "${call}" | head -c 800
+echo
+
+# We don't assert any specific payload — only that the call dispatched
+# successfully (no JSON-RPC error envelope at the top level).
+if echo "$call" | grep -q '"error"[[:space:]]*:[[:space:]]*{'; then
+  echo "FAIL: gateway-b returned JSON-RPC error envelope on tools/call" >&2
+  exit 1
+fi
+if echo "$call" | grep -q '"isError"[[:space:]]*:[[:space:]]*true'; then
+  echo "FAIL: gateway-b tools/call returned isError:true (federation dispatch crashed)" >&2
+  exit 1
+fi
+echo "ok: a.list_sources dispatched cleanly through federation"
+
+echo "=== federation E2E probe PASS ==="


### PR DESCRIPTION
## Summary
Federation shipped in v2.0 with **zero E2E coverage**. This adds a two-gateway docker-compose smoke test — and the smoke test immediately uncovered a production crash that's been silent since v2.0.

**The crash:** federation tool registration was passing a raw JSON Schema to the MCP SDK's \`tool()\`, which only accepts a Zod schema or ToolAnnotations. The gateway 500ed on the first MCP request whenever \`OMCP_FEDERATION_UPSTREAMS\` was set.

**The fix:** transcode the upstream's \`inputSchema.properties\` into a \`ZodRawShape\` where every field is \`z.unknown().optional()\`. The SDK uses the shape only to know the field-name set; the upstream re-validates with its full JSON Schema when the call arrives.

## What's in the PR
- \`mcp-server/src/index.ts\` — the transcoding fix.
- \`tests/federation-e2e/docker-compose.yml\` — minimal two-gateway compose (no demo deps).
- \`tests/federation-e2e/probe.sh\` — bash/curl probe: initialize → tools/list (asserts namespaced tool) → tools/call (asserts no error envelope, no isError).
- \`.github/workflows/federation-e2e.yml\` — runs the probe on every PR.

## Test plan
- [x] Local verified: pre-fix 500, post-fix returns the live sources list from gateway-a via federation dispatch.
- [x] mcp-server unit tests: 796/796 (no regression).
- [x] Reviewer-agent gate cleared.
- [ ] CI green (new \`federation-e2e\` job runs on this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)