### PR TITLE
feat(p9): ops visibility quick wins — DLQ surface + plugin-verify banner

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -87,7 +87,7 @@ import {
 } from "./connectors/hub.js";
 import { isValidConnectorName, installTarball } from "./connectors/install.js";
 import { PluginVerificationError } from "./connectors/verify.js";
-import { selfRegistry, withToolMetrics, apiRequests, mcpActiveSessions } from "./metrics/self.js";
+import { selfRegistry, withToolMetrics, apiRequests, mcpActiveSessions, auditDlqDepth } from "./metrics/self.js";
 import { initOtel } from "./observability/otel.js";
 import { WebSocketServerTransport } from "./transport/websocket.js";
 import { HookRegistry } from "./sdk/hooks.js";
@@ -1282,6 +1282,20 @@ async function main() {
   // this endpoint when enabled.
   if (process.env.METRICS_ENABLED !== "false") {
     app.get("/metrics", async (_req, res) => {
+      // P9: refresh the audit-webhook DLQ depth before the scrape so
+      // Prometheus sees the current file state rather than whatever
+      // /api/audit/dlq last set. Best-effort; ENOENT or missing-env
+      // resets to 0 (the dlqPath being unset is the normal state).
+      try {
+        const dlqPath = process.env.OMCP_AUDIT_WEBHOOK_DLQ;
+        if (dlqPath) {
+          const fs = await import("node:fs/promises");
+          const raw = await fs.readFile(dlqPath, "utf8").catch(() => "");
+          auditDlqDepth.set(raw.split("\n").filter((l) => l.trim()).length);
+        } else {
+          auditDlqDepth.set(0);
+        }
+      } catch { auditDlqDepth.set(0); }
       res.set("Content-Type", selfRegistry.contentType);
       res.end(await selfRegistry.metrics());
     });
@@ -1835,6 +1849,41 @@ async function main() {
       // so a cross-tenant admin sees an explicit "(all tenants)" hint.
       scopedTo: tenantFilter || (isAdmin ? null : callerTenant),
     });
+  });
+
+  // --- /api/audit/dlq — webhook-sink dead-letter queue surface (P9) ---
+  // When the audit webhook is configured AND the receiver exhausted
+  // its retry budget, entries land in the DLQ file. This endpoint
+  // surfaces the count + the last N entries so operators can decide
+  // whether to replay manually. Also refreshes the
+  // `obsmcp_audit_webhook_dlq_depth` gauge so the /metrics scrape
+  // alongside it stays accurate.
+  app.get("/api/audit/dlq", need("audit", "read"), async (_req, res) => {
+    const dlqPath = process.env.OMCP_AUDIT_WEBHOOK_DLQ;
+    if (!dlqPath) {
+      auditDlqDepth.set(0);
+      res.json({ enabled: false, path: null, depth: 0, entries: [] });
+      return;
+    }
+    try {
+      const fs = await import("node:fs/promises");
+      const raw = await fs.readFile(dlqPath, "utf8");
+      const lines = raw.split("\n").filter((l) => l.trim());
+      auditDlqDepth.set(lines.length);
+      const tail = lines.slice(-50).map((l) => {
+        try { return JSON.parse(l); } catch { return { _raw: l, _parseError: true }; }
+      });
+      res.json({ enabled: true, path: dlqPath, depth: lines.length, entries: tail });
+    } catch (err: unknown) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") {
+        auditDlqDepth.set(0);
+        res.json({ enabled: true, path: dlqPath, depth: 0, entries: [] });
+        return;
+      }
+      console.warn("[/api/audit/dlq] read failed:", err);
+      res.status(500).json({ error: (err as Error)?.message || "DLQ read failed" });
+    }
   });
 
   // --- /api/usage — per-identity MCP rate-limit snapshot -----------------

--- a/mcp-server/src/metrics/self.ts
+++ b/mcp-server/src/metrics/self.ts
@@ -54,6 +54,15 @@ export const mcpActiveSessions = new Gauge({
   registers: [selfRegistry],
 });
 
+// P9: Audit webhook dead-letter queue depth. Refreshed on each
+// `/metrics` scrape and when the operator hits `/api/audit/dlq`.
+// Stays at 0 when no DLQ file is configured or the file is missing.
+export const auditDlqDepth = new Gauge({
+  name: "obsmcp_audit_webhook_dlq_depth",
+  help: "Number of audit entries waiting in the webhook-sink dead-letter queue.",
+  registers: [selfRegistry],
+});
+
 /**
  * Wrap a (potentially async) tool handler to record call count + latency.
  * Outcome is "ok" or "error" — never throws on its own.

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -3725,10 +3725,21 @@ async function omcpCheckGovernance() {
     const info = await r.json();
     const g = info && info.governance;
     if (!g) return;
+    const warns = [];
     if (g.authMode === 'basic' && g.authSecretEphemeral) {
+      warns.push('OMCP_SESSION_SECRET is not set — every sign-in will be lost on server restart. Set a stable value in production.');
+    }
+    // P9: plugin signature verification is off — filesystem plugins
+    // load without integrity checks. Production deployments should
+    // turn this back on (VERIFY_PLUGINS=true is the default since
+    // F1, so seeing this banner means an operator opted OUT).
+    if (g.pluginsVerified === false) {
+      warns.push('Plugin signature verification is OFF (VERIFY_PLUGINS=false). Any filesystem plugin can load unchecked. Re-enable for production.');
+    }
+    if (warns.length > 0) {
       const bar = document.getElementById('omcp-warning-bar');
       if (bar) {
-        bar.textContent = '⚠ OMCP_SESSION_SECRET is not set — every sign-in will be lost on server restart. Set a stable value in production.';
+        bar.textContent = '⚠ ' + warns.join(' · ');
         bar.style.display = '';
       }
     }


### PR DESCRIPTION
## Summary
Closes the inventory's ops-visibility quick-wins bundle:

- **UI warning bar** now collects multiple posture issues into one line. New trigger: \`pluginsVerified === false\` ("Plugin signature verification is OFF — any filesystem plugin can load unchecked"). Existing \`authSecretEphemeral\` warning preserved.
- **\`GET /api/audit/dlq\`** webhook-sink dead-letter queue surface. Returns \`{enabled, path, depth, entries[]}\` (last 50). Handles missing-env, ENOENT, corrupt lines without 500ing.
- **\`obsmcp_audit_webhook_dlq_depth\` gauge** on \`selfRegistry\`. Refreshed before every \`/metrics\` scrape AND when the API route is hit.

Skipped from this bundle: Health-tab anomaly-history sparkline (P9b — too large for "quick wins").

## Test plan
- [x] 796/796 unit tests unchanged.
- [x] Build clean.
- [x] Reviewer-agent gate cleared.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)