### PR TITLE
feat(q3): Linkerd topology connector (CALLS from response_total)

### DIFF
--- a/connectors/linkerd/index.js
+++ b/connectors/linkerd/index.js
@@ -1,0 +1,230 @@
+// Linkerd topology connector for observability-mcp.
+//
+// Derives a service-graph from Linkerd's `response_total` Prometheus
+// metric (emitted by the linkerd-proxy sidecars). Each unique
+// (deployment, dst_deployment) pair becomes a CALLS edge in the
+// returned topology.
+//
+// Why the proxy metric and not the linkerd-viz API? Same reasoning
+// as the Istio connector — Linkerd installs ship Prometheus, the
+// viz `/api/edges` endpoint is itself backed by Prometheus, and
+// reusing what the operator already has avoids a new privileged
+// credential.
+//
+// Auth: optional Bearer token for environments that front Prometheus
+// with an auth proxy.
+
+const TOPOLOGY_TTL_MS = 30_000;
+const DEFAULT_LOOKBACK = "5m";
+
+function serviceId(namespace, name) {
+  return `linkerd:service:${namespace || "global"}/${name}`;
+}
+
+export class LinkerdConnector {
+  constructor() {
+    this.type = "linkerd";
+    this.signalType = "topology";
+    this.name = "linkerd";
+    this._base = "";
+    this._token = "";
+    this._lookback = DEFAULT_LOOKBACK;
+    this._snapshot = null;
+    this._snapshotExpiresAt = 0;
+    this._watchers = new Set();
+    this._watchTimer = null;
+    this._buildRevision = 0;
+    this._fetch = globalThis.fetch;
+  }
+
+  async connect(config) {
+    this.name = config.name || "linkerd";
+    if (!config.url) throw new Error("linkerd connector: url is required (Prometheus base URL)");
+    this._base = String(config.url).replace(/\/+$/, "");
+    this._token =
+      config.auth?.token ||
+      config.token ||
+      process.env.LINKERD_PROM_TOKEN ||
+      "";
+    this._lookback = config.lookback || DEFAULT_LOOKBACK;
+    if (config._fetch) this._fetch = config._fetch;
+  }
+
+  async healthCheck() {
+    const t0 = Date.now();
+    try {
+      const u = new URL(`${this._base}/api/v1/query`);
+      u.searchParams.set("query", "up");
+      const res = await this._fetch(u, { headers: this._headers() });
+      if (!res.ok) {
+        return { status: "down", latencyMs: Date.now() - t0, message: `prom HTTP ${res.status}` };
+      }
+      return { status: "up", latencyMs: Date.now() - t0 };
+    } catch (err) {
+      return {
+        status: "down",
+        latencyMs: Date.now() - t0,
+        message: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  async disconnect() {
+    if (this._watchTimer) {
+      clearInterval(this._watchTimer);
+      this._watchTimer = null;
+    }
+    this._watchers.clear();
+    this._snapshot = null;
+  }
+
+  getDefaultMetrics() { return []; }
+  getMetrics() { return []; }
+
+  async listServices() {
+    const snap = await this._refreshIfStale();
+    return snap.resources
+      .filter((r) => r.kind === "service_mesh_service")
+      .map((r) => ({ name: r.name, source: this.name, signals: ["topology"] }));
+  }
+
+  async listResources() {
+    return (await this._refreshIfStale()).resources;
+  }
+
+  async listEdges() {
+    return (await this._refreshIfStale()).edges;
+  }
+
+  async getTopologySnapshot() {
+    return this._refreshIfStale();
+  }
+
+  watchTopology(listener) {
+    this._watchers.add(listener);
+    queueMicrotask(async () => {
+      try {
+        const snap = await this._refreshIfStale();
+        listener({ type: "resync", snapshot: snap });
+      } catch { /* swallow */ }
+    });
+    if (!this._watchTimer) {
+      this._watchTimer = setInterval(async () => {
+        let snap;
+        try { snap = await this._buildSnapshot(); } catch { return; }
+        this._snapshot = snap;
+        this._snapshotExpiresAt = Date.now() + TOPOLOGY_TTL_MS;
+        for (const l of this._watchers) {
+          try { l({ type: "resync", snapshot: snap }); } catch { /* skip */ }
+        }
+      }, TOPOLOGY_TTL_MS);
+      if (this._watchTimer && typeof this._watchTimer.unref === "function") {
+        this._watchTimer.unref();
+      }
+    }
+    return () => {
+      this._watchers.delete(listener);
+      if (this._watchers.size === 0 && this._watchTimer) {
+        clearInterval(this._watchTimer);
+        this._watchTimer = null;
+      }
+    };
+  }
+
+  // --- internals ------------------------------------------------------
+
+  _headers() {
+    const h = { Accept: "application/json" };
+    if (this._token) h.Authorization = `Bearer ${this._token}`;
+    return h;
+  }
+
+  async _refreshIfStale() {
+    const now = Date.now();
+    if (this._snapshot && now < this._snapshotExpiresAt) return this._snapshot;
+    const snap = await this._buildSnapshot();
+    this._snapshot = snap;
+    this._snapshotExpiresAt = now + TOPOLOGY_TTL_MS;
+    return snap;
+  }
+
+  async _buildSnapshot() {
+    // Linkerd's outbound proxy metric: response_total grouped by
+    // (deployment, namespace, dst_deployment, dst_namespace). We
+    // increase() over the window so the result is "responses in
+    // window" — the volume share derives edge confidence the same
+    // way Istio's connector does.
+    const lookback = this._lookback;
+    const query = `sum by (deployment, namespace, dst_deployment, dst_namespace) (increase(response_total{direction="outbound"}[${lookback}]))`;
+    const u = new URL(`${this._base}/api/v1/query`);
+    u.searchParams.set("query", query);
+    const res = await this._fetch(u, { headers: this._headers() });
+    if (!res.ok) throw new Error(`linkerd prom query HTTP ${res.status}`);
+    const body = await res.json();
+    const samples = body?.data?.result || [];
+
+    const services = new Map();
+    const self = this;
+    const ensure = (ns, name) => {
+      if (!name) return null;
+      const k = `${ns || "global"}/${name}`;
+      let r = services.get(k);
+      if (!r) {
+        r = {
+          id: serviceId(ns, name),
+          kind: "service_mesh_service",
+          name,
+          source: self.name,
+          labels: { namespace: ns || "global", mesh: "linkerd" },
+          attributes: { provider: "linkerd", canonicalName: String(name).toLowerCase() },
+        };
+        services.set(k, r);
+      }
+      return r;
+    };
+
+    const edgeMap = new Map();
+    let maxWeight = 0;
+    for (const s of samples) {
+      const sNs = s.metric?.namespace;
+      const sName = s.metric?.deployment;
+      const dNs = s.metric?.dst_namespace;
+      const dName = s.metric?.dst_deployment;
+      const value = Number(s.value?.[1]);
+      if (!Number.isFinite(value) || value <= 0) continue;
+      const src = ensure(sNs, sName);
+      const dst = ensure(dNs, dName);
+      if (!src || !dst || src.id === dst.id) continue;
+      const key = `${src.id}|${dst.id}`;
+      const prev = edgeMap.get(key) || { from: src.id, to: dst.id, weight: 0 };
+      prev.weight += value;
+      edgeMap.set(key, prev);
+      if (prev.weight > maxWeight) maxWeight = prev.weight;
+    }
+
+    const edges = [];
+    for (const e of edgeMap.values()) {
+      const ratio = maxWeight > 0 ? e.weight / maxWeight : 0;
+      const confidence = 0.5 + 0.5 * ratio;
+      edges.push({
+        from: e.from,
+        to: e.to,
+        relation: "CALLS",
+        confidence,
+        attributes: { responses_in_window: e.weight, lookback: this._lookback },
+      });
+    }
+
+    this._buildRevision += 1;
+    return {
+      source: this.name,
+      resources: [...services.values()],
+      edges,
+      revision: this._buildRevision,
+    };
+  }
+}
+
+export default function create() {
+  return new LinkerdConnector();
+}

--- a/connectors/linkerd/index.test.mjs
+++ b/connectors/linkerd/index.test.mjs
@@ -1,0 +1,220 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import create, { LinkerdConnector } from "./index.js";
+
+function fakeProm(samples, opts = {}) {
+  const authCheck = opts.token;
+  return async (url, init = {}) => {
+    if (authCheck) {
+      const got = init.headers?.Authorization;
+      if (got !== `Bearer ${authCheck}`) throw new Error("missing or wrong auth");
+    }
+    const u = url.toString();
+    if (u.includes("query=up")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ status: "success", data: { resultType: "vector", result: [] } }),
+      };
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ status: "success", data: { resultType: "vector", result: samples } }),
+    };
+  };
+}
+
+function sample(srcNs, src, dstNs, dst, value) {
+  return {
+    metric: {
+      deployment: src,
+      namespace: srcNs,
+      dst_deployment: dst,
+      dst_namespace: dstNs,
+    },
+    value: [0, String(value)],
+  };
+}
+
+test("create() returns LinkerdConnector with signalType topology", () => {
+  const c = create();
+  assert.ok(c instanceof LinkerdConnector);
+  assert.equal(c.signalType, "topology");
+});
+
+test("connect requires url", async () => {
+  await assert.rejects(create().connect({}), /url is required/);
+});
+
+test("healthCheck up / down / throw paths", async () => {
+  const ok = create();
+  await ok.connect({ name: "linkerd", url: "http://prom:9090", _fetch: fakeProm([]) });
+  assert.equal((await ok.healthCheck()).status, "up");
+
+  const down = create();
+  await down.connect({
+    name: "linkerd",
+    url: "http://prom:9090",
+    _fetch: async () => ({ ok: false, status: 503, json: async () => ({}) }),
+  });
+  const h1 = await down.healthCheck();
+  assert.equal(h1.status, "down");
+  assert.match(h1.message, /HTTP 503/);
+
+  const thrown = create();
+  await thrown.connect({
+    name: "linkerd",
+    url: "http://prom:9090",
+    _fetch: async () => { throw new Error("dns failure"); },
+  });
+  const h2 = await thrown.healthCheck();
+  assert.equal(h2.status, "down");
+  assert.match(h2.message, /dns/);
+});
+
+test("auth token forwarded as Bearer", async () => {
+  const c = create();
+  await c.connect({
+    name: "linkerd",
+    url: "http://prom:9090",
+    auth: { token: "tok" },
+    _fetch: fakeProm([], { token: "tok" }),
+  });
+  assert.equal((await c.healthCheck()).status, "up");
+});
+
+test("empty result → empty snapshot", async () => {
+  const c = create();
+  await c.connect({ name: "linkerd", url: "http://prom:9090", _fetch: fakeProm([]) });
+  const snap = await c.getTopologySnapshot();
+  assert.equal(snap.source, "linkerd");
+  assert.deepEqual(snap.resources, []);
+  assert.deepEqual(snap.edges, []);
+});
+
+test("derives service_mesh_service + CALLS with weight-ranked confidence", async () => {
+  const c = create();
+  await c.connect({
+    name: "linkerd",
+    url: "http://prom:9090",
+    _fetch: fakeProm([
+      sample("prod", "checkout", "prod", "payment", 1000),
+      sample("prod", "checkout", "prod", "inventory", 100),
+    ]),
+  });
+  const snap = await c.getTopologySnapshot();
+  assert.equal(snap.resources.length, 3);
+  assert.ok(snap.resources.every((r) => r.kind === "service_mesh_service"));
+  assert.equal(snap.edges.length, 2);
+  const heavy = snap.edges.find((e) => e.to.endsWith("payment"));
+  const light = snap.edges.find((e) => e.to.endsWith("inventory"));
+  assert.ok(heavy.confidence > light.confidence);
+});
+
+test("self-loops dropped", async () => {
+  const c = create();
+  await c.connect({
+    name: "linkerd",
+    url: "http://prom:9090",
+    _fetch: fakeProm([sample("prod", "checkout", "prod", "checkout", 50)]),
+  });
+  const snap = await c.getTopologySnapshot();
+  assert.equal(snap.edges.length, 0);
+});
+
+test("samples with missing dst dropped", async () => {
+  const c = create();
+  await c.connect({
+    name: "linkerd",
+    url: "http://prom:9090",
+    _fetch: fakeProm([
+      { metric: { deployment: "checkout", namespace: "prod" /* no dst */ }, value: [0, "10"] },
+      sample("prod", "checkout", "prod", "payment", 50),
+    ]),
+  });
+  const snap = await c.getTopologySnapshot();
+  // Only checkout + payment + one edge survive
+  assert.equal(snap.resources.length, 2);
+  assert.equal(snap.edges.length, 1);
+});
+
+test("duplicate edges aggregate weights", async () => {
+  const c = create();
+  await c.connect({
+    name: "linkerd",
+    url: "http://prom:9090",
+    _fetch: fakeProm([
+      sample("prod", "checkout", "prod", "payment", 100),
+      sample("prod", "checkout", "prod", "payment", 200),
+    ]),
+  });
+  const snap = await c.getTopologySnapshot();
+  assert.equal(snap.edges.length, 1);
+  assert.equal(snap.edges[0].attributes.responses_in_window, 300);
+});
+
+test("cross-namespace workloads → distinct ids", async () => {
+  const c = create();
+  await c.connect({
+    name: "linkerd",
+    url: "http://prom:9090",
+    _fetch: fakeProm([
+      sample("prod", "checkout", "prod", "payment", 100),
+      sample("staging", "checkout", "staging", "payment", 100),
+    ]),
+  });
+  const snap = await c.getTopologySnapshot();
+  const ids = snap.resources.map((r) => r.id).sort();
+  assert.deepEqual(ids, [
+    "linkerd:service:prod/checkout",
+    "linkerd:service:prod/payment",
+    "linkerd:service:staging/checkout",
+    "linkerd:service:staging/payment",
+  ]);
+});
+
+test("listResources + listEdges parity with snapshot", async () => {
+  const c = create();
+  await c.connect({
+    name: "linkerd",
+    url: "http://prom:9090",
+    _fetch: fakeProm([sample("prod", "checkout", "prod", "payment", 50)]),
+  });
+  const snap = await c.getTopologySnapshot();
+  assert.deepEqual(await c.listResources(), snap.resources);
+  assert.deepEqual(await c.listEdges(), snap.edges);
+});
+
+test("listServices returns discovered service_mesh_service names", async () => {
+  const c = create();
+  await c.connect({
+    name: "linkerd",
+    url: "http://prom:9090",
+    _fetch: fakeProm([sample("prod", "checkout", "prod", "payment", 50)]),
+  });
+  const services = await c.listServices();
+  assert.equal(services.length, 2);
+});
+
+test("snapshot is cached for TTL", async () => {
+  let promCalls = 0;
+  const c = create();
+  await c.connect({
+    name: "linkerd",
+    url: "http://prom:9090",
+    _fetch: async (url) => {
+      promCalls += 1;
+      const u = url.toString();
+      if (u.includes("query=up")) {
+        return { ok: true, status: 200, json: async () => ({ status: "success", data: { result: [] } }) };
+      }
+      return { ok: true, status: 200, json: async () => ({ status: "success", data: { result: [] } }) };
+    },
+  });
+  await c.getTopologySnapshot();
+  await c.getTopologySnapshot();
+  await c.getTopologySnapshot();
+  assert.equal(promCalls, 1);
+});

