### PR TITLE
feat(q2): Istio topology connector (CALLS from istio_requests_total)

### DIFF
--- a/connectors/istio/index.js
+++ b/connectors/istio/index.js
@@ -1,0 +1,244 @@
+// Istio topology connector for observability-mcp.
+//
+// Derives a service-graph from Istio's telemetry-v2 Prometheus metric
+// `istio_requests_total` — one CALLS edge per observed
+// (source_workload, destination_workload) pair, normalised over the
+// chosen lookback window. Edge confidence reflects the request volume
+// share so a chatty noisy edge ranks above a rare one.
+//
+// Why Prometheus and not the Istio control-plane API? Two reasons:
+//   1. Istio's own istiod doesn't expose a "give me the runtime graph"
+//      endpoint — Kiali talks to the same Prometheus we do.
+//   2. Every Istio install already ships a Prometheus scrape config; we
+//      reuse what the operator already has rather than asking for a
+//      new privileged credential.
+//
+// Auth: optional Bearer token (when the operator fronts Prometheus
+// with an auth proxy). Standard HTTP via node-builtin fetch.
+
+const TOPOLOGY_TTL_MS = 30_000;
+const DEFAULT_LOOKBACK = "5m";
+
+// Stable resource ids. We scope by namespace + workload so two
+// workloads named "checkout" in different namespaces don't collide.
+function serviceId(namespace, name) {
+  return `istio:service:${namespace || "global"}/${name}`;
+}
+
+export class IstioConnector {
+  constructor() {
+    this.type = "istio";
+    this.signalType = "topology";
+    this.name = "istio";
+    this._base = "";
+    this._token = "";
+    this._lookback = DEFAULT_LOOKBACK;
+    this._snapshot = null;
+    this._snapshotExpiresAt = 0;
+    this._watchers = new Set();
+    this._watchTimer = null;
+    this._buildRevision = 0;
+    this._fetch = globalThis.fetch;
+  }
+
+  async connect(config) {
+    this.name = config.name || "istio";
+    if (!config.url) throw new Error("istio connector: url is required (Prometheus base URL)");
+    this._base = String(config.url).replace(/\/+$/, "");
+    // Auth: source token (from sources.yaml `auth.token`) wins over
+    // ISTIO_PROM_TOKEN env. Operators wiring through a sealed-secret
+    // typically use the env path.
+    this._token =
+      config.auth?.token ||
+      config.token ||
+      process.env.ISTIO_PROM_TOKEN ||
+      "";
+    this._lookback = config.lookback || DEFAULT_LOOKBACK;
+    // Test path: inject a custom fetch.
+    if (config._fetch) this._fetch = config._fetch;
+  }
+
+  async healthCheck() {
+    const t0 = Date.now();
+    try {
+      const u = new URL(`${this._base}/api/v1/query`);
+      u.searchParams.set("query", "up");
+      const res = await this._fetch(u, { headers: this._headers() });
+      if (!res.ok) {
+        return { status: "down", latencyMs: Date.now() - t0, message: `prom HTTP ${res.status}` };
+      }
+      return { status: "up", latencyMs: Date.now() - t0 };
+    } catch (err) {
+      return {
+        status: "down",
+        latencyMs: Date.now() - t0,
+        message: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  async disconnect() {
+    if (this._watchTimer) {
+      clearInterval(this._watchTimer);
+      this._watchTimer = null;
+    }
+    this._watchers.clear();
+    this._snapshot = null;
+  }
+
+  getDefaultMetrics() { return []; }
+  getMetrics() { return []; }
+
+  async listServices() {
+    const snap = await this._refreshIfStale();
+    return snap.resources
+      .filter((r) => r.kind === "service_mesh_service")
+      .map((r) => ({ name: r.name, source: this.name, signals: ["topology"] }));
+  }
+
+  async listResources() {
+    return (await this._refreshIfStale()).resources;
+  }
+
+  async listEdges() {
+    return (await this._refreshIfStale()).edges;
+  }
+
+  async getTopologySnapshot() {
+    return this._refreshIfStale();
+  }
+
+  watchTopology(listener) {
+    this._watchers.add(listener);
+    queueMicrotask(async () => {
+      try {
+        const snap = await this._refreshIfStale();
+        listener({ type: "resync", snapshot: snap });
+      } catch { /* swallow */ }
+    });
+    if (!this._watchTimer) {
+      this._watchTimer = setInterval(async () => {
+        let snap;
+        try { snap = await this._buildSnapshot(); } catch { return; }
+        this._snapshot = snap;
+        this._snapshotExpiresAt = Date.now() + TOPOLOGY_TTL_MS;
+        for (const l of this._watchers) {
+          try { l({ type: "resync", snapshot: snap }); } catch { /* skip */ }
+        }
+      }, TOPOLOGY_TTL_MS);
+      if (this._watchTimer && typeof this._watchTimer.unref === "function") {
+        this._watchTimer.unref();
+      }
+    }
+    return () => {
+      this._watchers.delete(listener);
+      if (this._watchers.size === 0 && this._watchTimer) {
+        clearInterval(this._watchTimer);
+        this._watchTimer = null;
+      }
+    };
+  }
+
+  // --- internals ------------------------------------------------------
+
+  _headers() {
+    const h = { Accept: "application/json" };
+    if (this._token) h.Authorization = `Bearer ${this._token}`;
+    return h;
+  }
+
+  async _refreshIfStale() {
+    const now = Date.now();
+    if (this._snapshot && now < this._snapshotExpiresAt) return this._snapshot;
+    const snap = await this._buildSnapshot();
+    this._snapshot = snap;
+    this._snapshotExpiresAt = now + TOPOLOGY_TTL_MS;
+    return snap;
+  }
+
+  async _buildSnapshot() {
+    // Aggregate istio_requests_total over the lookback. Group by the
+    // (source_workload, source_workload_namespace, destination_workload,
+    // destination_workload_namespace) tuple; sum the counter increment
+    // over the window so the resulting value is "requests in window".
+    const lookback = this._lookback;
+    const query = `sum by (source_workload, source_workload_namespace, destination_workload, destination_workload_namespace) (increase(istio_requests_total[${lookback}]))`;
+    const u = new URL(`${this._base}/api/v1/query`);
+    u.searchParams.set("query", query);
+    const res = await this._fetch(u, { headers: this._headers() });
+    if (!res.ok) throw new Error(`istio prom query HTTP ${res.status}`);
+    const body = await res.json();
+    const samples = body?.data?.result || [];
+
+    // Build a service-name → resource map (namespace + name uniquely
+    // identify a workload). canonicalName goes onto the resource so
+    // mergeTopologies collapses the same name from k8s + tempo + the
+    // service-mesh.
+    const services = new Map();
+    const self = this;
+    const ensure = (ns, name) => {
+      if (!name || name === "unknown") return null;
+      const k = `${ns || "global"}/${name}`;
+      let r = services.get(k);
+      if (!r) {
+        r = {
+          id: serviceId(ns, name),
+          kind: "service_mesh_service",
+          name,
+          source: self.name,
+          labels: { namespace: ns || "global", mesh: "istio" },
+          attributes: { provider: "istio", canonicalName: String(name).toLowerCase() },
+        };
+        services.set(k, r);
+      }
+      return r;
+    };
+
+    // Aggregate edge weights so we can normalise confidence.
+    const edgeMap = new Map();
+    let maxWeight = 0;
+    for (const s of samples) {
+      const sNs = s.metric?.source_workload_namespace;
+      const sName = s.metric?.source_workload;
+      const dNs = s.metric?.destination_workload_namespace;
+      const dName = s.metric?.destination_workload;
+      const value = Number(s.value?.[1]);
+      if (!Number.isFinite(value) || value <= 0) continue;
+      const src = ensure(sNs, sName);
+      const dst = ensure(dNs, dName);
+      if (!src || !dst || src.id === dst.id) continue;
+      const key = `${src.id}|${dst.id}`;
+      const prev = edgeMap.get(key) || { from: src.id, to: dst.id, weight: 0 };
+      prev.weight += value;
+      edgeMap.set(key, prev);
+      if (prev.weight > maxWeight) maxWeight = prev.weight;
+    }
+
+    const edges = [];
+    for (const e of edgeMap.values()) {
+      const ratio = maxWeight > 0 ? e.weight / maxWeight : 0;
+      // Confidence stays in [0.5, 1.0] so even rare edges register —
+      // the relative weight is in the label for ranking.
+      const confidence = 0.5 + 0.5 * ratio;
+      edges.push({
+        from: e.from,
+        to: e.to,
+        relation: "CALLS",
+        confidence,
+        attributes: { requests_in_window: e.weight, lookback: this._lookback },
+      });
+    }
+
+    this._buildRevision += 1;
+    return {
+      source: this.name,
+      resources: [...services.values()],
+      edges,
+      revision: this._buildRevision,
+    };
+  }
+}
+
+export default function create() {
+  return new IstioConnector();
+}

--- a/connectors/istio/index.test.mjs
+++ b/connectors/istio/index.test.mjs
@@ -1,0 +1,218 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import create, { IstioConnector } from "./index.js";
+
+// Fake Prometheus that returns a canned response by route + asserts
+// the auth header is present when one is configured.
+function fakeProm(samples, opts = {}) {
+  const authCheck = opts.token;
+  return async (url, init = {}) => {
+    if (authCheck) {
+      const got = init.headers?.Authorization;
+      if (got !== `Bearer ${authCheck}`) throw new Error("missing or wrong auth");
+    }
+    const u = url.toString();
+    if (u.includes("query=up")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ status: "success", data: { resultType: "vector", result: [] } }),
+      };
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "success", data: { resultType: "vector", result: samples } }),
+    };
+  };
+}
+
+function sample(srcNs, src, dstNs, dst, value) {
+  return {
+    metric: {
+      source_workload: src,
+      source_workload_namespace: srcNs,
+      destination_workload: dst,
+      destination_workload_namespace: dstNs,
+    },
+    value: [0, String(value)],
+  };
+}
+
+test("create() returns IstioConnector with signalType topology", () => {
+  const c = create();
+  assert.ok(c instanceof IstioConnector);
+  assert.equal(c.signalType, "topology");
+});
+
+test("connect requires url", async () => {
+  const c = create();
+  await assert.rejects(c.connect({}), /url is required/);
+});
+
+test("healthCheck up when Prometheus responds 200", async () => {
+  const c = create();
+  await c.connect({ name: "istio", url: "http://prom:9090", _fetch: fakeProm([]) });
+  const h = await c.healthCheck();
+  assert.equal(h.status, "up");
+});
+
+test("healthCheck down when Prometheus 500s", async () => {
+  const c = create();
+  await c.connect({
+    name: "istio",
+    url: "http://prom:9090",
+    _fetch: async () => ({ ok: false, status: 500, json: async () => ({}) }),
+  });
+  const h = await c.healthCheck();
+  assert.equal(h.status, "down");
+  assert.match(h.message, /HTTP 500/);
+});
+
+test("healthCheck down when fetch throws", async () => {
+  const c = create();
+  await c.connect({
+    name: "istio",
+    url: "http://prom:9090",
+    _fetch: async () => { throw new Error("connection refused"); },
+  });
+  const h = await c.healthCheck();
+  assert.equal(h.status, "down");
+  assert.match(h.message, /refused/);
+});
+
+test("auth token forwarded as Bearer", async () => {
+  const c = create();
+  await c.connect({
+    name: "istio",
+    url: "http://prom:9090",
+    auth: { token: "t0k3n" },
+    _fetch: fakeProm([], { token: "t0k3n" }),
+  });
+  const h = await c.healthCheck();
+  assert.equal(h.status, "up");
+});
+
+test("empty Prometheus result → empty snapshot", async () => {
+  const c = create();
+  await c.connect({ name: "istio", url: "http://prom:9090", _fetch: fakeProm([]) });
+  const snap = await c.getTopologySnapshot();
+  assert.equal(snap.source, "istio");
+  assert.deepEqual(snap.resources, []);
+  assert.deepEqual(snap.edges, []);
+});
+
+test("derives service_mesh_service resources + CALLS edges from samples", async () => {
+  const c = create();
+  await c.connect({
+    name: "istio",
+    url: "http://prom:9090",
+    _fetch: fakeProm([
+      sample("prod", "checkout", "prod", "payment", 1000),
+      sample("prod", "checkout", "prod", "inventory", 100),
+    ]),
+  });
+  const snap = await c.getTopologySnapshot();
+  // 3 services: checkout, payment, inventory
+  assert.equal(snap.resources.length, 3);
+  assert.ok(snap.resources.every((r) => r.kind === "service_mesh_service"));
+  assert.ok(snap.resources.every((r) => r.attributes.canonicalName));
+  // 2 CALLS edges
+  assert.equal(snap.edges.length, 2);
+  assert.ok(snap.edges.every((e) => e.relation === "CALLS"));
+  // Edge confidence: chatty edge ranks higher
+  const heavy = snap.edges.find((e) => e.to.endsWith("payment"));
+  const light = snap.edges.find((e) => e.to.endsWith("inventory"));
+  assert.ok(heavy.confidence > light.confidence);
+});
+
+test("self-loops are dropped", async () => {
+  const c = create();
+  await c.connect({
+    name: "istio",
+    url: "http://prom:9090",
+    _fetch: fakeProm([sample("prod", "checkout", "prod", "checkout", 50)]),
+  });
+  const snap = await c.getTopologySnapshot();
+  assert.equal(snap.edges.length, 0);
+});
+
+test("'unknown' workload entries are dropped", async () => {
+  const c = create();
+  await c.connect({
+    name: "istio",
+    url: "http://prom:9090",
+    _fetch: fakeProm([
+      sample("prod", "unknown", "prod", "checkout", 50),
+      sample("prod", "checkout", "prod", "unknown", 50),
+      sample("prod", "checkout", "prod", "payment", 50),
+    ]),
+  });
+  const snap = await c.getTopologySnapshot();
+  // Only checkout + payment survive; one edge
+  assert.equal(snap.resources.length, 2);
+  assert.equal(snap.edges.length, 1);
+});
+
+test("duplicate edges aggregate into one with summed weight", async () => {
+  const c = create();
+  await c.connect({
+    name: "istio",
+    url: "http://prom:9090",
+    // Same (src, dst) appearing twice — different label noise upstream
+    _fetch: fakeProm([
+      sample("prod", "checkout", "prod", "payment", 100),
+      sample("prod", "checkout", "prod", "payment", 200),
+    ]),
+  });
+  const snap = await c.getTopologySnapshot();
+  assert.equal(snap.edges.length, 1);
+  assert.equal(snap.edges[0].attributes.requests_in_window, 300);
+});
+
+test("cross-namespace workloads produce distinct ids", async () => {
+  const c = create();
+  await c.connect({
+    name: "istio",
+    url: "http://prom:9090",
+    _fetch: fakeProm([
+      sample("prod", "checkout", "prod", "payment", 100),
+      sample("staging", "checkout", "staging", "payment", 100),
+    ]),
+  });
+  const snap = await c.getTopologySnapshot();
+  const ids = snap.resources.map((r) => r.id).sort();
+  assert.deepEqual(ids, [
+    "istio:service:prod/checkout",
+    "istio:service:prod/payment",
+    "istio:service:staging/checkout",
+    "istio:service:staging/payment",
+  ]);
+});
+
+test("listResources + listEdges parity with snapshot", async () => {
+  const c = create();
+  await c.connect({
+    name: "istio",
+    url: "http://prom:9090",
+    _fetch: fakeProm([sample("prod", "checkout", "prod", "payment", 100)]),
+  });
+  const snap = await c.getTopologySnapshot();
+  const r = await c.listResources();
+  const e = await c.listEdges();
+  assert.deepEqual(r, snap.resources);
+  assert.deepEqual(e, snap.edges);
+});
+
+test("listServices returns discovered service_mesh_service names", async () => {
+  const c = create();
+  await c.connect({
+    name: "istio",
+    url: "http://prom:9090",
+    _fetch: fakeProm([sample("prod", "checkout", "prod", "payment", 100)]),
+  });
+  const services = await c.listServices();
+  assert.equal(services.length, 2);
+  assert.deepEqual(services.map((s) => s.name).sort(), ["checkout", "payment"]);
+});

