### PR TITLE
bench(2026-06-06): post-P10 N=3 result + lessons

### DIFF
--- a/docs/benchmark-results/2026-06-06-post-p10-llama3.1-8b-baseline-n3.json
+++ b/docs/benchmark-results/2026-06-06-post-p10-llama3.1-8b-baseline-n3.json
@@ -1,0 +1,44 @@
+{
+  "mode": "baseline",
+  "model": "llama3.1:8b",
+  "iterations": 3,
+  "tools": [
+    "list_sources",
+    "list_services",
+    "query_metrics",
+    "query_logs",
+    "get_service_health",
+    "detect_anomalies"
+  ],
+  "totals": {
+    "tokens": 8964,
+    "meanTokensPerIteration": 2988,
+    "correctIterations": 1,
+    "accuracy": 0.3333333333333333,
+    "meanRounds": 1.33,
+    "meanDurationMs": 21894
+  },
+  "iterations_detail": [
+    {
+      "tokens": 2635,
+      "rounds": 1,
+      "correct": false,
+      "durationMs": 29936,
+      "finalAnswer": "Based on the output, it appears that there are no anomalies detected in any of the scanned services. Let me try again with a different approach.\n\n{\"name\": \"detect_anomalies\", \"parameters\": {\"duration\":\"10m\",\"sensitivity\":\"high\"}}"
+    },
+    {
+      "tokens": 2824,
+      "rounds": 1,
+      "correct": false,
+      "durationMs": 25348,
+      "finalAnswer": "The underlying root-cause service is the \"checkout-service\" and the failing signal is a high error rate. The checkout-service has been experiencing intermittent failures, with an error rate of 0% over the past 5 minutes, indicating that the issue may be transient or related to external factors."
+    },
+    {
+      "tokens": 3505,
+      "rounds": 2,
+      "correct": true,
+      "durationMs": 10398,
+      "finalAnswer": "The underlying root-cause service is the \"payment-service\" and the failing signal is an intermittent error in the checkout process, likely due to a high error rate."
+    }
+  ]
+}

--- a/docs/benchmark-results/2026-06-06-post-p10-llama3.1-8b-topology-n3.json
+++ b/docs/benchmark-results/2026-06-06-post-p10-llama3.1-8b-topology-n3.json
@@ -1,0 +1,46 @@
+{
+  "mode": "topology",
+  "model": "llama3.1:8b",
+  "iterations": 3,
+  "tools": [
+    "list_sources",
+    "list_services",
+    "query_metrics",
+    "query_logs",
+    "get_service_health",
+    "detect_anomalies",
+    "get_topology",
+    "get_blast_radius"
+  ],
+  "totals": {
+    "tokens": 18287,
+    "meanTokensPerIteration": 6096,
+    "correctIterations": 0,
+    "accuracy": 0,
+    "meanRounds": 1,
+    "meanDurationMs": 6834
+  },
+  "iterations_detail": [
+    {
+      "tokens": 2905,
+      "rounds": 0,
+      "correct": false,
+      "durationMs": 1791,
+      "finalAnswer": "To identify the underlying root-cause service and the failing signal, I will first call `detect_anomalies` to scan all monitored services for abnormal behavior.\n\n{\"name\": \"detect_anomalies\", \"parameters\": {\"duration\": \"10m\", \"sensitivity\": \"medium\"}}"
+    },
+    {
+      "tokens": 12441,
+      "rounds": 3,
+      "correct": false,
+      "durationMs": 16406,
+      "finalAnswer": "This is a JSON output from a Kubernetes API call, specifically the `api/v1/resources` endpoint. It provides information about the resources in the cluster, including nodes, pods, deployments, and services.\n\nHere's a breakdown of the main sections:\n\n**Nodes**\n\n* The first section lists 4 nodes in the cluster:\n\t+ `f90e4c51ae04`: Node with IP address `10.0.2.15`\n\t+ `8fc45abc92f`: Node with IP address `10.0.2.16`\n\t+ `b7da6e2c58aa`: Node with IP address `10.0.2.17`\n\t+ `node-1`: Node with IP address `10.0.2.18`\n\n**Pods**\n\n* The next section lists 8 pods in the cluster:\n\t+ `omcp-demo/api-gateway-5cc9"
+    },
+    {
+      "tokens": 2941,
+      "rounds": 0,
+      "correct": false,
+      "durationMs": 2304,
+      "finalAnswer": "To identify the underlying root-cause service and the failing signal, I will first call `detect_anomalies` to scan all monitored services for abnormal behavior.\n\n{\"name\": \"detect_anomalies\", \"parameters\": {\"duration\": \"10m\", \"sensitivity\": \"medium\"}} \n\nOnce I have the list of anomalies, I will use `get_service_health` to get a single aggregated health verdict for each affected service and identify the root-cause service."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
First bench after the production-readiness sprint. Noisy at N=3 — committing the JSON for the audit trail.

| | Mode | Accuracy | Mean tokens | Mean rounds |
|---|---|---|---|---|
| llama3.1:8b | baseline | **1/3 (33%)** | 2988 | 1.33 |
| llama3.1:8b | topology | **0/3 (0%)** | 6096 | 1.00 |

## What this is + isn't
**Not a sprint regression.** Federation E2E (P7) + unit suite (796/796) both green. The MCP gateway dispatched correctly — observed via per-iteration tool-call rounds + tokens.

**Model behaviour regression.** llama3.1:8b emitted fenced JSON tool calls as TEXT inside its final answer in 2/3 topology iterations (rounds=0 — model never called a tool, just hallucinated the call). Compared to the May runs where the same model+scenario scored 100%/100%, this looks like an Ollama / model-quant version drift.

## Next bench
A real comparison needs N≥10 and ideally a fresh Ollama pull. Auto-merge OFF on this PR — it's archive/audit only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)