--- a/connectors/linkerd/manifest.json
+++ b/connectors/linkerd/manifest.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 1,
+  "name": "linkerd",
+  "displayName": "Linkerd",
+  "version": "1.0.0",
+  "description": "Linkerd service-mesh topology connector — derives a CALLS graph from response_total in the operator's existing Prometheus. Service names + namespaces from the linkerd-proxy outbound deployment / dst_deployment labels. Edge confidence reflects relative response volume so chatty edges rank above rare ones.",
+  "signalTypes": ["topology"],
+  "homepage": "https://github.com/ThoTischner/observability-mcp",
+  "license": "Apache-2.0",
+  "capabilities": {
+    "listServices": true,
+    "listResources": true,
+    "listEdges": true,
+    "getTopologySnapshot": true,
+    "watchTopology": true
+  },
+  "compat": {
+    "serverVersion": ">=3.0.0"
+  },
+  "integrity": "sha256-pUNPXuokuF3T02cJ8r3wf1qt3wYtKFd/iEUX1ydWpOU="
+}

--- a/connectors/linkerd/package.json
+++ b/connectors/linkerd/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@observability-mcp/connector-linkerd",
+  "version": "1.0.0",
+  "description": "Linkerd service-mesh topology connector for observability-mcp — derives a CALLS graph from response_total in the operator's existing Prometheus.",
+  "type": "module",
+  "main": "./index.js",
+  "license": "Apache-2.0",
+  "files": ["index.js", "manifest.json"],
+  "observabilityMcp": {
+    "kind": "connector",
+    "name": "linkerd",
+    "manifest": "./manifest.json"
+  },
+  "scripts": {
+    "test": "node --test index.test.mjs"
+  },
+  "dependencies": {}
+}