--- a/connectors/istio/manifest.json
+++ b/connectors/istio/manifest.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 1,
+  "name": "istio",
+  "displayName": "Istio",
+  "version": "1.0.0",
+  "description": "Istio service-mesh topology connector — derives a CALLS graph from istio_requests_total in the operator's existing Prometheus. Service names + namespaces from Istio telemetry-v2 labels (source_workload, destination_workload). Edge confidence reflects relative request volume so chatty edges rank above rare ones.",
+  "signalTypes": ["topology"],
+  "homepage": "https://github.com/ThoTischner/observability-mcp",
+  "license": "Apache-2.0",
+  "capabilities": {
+    "listServices": true,
+    "listResources": true,
+    "listEdges": true,
+    "getTopologySnapshot": true,
+    "watchTopology": true
+  },
+  "compat": {
+    "serverVersion": ">=3.0.0"
+  },
+  "integrity": "sha256-37TMXYn9X3PzhKkV8PrAZ5WHXymDVIZsK9wWnyIljzg="
+}

--- a/connectors/istio/package.json
+++ b/connectors/istio/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@observability-mcp/connector-istio",
+  "version": "1.0.0",
+  "description": "Istio service-mesh topology connector for observability-mcp — derives a CALLS graph from istio_requests_total in the operator's existing Prometheus.",
+  "type": "module",
+  "main": "./index.js",
+  "license": "Apache-2.0",
+  "files": ["index.js", "manifest.json"],
+  "observabilityMcp": {
+    "kind": "connector",
+    "name": "istio",
+    "manifest": "./manifest.json"
+  },
+  "scripts": {
+    "test": "node --test index.test.mjs"
+  },
+  "dependencies": {}
+}

