### PR TITLE
fix(license): chart README + presentation footer say Apache-2.0

### DIFF
--- a/docs/presentation.html
+++ b/docs/presentation.html
@@ -547,7 +547,7 @@ docker-compose up</code></pre>
         Star ⭐ helps others discover the project.
       </p>
       <p style="margin-top:48px;font-size:0.6em;" class="muted">
-        Apache 2026 — MIT License — Built with TypeScript, Node 20, MCP SDK 1.12+
+        Apache 2026 — Apache-2.0 License — Built with TypeScript, Node 20, MCP SDK 1.12+
       </p>
     </section>
 

--- a/helm/observability-mcp/README.md
+++ b/helm/observability-mcp/README.md
@@ -91,4 +91,5 @@ Major-version bumps of the chart will be documented in the CHANGELOG.
 
 ## License
 
-MIT — same as the upstream project.
+Apache-2.0 — same as the upstream project. See
+[LICENSE](https://github.com/ThoTischner/observability-mcp/blob/main/LICENSE).


### PR DESCRIPTION
## Summary
ArtifactHub renders \`helm/observability-mcp/README.md\` alongside the chart card. The "## License" section claimed MIT but the project flipped to Apache-2.0 — every other surface (LICENSE file, top-level package.json metadata, Chart.yaml \`artifacthub.io/license: Apache-2.0\`) already agrees. Two fixes here:

- \`helm/observability-mcp/README.md\` — License section "MIT" → "Apache-2.0" with link to LICENSE.
- \`docs/presentation.html\` — footer footer "MIT License" → "Apache-2.0 License".

Connectors under \`connectors/*\` keep their MIT declarations — independent npm packages, separate decision (would also need integrity-hash + catalog rebuild if changed).

## Test plan
- [x] Reviewer-eyeball: no other MIT claims for the gateway proper.
- [ ] CI green.
- [ ] After merge: helm-release republishes the chart → ArtifactHub picks up the README change on its next 30min crawl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)