### PR TITLE
fix(helm): point artifacthub image annotation at current 3.0.0

### DIFF
--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,7 +4,7 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 2.0.0
+version: 2.0.1
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
@@ -51,11 +51,13 @@ annotations:
     url: https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc
   artifacthub.io/images: |
     - name: observability-mcp
-      image: ghcr.io/thotischner/observability-mcp:1.8.1
+      image: ghcr.io/thotischner/observability-mcp:3.0.0
       platforms:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
+    - kind: fixed
+      description: artifacthub.io/images now points at the current 3.0.0 image (was stale at 1.8.1, causing ArtifactHub to scan an old image with 4 medium-severity findings — the 3.0.0 image scans clean)
     - kind: added
       description: plugins.persistence — back /app/plugins with a PVC so connectors installed at runtime (Web UI / bundle upload / omcp) survive pod restarts
     - kind: added


### PR DESCRIPTION
## Summary
ArtifactHub's card shows **4 medium** security findings against the chart. Investigation:

- Trivy scan of \`ghcr.io/thotischner/observability-mcp:latest\` (3.0.0): **0 CRITICAL / 0 HIGH / 0 MEDIUM**.
- \`npm audit\` on \`mcp-server\`: 0 vulnerabilities.
- GitHub Dependabot open alerts: 0.
- BUT \`helm/observability-mcp/Chart.yaml:54\` hardcodes \`artifacthub.io/images: ghcr.io/thotischner/observability-mcp:**1.8.1**\`. That's the stale image ArtifactHub keeps scanning.

Fix the annotation to point at the current \`3.0.0\` and bump the chart to \`2.0.1\` so chart-releaser actually republishes (it uses \`skip_existing: true\`).

ArtifactHub re-crawls ~every 30 minutes; the next crawl will scan the current image and the summary should flip to 0/0/0/0/0.

The 4 medium findings the user mentioned — and the "hono medium" hint — are accurate as state of the OLD 1.8.1 image. They don't exist in the current 3.0.0 build.

## Test plan
- [x] \`helm lint\` clean.
- [x] Trivy current-image scan: 0/0/0.
- [ ] CI green.
- [ ] After merge: helm-release republishes 2.0.1; ArtifactHub re-crawls within ~30min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)