--- a/docs/topology-providers.md
+++ b/docs/topology-providers.md
@@ -22,7 +22,7 @@ This page describes:
 | AWS | `aws` | ✅ shipped (Q1 / v3.1) | EC2 + ECS clusters/services/tasks + EKS clusters/nodegroups. Edges: ECS task → service (OWNED_BY); ECS service → cluster (OWNED_BY); EKS nodegroup → cluster (OWNED_BY). Snapshots memoized for 30 s. Auth via standard AWS SDK credential chain. |
 | GCP | `gcp` | 🔧 follow-up | GKE workloads, Cloud Run, Cloud SQL, Pub/Sub. Edges via Service Directory + VPC peerings. |
 | Consul | `consul` | 🔧 follow-up | Service registry + intentions over the Consul HTTP API. |
-| Istio | `istio` | 🔧 follow-up | mTLS-protected call edges + service-mesh resource graph. |
+| Istio | `istio` | ✅ shipped (Q2 / v3.1) | CALLS graph derived from `istio_requests_total` in the operator's existing Prometheus. Workload names + namespaces from `source_workload`/`destination_workload` telemetry-v2 labels. Edge `confidence` ∈ [0.5, 1.0] reflects relative request volume so chatty edges rank above rare ones. Snapshots memoized 30 s. Auth via optional Bearer token. |
 | Linkerd | `linkerd` | 🔧 follow-up | mTLS-protected call edges, identity-aware. |
 | Tempo | `tempo` | ✅ shipped (plugin) | CALLS edges derived from a sampled batch of recent traces. |
 

