### PR TITLE
fix(docs): preserve artifacthub-repo.yml on the Pages site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -66,10 +66,15 @@ jobs:
           set -euo pipefail
           if git fetch --depth 1 origin gh-pages 2>/dev/null; then
             git worktree add /tmp/ghpages FETCH_HEAD
-            # copy *.tgz, *.tgz.prov, index.yaml — skip index.html
-            # (mkdocs landing wins) and the chart-releaser-noise.
+            # copy *.tgz, *.tgz.prov, index.yaml, artifacthub-repo.yml,
+            # .artifacthub-repo.yml — skip index.html (mkdocs landing
+            # wins) and the chart-releaser noise.
+            #
+            # artifacthub-repo.yml is what claims the chart for the
+            # ArtifactHub Verified Publisher badge. Without it the
+            # badge silently drops on the next scan.
             shopt -s nullglob
-            for f in /tmp/ghpages/*.tgz /tmp/ghpages/*.tgz.prov /tmp/ghpages/index.yaml; do
+            for f in /tmp/ghpages/*.tgz /tmp/ghpages/*.tgz.prov /tmp/ghpages/index.yaml /tmp/ghpages/artifacthub-repo.yml /tmp/ghpages/.artifacthub-repo.yml; do
               [ -f "$f" ] || continue
               cp -n "$f" site/
               echo "  preserved $(basename "$f")"
@@ -78,6 +83,14 @@ jobs:
             echo "::notice::Helm repo files preserved alongside docs site"
           else
             echo "::notice::No gh-pages branch yet — nothing to preserve"
+          fi
+          # Source-of-truth path: ship the repo-root .artifacthub-repo.yml
+          # under the dotless name ArtifactHub expects at the chart-repo
+          # URL. This puts the publisher-claim in main/PR diffs instead
+          # of only-on-gh-pages where stale or drift goes unnoticed.
+          if [ -f .artifacthub-repo.yml ]; then
+            cp .artifacthub-repo.yml site/artifacthub-repo.yml
+            echo "::notice::Copied .artifacthub-repo.yml → site/artifacthub-repo.yml"
           fi
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')


### PR DESCRIPTION
## Summary
Pages is served via docs.yml's mkdocs build + upload-pages-artifact pipeline, NOT directly from gh-pages. The merge step copied `*.tgz`, `*.tgz.prov`, `index.yaml` — but NOT `artifacthub-repo.yml`. ArtifactHub scanned `/artifacthub-repo.yml`, got the mkdocs 404 HTML fallback, and silently dropped our Verified Publisher badge.

## Fix
1. Add both `artifacthub-repo.yml` and `.artifacthub-repo.yml` to the preserved-files glob.
2. Belt-and-braces: copy repo-root `.artifacthub-repo.yml` → `site/artifacthub-repo.yml` so the publisher-claim is committed in main, not only on gh-pages.

After merge: next push triggers a Pages deploy serving `artifacthub-repo.yml` → user force-scans on ArtifactHub → badge restored.

## Test plan
- [ ] CI green.
- [ ] After merge: `curl https://thotischner.github.io/observability-mcp/artifacthub-repo.yml` returns the YAML (HTTP 200), NOT mkdocs HTML.
- [ ] ArtifactHub force-scan → Verified Publisher badge reappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)