### PR TITLE
fix(security): close 9 CodeQL findings (real, not false-positives)

### DIFF
--- a/enterprise/entitlement/entitlement.mjs
+++ b/enterprise/entitlement/entitlement.mjs
@@ -29,7 +29,10 @@ export function canonical(value) {
 }
 
 const b64url = (buf) =>
-  Buffer.from(buf).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  // `={1,4}$` instead of `=+$` so the engine doesn't backtrack on
+  // attacker-controlled strings with many `=` chars (CodeQL
+  // js/polynomial-redos). base64 padding is at most 4 chars anyway.
+  Buffer.from(buf).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/={1,4}$/, "");
 
 function b64urlDecode(str) {
   const pad = str.length % 4 === 0 ? "" : "=".repeat(4 - (str.length % 4));

--- a/mcp-server/src/auth/policy/batch-dry-run.ts
+++ b/mcp-server/src/auth/policy/batch-dry-run.ts
@@ -120,14 +120,28 @@ export async function evaluateBatch(
     actions.length = limits.maxActions;
   }
 
+  // Reject keys that could mutate Object.prototype if injected from
+  // user input — `__proto__`, `constructor`, `prototype`. CodeQL
+  // js/prototype-polluting-assignment + js/remote-property-injection.
+  const DANGEROUS = new Set(["__proto__", "constructor", "prototype"]);
+  const isSafeKey = (k: string): boolean => !DANGEROUS.has(k);
+
+  // Plain object so JSON round-trip + deep-equal in tests keeps
+  // working; the DANGEROUS guard below is the actual protection.
   const matrix: BatchDryRunResult["matrix"] = {};
   let allowCount = 0;
   let denyCount = 0;
   for (const s of subjects) {
+    if (!isSafeKey(s.key)) {
+      dropped.push({ kind: "subject", value: s.key, reason: "reserved key name" });
+      continue;
+    }
     matrix[s.key] = {};
     for (const r of resources) {
+      if (!isSafeKey(String(r))) continue;
       matrix[s.key][r] = {};
       for (const a of actions) {
+        if (!isSafeKey(String(a))) continue;
         const verdict = await Promise.resolve(
           engine.evaluate(
             s.roles,

--- a/mcp-server/src/policy/redact.ts
+++ b/mcp-server/src/policy/redact.ts
@@ -51,7 +51,7 @@ const PATTERNS: Array<{ category: RedactionCategory; re: RegExp }> = [
   // - PEM private-key blocks: greedy match across newlines.
   { category: "aws-key", re: /\b(?:AKIA|ASIA|AROA)[0-9A-Z]{16,20}\b/g },
   { category: "slack-token", re: /\bxox[abprsu]-[A-Za-z0-9-]{10,}\b/g },
-  { category: "gh-pat", re: /\b(?:github_pat_[A-Za-z0-9_]{40,}|gh[opsuru]_[A-Za-z0-9]{36})\b/g },
+  { category: "gh-pat", re: /\b(?:github_pat_[A-Za-z0-9_]{40,}|gh[oprsu]_[A-Za-z0-9]{36})\b/g },
   { category: "private-key", re: /-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY-----/g },
 
   // emails before other patterns so they don't get eaten partially

--- a/mcp-server/src/scim/routes.ts
+++ b/mcp-server/src/scim/routes.ts
@@ -41,7 +41,11 @@ export interface ScimRoutesDeps {
 
 const constantTimeBearerMatch = (raw: string | undefined, expected: string): boolean => {
   if (!raw) return false;
-  const m = raw.match(/^Bearer\s+(.+)$/i);
+  // Use bounded whitespace ({1,16}) instead of `\s+` to avoid the
+  // polynomial-ReDoS class — `\s+` followed by `(.+)` backtracks on
+  // strings like "bearer<many spaces><payload>". 16 is generous;
+  // RFC 7235 only requires one space.
+  const m = raw.match(/^Bearer[ \t]{1,16}(.+)$/i);
   if (!m) return false;
   const a = Buffer.from(m[1].trim());
   const b = Buffer.from(expected);
@@ -240,6 +244,30 @@ function withGroups(u: ScimUser, store: ScimStore): ScimUser {
  *  `remove` for members/emails arrays are a follow-up — the
  *  Entra/Okta provisioning checklists exercise replace-only on the
  *  attributes we expose. */
+// Allow-list of attribute names patchable via SCIM PatchOp.
+// `applyPatchOps` writes into a plain object using a user-supplied
+// path/key — every key is gated through this set so a malicious
+// client can't inject __proto__ / constructor / arbitrary fields.
+const PATCH_ALLOWED_ATTRS: ReadonlySet<string> = new Set([
+  "userName", "active", "displayName", "name", "emails", "externalId",
+  "members", "groups",
+]);
+
+function safePatchKey(k: unknown): k is string {
+  return typeof k === "string" && PATCH_ALLOWED_ATTRS.has(k);
+}
+
+/** Translate a SCIM PatchOp into a partial resource patch. Minimal:
+ *  we accept `op: "replace"` with no path (whole-resource merge) or
+ *  with a single-segment path naming a top-level attribute. `add` and
+ *  `remove` for members/emails arrays are a follow-up — the
+ *  Entra/Okta provisioning checklists exercise replace-only on the
+ *  attributes we expose.
+ *
+ *  Every property name written into `out` is gated through
+ *  `PATCH_ALLOWED_ATTRS` so a SCIM client can't inject __proto__ /
+ *  constructor / arbitrary fields (CodeQL js/remote-property-injection +
+ *  js/prototype-polluting-assignment). */
 function applyPatchOps<T extends { id: string }>(current: T | undefined, patch: ScimPatchRequest): Partial<T> {
   if (!current) throw new ScimNotFoundError("target resource not found");
   if (!patch?.Operations || !Array.isArray(patch.Operations)) return {};
@@ -247,13 +275,14 @@ function applyPatchOps<T extends { id: string }>(current: T | undefined, patch: 
   for (const op of patch.Operations) {
     if (op.op !== "replace") continue; // skip add/remove for F21a
     if (!op.path) {
-      // value is a partial object — merge top-level keys
       if (op.value && typeof op.value === "object") {
-        Object.assign(out, op.value);
+        for (const [k, v] of Object.entries(op.value as Record<string, unknown>)) {
+          if (safePatchKey(k)) out[k] = v;
+        }
       }
       continue;
     }
-    out[op.path] = op.value;
+    if (safePatchKey(op.path)) out[op.path] = op.value;
   }
   return out as Partial<T>;
 }

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -6317,7 +6317,10 @@ function renderTopologyGraph(){
     const r = idx.byId.get(id);
     const base = topoKindColor(r ? r.kind : 'scope');
     // soft alpha + slightly lighter
-    return base.replace(/^#/, '#') + '22'; // append alpha (works because we use hex)
+    // `base` already starts with `#` from topoKindColor; just append
+    // a 1-byte alpha to get an 8-digit hex CSS colour. The dead
+    // `.replace(/^#/, '#')` step from an earlier refactor is gone.
+    return base + '22';
   };
   const scopeBands = [];
   for (const scopeId of pureScope){


### PR DESCRIPTION
## Summary
9 genuine CodeQL findings fixed. The remaining ~30 alerts are OpenSSF-Scorecard items (workflow + Dockerfile dependency pinning, token-permission scoping) that need a separate sweep.

| Rule | Path | Fix |
|---|---|---|
| \`js/regex/duplicate-in-character-class\` | redact.ts:54 | \`gh[opsuru]\` → \`gh[oprsu]\` (duplicate \`u\`) |
| \`js/polynomial-redos\` | scim/routes.ts:44 | Bearer regex \`\s+\` → \`[ \t]{1,16}\` |
| \`js/remote-property-injection\` × 1 | scim/routes.ts:256 | \`PATCH_ALLOWED_ATTRS\` allow-list via \`safePatchKey()\` |
| \`js/remote-property-injection\` × 3 | batch-dry-run.ts:127,129,139 | \`DANGEROUS\` set + \`isSafeKey()\` |
| \`js/prototype-polluting-assignment\` × 2 | batch-dry-run.ts:129,139 | Same DANGEROUS guard |
| \`js/identity-replacement\` | ui/index.html:6320 | Dead \`.replace(/^#/,'#')\` removed |
| \`js/polynomial-redos\` | entitlement.mjs:32 | \`=+$\` → \`={1,4}$\` (base64 padding ≤4) |

## Test plan
- [x] Unit tests: 786/786.
- [x] Build clean.
- [x] Reviewer-agent gate cleared.
- [ ] CI green.

## After merge
Next CodeQL scan should drop ~9 alerts. Remaining ~30 (Scorecard pinning + permissions) is a separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)