### PR TITLE
docs(p10): flip mkdocs to --strict + fix all cross-repo link warnings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,11 +37,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install "mkdocs>=1.6,<2" "mkdocs-material>=9.5,<10" "pymdown-extensions>=10,<11"
       - name: Build site
-        # `mkdocs build` without --strict so cross-repo links (to
-        # ../CHANGELOG.md, ../enterprise/, etc.) that won't resolve
-        # in the published site are warnings, not failures. A
-        # follow-up cleans up those links so we can flip to strict.
-        run: mkdocs build
+        # P10: --strict is on. Every cross-repo link in docs/ must
+        # either point at another docs/ page or use a full GitHub
+        # URL. A regression that adds a broken link now fails CI
+        # immediately instead of shipping silently.
+        run: mkdocs build --strict
       - name: Merge Helm chart-releaser repo into site/
         # We switched Pages source from the gh-pages branch to a
         # workflow-driven deploy so MkDocs could serve from /. The

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -9,7 +9,7 @@ the README quickstart promises.
 
 - [The four layers, in dependency order](#the-four-layers-in-dependency-order)
 - [Minimal production-ready setup](#minimal-production-ready-setup)
-- [Roles & permissions](#roles--permissions)
+- [Roles & permissions](#roles-permissions)
 - [Audit log](#audit-log) — `/api/audit`, hash chain, offline verifier
 - [Rate limits](#rate-limits) — `/api/usage`, `X-RateLimit-*` headers
 - [Service catalog enrichment](#service-catalog-enrichment)
@@ -86,7 +86,7 @@ the file read-only.
 ## Roles & permissions
 
 The built-in policy ships three roles. The full table is in
-[`mcp-server/src/auth/rbac.ts`](../mcp-server/src/auth/rbac.ts); the
+[`mcp-server/src/auth/rbac.ts`](https://github.com/ThoTischner/observability-mcp/blob/main/mcp-server/src/auth/rbac.ts); the
 short version:
 
 | | viewer | operator | admin |
@@ -121,7 +121,7 @@ Every mutating `/api/*` request produces one append-only entry with
 actor + resource + action + status + IP + the optional `:name` path
 parameter as `target`. Entries are hash-chained: each entry's `hash`
 covers the previous entry's `hash`, so
-[`scripts/verify-audit.mjs`](../scripts/verify-audit.mjs) can prove
+[`scripts/verify-audit.mjs`](https://github.com/ThoTischner/observability-mcp/blob/main/scripts/verify-audit.mjs) can prove
 the log hasn't been silently truncated or reordered:
 
 ```bash
@@ -287,7 +287,7 @@ traffic yet, or the viewer lacks the `audit:read` permission.
 ## Service catalog enrichment
 
 When `OMCP_SERVICE_CATALOG_FILE` points at a JSON catalog (schema in
-[`mcp-server/src/catalog/loader.ts`](../mcp-server/src/catalog/loader.ts)),
+[`mcp-server/src/catalog/loader.ts`](https://github.com/ThoTischner/observability-mcp/blob/main/mcp-server/src/catalog/loader.ts)),
 every `list_services` / `get_service_health` / `query_metrics` derived
 response is decorated with `.catalog = { owner, tier, onCall, slo, … }`.
 The agent sees ownership context inline — no separate CMDB hop.

--- a/docs/anomaly-history.md
+++ b/docs/anomaly-history.md
@@ -1,7 +1,8 @@
 # Anomaly history (since v2.x / Phase F15)
 
 The gateway's deterministic anomaly detector (MAD + seasonality +
-correlator, see [`docs/analysis-engine.md`](analysis-engine.md))
+correlator — implemented in
+[`mcp-server/src/analysis/`](https://github.com/ThoTischner/observability-mcp/tree/main/mcp-server/src/analysis))
 produces scores live. By default those scores live in process memory
 only — restart the gateway and the trail is gone. F15 adds an
 opt-in **TSDB sink** that mirrors every score to a Prometheus

--- a/docs/auth-oidc.md
+++ b/docs/auth-oidc.md
@@ -29,7 +29,7 @@ make demo-oidc
 ```
 
 The realm export lives at
-[`examples/keycloak/omcp-demo-realm.json`](../examples/keycloak/omcp-demo-realm.json);
+[`examples/keycloak/omcp-demo-realm.json`](https://github.com/ThoTischner/observability-mcp/blob/main/examples/keycloak/omcp-demo-realm.json);
 its README documents the client / mappers / groups.
 
 ## When to use OIDC mode

--- a/docs/benchmark-astronomy-shop.md
+++ b/docs/benchmark-astronomy-shop.md
@@ -180,7 +180,7 @@ impossible.**
 
 Same harness, same model, same demo workload. Only the question and
 the tool set change. Raw JSON evidence under
-[`benchmark-results/`](benchmark-results/).
+[`benchmark-results/`](https://github.com/ThoTischner/observability-mcp/tree/main/docs/benchmark-results).
 
 | scenario                                  | model        | n  | baseline acc | topology acc | tokens (B → T) | meaningful winner |
 |-------------------------------------------|--------------|----|--------------|--------------|---------------|-------------------|
@@ -328,7 +328,7 @@ orchestrates both stacks: ours brings up Tempo + an OTel collector
 bridge under `--profile benchmark`; upstream runs in its own compose
 project (`-p otel-demo`) with `OTEL_COLLECTOR_HOST` repointed at our
 bridge so traces land in our Tempo. See
-[examples/benchmark/README.md](../examples/benchmark/README.md) for the
+[examples/benchmark/README.md](https://github.com/ThoTischner/observability-mcp/blob/main/examples/benchmark/README.md) for the
 exact commands and caveats.
 
 ### Why this split

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -83,7 +83,7 @@ same doc shows scenarios where topology tools cost more without helping.
 ## Sources
 
 [^omcp-license]: `LICENSE` in this repo.
-[^omcp-readme]: [`README.md`](../README.md) in this repo.
+[^omcp-readme]: [`README.md`](https://github.com/ThoTischner/observability-mcp/blob/main/README.md) in this repo.
 [^omcp-topo]: [`docs/topology-vocabulary.md`](topology-vocabulary.md) — the canonical `kind`/`relation` contract.
 [^omcp-bench]: [`docs/benchmark-astronomy-shop.md`](benchmark-astronomy-shop.md) — methodology + raw JSON in `docs/benchmark-results/`.
 [^dd-pricing]: <https://www.datadoghq.com/pricing/>

--- a/docs/enterprise-gate.md
+++ b/docs/enterprise-gate.md
@@ -7,7 +7,7 @@ explicitly opts in.
 
 The seam itself (`mcp-server/src/enterprise-gate.ts`) is Apache-2.0 and
 ships in the published package. The modules it enforces live under
-[`enterprise/`](../enterprise/README.md) and are licensed
+[`enterprise/`](https://github.com/ThoTischner/observability-mcp/blob/main/enterprise/README.md) and are licensed
 `FSL-1.1-Apache-2.0`. Because they sit outside `mcp-server/`, they are
 **not** in the npm package or the Docker image — activating the gate
 requires running from a full source checkout that still contains
@@ -82,15 +82,15 @@ curl -s localhost:3000/api/info | jq .enterpriseGate
 ## Policy and catalog
 
 Working examples live in
-[`enterprise/examples/`](../enterprise/examples) and are exercised by
+[`enterprise/examples/`](https://github.com/ThoTischner/observability-mcp/tree/main/enterprise/examples) and are exercised by
 the test suite, so they stay correct:
 
-- [`rbac-policy.json`](../enterprise/examples/rbac-policy.json) — roles
+- [`rbac-policy.json`](https://github.com/ThoTischner/observability-mcp/blob/main/enterprise/examples/rbac-policy.json) — roles
   map principals (the API-key identity, e.g. `key:platform-bot`) to
   allow-lists over `tools` / `sources` / `services`; `"*"` is a
   wildcard, `readOnly` blocks mutating tools, `defaultRoles` applies to
   unbound principals (empty ⇒ default-deny).
-- [`catalog.json`](../enterprise/examples/catalog.json) — named
+- [`catalog.json`](https://github.com/ThoTischner/observability-mcp/blob/main/enterprise/examples/catalog.json) — named
   **products** bundle `sources`/`services`; **grants** map principals to
   products. RBAC answers *which verbs*; the catalog answers *which
   resource bundle*. A request must pass **both**.

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -117,7 +117,7 @@ applies a workload that puts the three chaos-able example services
 Deployments — that is what lets an agent correlate a metric or log
 anomaly with its underlying host. See
 [`docs/configuration.md`](configuration.md) and
-[`CLAUDE.md`](../CLAUDE.md) for the demo plumbing.
+[`CLAUDE.md`](https://github.com/ThoTischner/observability-mcp/blob/main/CLAUDE.md) for the demo plumbing.
 
 ## Caveats
 

--- a/docs/mcp-conformance.md
+++ b/docs/mcp-conformance.md
@@ -10,7 +10,7 @@ upholds the MCP 2025-11-25 wire contract. The same suite runs:
 ## What's covered
 
 The harness file
-[`mcp-server/src/conformance/mcp-2025-11-25.test.ts`](../mcp-server/src/conformance/mcp-2025-11-25.test.ts)
+[`mcp-server/src/conformance/mcp-2025-11-25.test.ts`](https://github.com/ThoTischner/observability-mcp/blob/main/mcp-server/src/conformance/mcp-2025-11-25.test.ts)
 exercises:
 
 | Method / requirement | Assertion |

--- a/docs/migrations/1.x-to-2.0.md
+++ b/docs/migrations/1.x-to-2.0.md
@@ -64,7 +64,7 @@ see no behaviour change.
 | `redis.enabled=true` + `redis.url` | Multi-replica HA via shared session store | [horizontal-scaling.md](../horizontal-scaling.md) |
 | `OMCP_OTEL_ENABLED=true` + `OMCP_OTEL_ENDPOINT` | OpenTelemetry self-tracing | [self-observability.md](../self-observability.md) |
 | `OMCP_AUDIT_WEBHOOK_URL` + `OMCP_AUDIT_WEBHOOK_TOKEN` | External SIEM webhook sink | [audit-sinks.md](../audit-sinks.md) |
-| `OMCP_OIDC_PROFILE=<vendor>` | SSO vendor presets | [auth-oidc-providers/](../auth-oidc-providers/) |
+| `OMCP_OIDC_PROFILE=<vendor>` | SSO vendor presets | [auth-oidc.md](../auth-oidc.md) |
 | `OMCP_OIDC_DCR_ENABLED=true` | RFC 7591 Dynamic Client Registration | – |
 | `ingressSticky.enabled=true` | Sticky-session ingress fallback | [horizontal-scaling.md](../horizontal-scaling.md) |
 | `OMCP_CSRF_BYPASS_BEARER=false` | Force CSRF on every mutating call regardless of auth method | [hardening.md](../hardening.md) |
@@ -124,7 +124,7 @@ relied on them.
 ## After the upgrade
 
 The capabilities scoped to v2.x incremental follow-ups are listed
-in [CHANGELOG.md](../../CHANGELOG.md) under the "Deferred to v2.x
-(incremental)" section. Track [ROADMAP.md](../../ROADMAP.md) for
+in [CHANGELOG.md](https://github.com/ThoTischner/observability-mcp/blob/main/CHANGELOG.md) under the "Deferred to v2.x
+(incremental)" section. Track [ROADMAP.md](https://github.com/ThoTischner/observability-mcp/blob/main/ROADMAP.md) for
 the v3.0 work (multi-cloud topology, anomaly history, SCIM
 provisioning, MkDocs site, …).

--- a/docs/migrations/2.x-to-3.0.md
+++ b/docs/migrations/2.x-to-3.0.md
@@ -106,7 +106,7 @@ new `scim.json`) are forward-compatible — a 2.x server reading a
 ## After the upgrade
 
 The v3.x incremental follow-ups live in
-[CHANGELOG.md](../../CHANGELOG.md) under "Deferred to v3.x
+[CHANGELOG.md](https://github.com/ThoTischner/observability-mcp/blob/main/CHANGELOG.md) under "Deferred to v3.x
 (incremental)". The next planned major (v4.x) is up for grabs —
 [Issue tracker](https://github.com/ThoTischner/observability-mcp/issues)
 and [Discussions](https://github.com/ThoTischner/observability-mcp/discussions)

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -154,7 +154,7 @@ The operator distributes only the **public** key as `PLUGIN_TRUST_ROOT`. The Hel
 
 ## The connector hub
 
-The catalog contract lives in-repo at [`hub/`](../hub/README.md): a
+The catalog contract lives in-repo at [`hub/`](https://github.com/ThoTischner/observability-mcp/blob/main/hub/README.md): a
 schema-validated `catalog/<name>.json` per connector aggregated into a
 static `catalog/index.json` (CI keeps it in sync). It is **live** today:
 

--- a/docs/policy-engines.md
+++ b/docs/policy-engines.md
@@ -130,7 +130,7 @@ make demo-opa
 #                                so you can run both side by side)
 ```
 
-The example Rego at [`examples/opa/policy.rego`](../examples/opa/policy.rego)
+The example Rego at [`examples/opa/policy.rego`](https://github.com/ThoTischner/observability-mcp/blob/main/examples/opa/policy.rego)
 reproduces the built-in DEFAULT_POLICY exactly so you can swap engines
 without losing access.
 

--- a/docs/topology-providers.md
+++ b/docs/topology-providers.md
@@ -28,7 +28,7 @@ This page describes:
 
 Reserved kind/relation vocabulary for the multi-cloud providers is
 documented in [`topology-vocabulary.md`](topology-vocabulary.md). The
-merger logic lives in [`mcp-server/src/topology/merge.ts`](../mcp-server/src/topology/merge.ts) — covered by 11 unit tests in F14.
+merger logic lives in [`mcp-server/src/topology/merge.ts`](https://github.com/ThoTischner/observability-mcp/blob/main/mcp-server/src/topology/merge.ts) — covered by 11 unit tests in F14.
 
 ## How the merger collapses cross-provider duplicates
 


### PR DESCRIPTION
## Summary
F17 shipped \`mkdocs build\` (non-strict) so 17 cross-repo link warnings shipped silently. P10 fixes every warning and enforces the gate at PR time.

- All \`../<repo-rel-path>\` links → absolute \`https://github.com/.../blob/main/<path>\` URLs. Works from BOTH the Pages site AND github.com.
- \`docs/anomaly-history.md\` — removed dead link to non-existent \`analysis-engine.md\`.
- \`docs/access-control.md\` — fixed \`#roles--permissions\` anchor.
- \`docs/migrations/1.x-to-2.0.md\` — SSO row links to \`auth-oidc.md\` (real).
- \`.github/workflows/docs.yml\` — \`mkdocs build\` → \`mkdocs build --strict\`.

\`mkdocs build --strict\` succeeds locally with **0 warnings + 0 errors**.

## Test plan
- [x] strict build verified locally.
- [x] Reviewer-agent gate cleared.
- [ ] CI green (docs job now runs in strict mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)