--- a/docs/topology-providers.md
+++ b/docs/topology-providers.md
@@ -23,7 +23,7 @@ This page describes:
 | GCP | `gcp` | 🔧 follow-up | GKE workloads, Cloud Run, Cloud SQL, Pub/Sub. Edges via Service Directory + VPC peerings. |
 | Consul | `consul` | 🔧 follow-up | Service registry + intentions over the Consul HTTP API. |
 | Istio | `istio` | ✅ shipped (Q2 / v3.1) | CALLS graph derived from `istio_requests_total` in the operator's existing Prometheus. Workload names + namespaces from `source_workload`/`destination_workload` telemetry-v2 labels. Edge `confidence` ∈ [0.5, 1.0] reflects relative request volume so chatty edges rank above rare ones. Snapshots memoized 30 s. Auth via optional Bearer token. |
-| Linkerd | `linkerd` | 🔧 follow-up | mTLS-protected call edges, identity-aware. |
+| Linkerd | `linkerd` | ✅ shipped (Q3 / v3.1) | CALLS graph derived from `response_total{direction="outbound"}` in the operator's existing Prometheus. Workload names + namespaces from the linkerd-proxy `deployment`/`dst_deployment` labels. Same confidence-by-volume model as Istio. Snapshots memoized 30 s. Optional Bearer auth. |
 | Tempo | `tempo` | ✅ shipped (plugin) | CALLS edges derived from a sampled batch of recent traces. |
 
 Reserved kind/relation vocabulary for the multi-cloud providers is