--- a/hub/catalog/index.json
+++ b/hub/catalog/index.json
@@ -88,6 +88,26 @@
       ]
     },
     {
+      "name": "istio",
+      "displayName": "Istio",
+      "description": "Istio service-mesh topology connector — derives a CALLS graph from istio_requests_total in the operator's existing Prometheus. Service names + namespaces from Istio telemetry-v2 labels (source_workload, destination_workload). Edge confidence reflects relative request volume so chatty edges rank above rare ones.",
+      "tier": "official",
+      "builtin": false,
+      "signalTypes": [
+        "topology"
+      ],
+      "latest": "1.0.0",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "releasedAt": "2026-06-06",
+          "serverCompat": ">=3.0.0",
+          "integrity": "sha256-37TMXYn9X3PzhKkV8PrAZ5WHXymDVIZsK9wWnyIljzg=",
+          "changelog": "Initial release: Istio service-mesh CALLS graph via istio_requests_total Prometheus metric. Snapshots memoized 30s. Auth via optional Bearer token."
+        }
+      ]
+    },
+    {
       "name": "kubernetes",
       "displayName": "Kubernetes",
       "description": "Watches a Kubernetes cluster (in-cluster or via kubeconfig) and exposes pods, nodes, deployments, replicasets and namespaces as an infrastructure topology graph. Edges: RUNS_ON (pod→node), OWNED_BY (pod→rs→deployment), IN_NAMESPACE. Built on @kubernetes/client-node Informers — no polling.",

--- a/hub/catalog/istio.json
+++ b/hub/catalog/istio.json
@@ -1,0 +1,19 @@
+{
+  "catalogVersion": 1,
+  "name": "istio",
+  "displayName": "Istio",
+  "description": "Istio service-mesh topology connector — derives a CALLS graph from istio_requests_total in the operator's existing Prometheus. Service names + namespaces from Istio telemetry-v2 labels (source_workload, destination_workload). Edge confidence reflects relative request volume so chatty edges rank above rare ones.",
+  "vendor": "observability-mcp",
+  "homepage": "https://github.com/ThoTischner/observability-mcp",
+  "tier": "official",
+  "signalTypes": ["topology"],
+  "versions": [
+    {
+      "version": "1.0.0",
+      "releasedAt": "2026-06-06",
+      "serverCompat": ">=3.0.0",
+      "integrity": "sha256-37TMXYn9X3PzhKkV8PrAZ5WHXymDVIZsK9wWnyIljzg=",
+      "changelog": "Initial release: Istio service-mesh CALLS graph via istio_requests_total Prometheus metric. Snapshots memoized 30s. Auth via optional Bearer token."
+    }
+  ]
+}


### PR DESCRIPTION
Second Q-sprint slice. Derives a service-mesh graph from `istio_requests_total` in the operator's existing Prometheus — reuses what Istio installs already have, no new credentials, no extra deps.

- Stable ids `istio:service:<ns>/<name>` (cross-namespace distinct).
- canonicalName for cross-provider merger.
- Edge confidence ∈ [0.5, 1.0] from relative request volume.
- Self-loops + unknown drops handled.
- Optional Bearer auth.
- 14/14 unit tests.
- Apache-2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)