--- a/hub/catalog/index.json
+++ b/hub/catalog/index.json
@@ -127,6 +127,26 @@
       ]
     },
     {
+      "name": "linkerd",
+      "displayName": "Linkerd",
+      "description": "Linkerd service-mesh topology connector — derives a CALLS graph from response_total in the operator's existing Prometheus.",
+      "tier": "official",
+      "builtin": false,
+      "signalTypes": [
+        "topology"
+      ],
+      "latest": "1.0.0",
+      "versions": [
+        {
+          "version": "1.0.0",
+          "releasedAt": "2026-06-06",
+          "serverCompat": ">=3.0.0",
+          "integrity": "sha256-pUNPXuokuF3T02cJ8r3wf1qt3wYtKFd/iEUX1ydWpOU=",
+          "changelog": "Initial release: Linkerd service-mesh CALLS graph via response_total. 30s snapshot TTL. Optional Bearer auth."
+        }
+      ]
+    },
+    {
       "name": "loki",
       "displayName": "Grafana Loki",
       "description": "LogQL-based logs backend. Service discovery from log streams and label-scoped log queries.",

--- a/hub/catalog/linkerd.json
+++ b/hub/catalog/linkerd.json
@@ -1,0 +1,19 @@
+{
+  "catalogVersion": 1,
+  "name": "linkerd",
+  "displayName": "Linkerd",
+  "description": "Linkerd service-mesh topology connector — derives a CALLS graph from response_total in the operator's existing Prometheus.",
+  "vendor": "observability-mcp",
+  "homepage": "https://github.com/ThoTischner/observability-mcp",
+  "tier": "official",
+  "signalTypes": ["topology"],
+  "versions": [
+    {
+      "version": "1.0.0",
+      "releasedAt": "2026-06-06",
+      "serverCompat": ">=3.0.0",
+      "integrity": "sha256-pUNPXuokuF3T02cJ8r3wf1qt3wYtKFd/iEUX1ydWpOU=",
+      "changelog": "Initial release: Linkerd service-mesh CALLS graph via response_total. 30s snapshot TTL. Optional Bearer auth."
+    }
+  ]
+}


### PR DESCRIPTION
Third Q-sprint slice. Same shape as Q2 (Istio), distinct metric (`response_total{direction="outbound"}`) and labels (`deployment`/`dst_deployment`). 13/13 tests, Apache-2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)