### PR TITLE
feat(q9): WebSocket federation upstream transport

### DIFF
--- a/docs/federation.md
+++ b/docs/federation.md
@@ -27,6 +27,11 @@ Set `OMCP_FEDERATION_UPSTREAMS` to a comma-separated list of
 
 - **HTTP** (default): `name=https://upstream.host/mcp` — must end at
   the upstream's Streamable HTTP `/mcp` endpoint.
+- **WebSocket**: `name=ws://upstream.host/mcp/ws` or `name=wss://…`.
+  Targets the upstream's WebSocket transport. No bearer-auth header
+  is added (the SDK transport only accepts a URL) — embed auth
+  credentials in the URL or front the gateway with an
+  authenticating reverse proxy.
 - **Stdio**: `name=stdio:<command> [args...]` — spawn a child process
   that speaks MCP over its stdio channels. Useful when the upstream
   is a CLI-style MCP (e.g. an `omcp inspector-config` instance, a
@@ -39,8 +44,8 @@ export OMCP_FEDERATION_UPSTREAMS="payments=https://payments-mcp.internal/mcp,ris
 export OMCP_FEDERATION_TOKEN_PAYMENTS="bearer-for-payments-gw"
 export OMCP_FEDERATION_TOKEN_RISK="bearer-for-risk-gw"
 
-# Mix of HTTP + stdio upstreams
-export OMCP_FEDERATION_UPSTREAMS="prod=https://gw/mcp,weather=stdio:node /opt/weather-mcp/server.js --quiet"
+# Mix of HTTP + WebSocket + stdio upstreams
+export OMCP_FEDERATION_UPSTREAMS="prod=https://gw/mcp,realtime=wss://gw/mcp/ws,weather=stdio:node /opt/weather-mcp/server.js --quiet"
 ```
 
 HTTP upstreams' static bearer tokens (forwarded as

--- a/mcp-server/src/federation/registry.test.ts
+++ b/mcp-server/src/federation/registry.test.ts
@@ -184,6 +184,40 @@ test("parseFederationEnv: http + stdio entries co-exist", () => {
   assert.equal(parsed[1]?.kind, "stdio");
 });
 
+test("parseFederationEnv: ws:// + wss:// entries parse with kind=ws", () => {
+  const parsed = parseFederationEnv({
+    OMCP_FEDERATION_UPSTREAMS: "plain=ws://gw/mcp/ws,secure=wss://gw/mcp/ws",
+  });
+  assert.equal(parsed.length, 2);
+  assert.deepEqual(parsed[0], { kind: "ws", name: "plain", url: "ws://gw/mcp/ws" });
+  assert.deepEqual(parsed[1], { kind: "ws", name: "secure", url: "wss://gw/mcp/ws" });
+});
+
+test("parseFederationEnv: ws upstreams do NOT carry bearer tokens (URL-only)", () => {
+  // Even when a matching OMCP_FEDERATION_TOKEN_X is set, the ws entry
+  // shouldn't grow a bearerToken field — the SDK transport only
+  // accepts the URL.
+  const parsed = parseFederationEnv({
+    OMCP_FEDERATION_UPSTREAMS: "x=wss://gw/mcp/ws",
+    OMCP_FEDERATION_TOKEN_X: "would-be-ignored",
+  });
+  assert.equal(parsed[0]?.kind, "ws");
+  // The ws branch has no `bearerToken` property at all.
+  assert.equal((parsed[0] as unknown as Record<string, unknown>).bearerToken, undefined);
+});
+
+test("parseFederationEnv: all four transport variants co-exist", () => {
+  const parsed = parseFederationEnv({
+    OMCP_FEDERATION_UPSTREAMS:
+      "a=https://gw/mcp,b=http://gw/mcp,c=ws://gw/mcp/ws,d=stdio:/bin/mcp",
+  });
+  assert.equal(parsed.length, 4);
+  assert.deepEqual(
+    parsed.map((p) => p.kind),
+    ["http", "http", "ws", "stdio"],
+  );
+});
+
 test("parseFederationEnv: skips malformed entries with a warning, keeps the rest", () => {
   const parsed = parseFederationEnv({
     OMCP_FEDERATION_UPSTREAMS:

--- a/mcp-server/src/federation/registry.ts
+++ b/mcp-server/src/federation/registry.ts
@@ -59,15 +59,20 @@ export class FederationRegistry {
  * Parse the OMCP_FEDERATION_UPSTREAMS env into a list of upstream
  * configs. Shape:
  *
- *   "name1=https://gw.a/mcp,name2=https://gw.b/mcp,name3=stdio:/usr/bin/mcp arg1 arg2"
+ *   "a=https://gw.a/mcp,b=stdio:/usr/bin/mcp arg1,c=wss://gw.c/mcp/ws"
  *
- * Each upstream's bearer token (HTTP transport only) is read from
- * OMCP_FEDERATION_TOKEN_<UPPERCASE-NAME> (dots → underscores), so
- * tokens stay out of the URL list itself.
+ * Transport selection:
+ *   - `https?://`   → HTTP (Streamable). Bearer token from
+ *                     OMCP_FEDERATION_TOKEN_<UPPERCASE-NAME>.
+ *   - `ws://`/`wss://` → WebSocket. No bearer header (the SDK
+ *                     transport only accepts a URL); embed auth
+ *                     in the URL or front the gateway with a
+ *                     proxy.
+ *   - `stdio:<cmd>` → spawn a child process; `\` escapes spaces
+ *                     in the command/argv list.
  *
- * Stdio entries are written as `name=stdio:<command> [arg ...]`. The
- * command may be quoted with `\` escapes to embed spaces. Stdio
- * upstreams don't carry bearer tokens — they're local-only.
+ * Tokens never appear in the URL list itself for HTTP — kept
+ * separate so they don't leak into logs / audit entries.
  */
 export interface ParsedUpstreamHttp {
   kind: "http";
@@ -83,7 +88,16 @@ export interface ParsedUpstreamStdio {
   args: string[];
 }
 
-export type ParsedUpstream = ParsedUpstreamHttp | ParsedUpstreamStdio;
+export interface ParsedUpstreamWebsocket {
+  kind: "ws";
+  name: string;
+  url: string;
+}
+
+export type ParsedUpstream =
+  | ParsedUpstreamHttp
+  | ParsedUpstreamStdio
+  | ParsedUpstreamWebsocket;
 
 /** Split a "command arg1 arg2" string honouring backslash escapes
  *  so an operator can embed a literal space with `\ `. Nothing
@@ -134,8 +148,12 @@ export function parseFederationEnv(env: NodeJS.ProcessEnv = process.env): Parsed
       entries.push({ kind: "stdio", name, command, args });
       continue;
     }
+    if (/^wss?:\/\//.test(spec)) {
+      entries.push({ kind: "ws", name, url: spec });
+      continue;
+    }
     if (!/^https?:\/\//.test(spec)) {
-      console.warn(`OMCP_FEDERATION_UPSTREAMS entry "${name}" url "${spec}" must start with http:// or https:// (or stdio:) — skipping`);
+      console.warn(`OMCP_FEDERATION_UPSTREAMS entry "${name}" url "${spec}" must start with http://, https://, ws://, wss:// (or stdio:) — skipping`);
       continue;
     }
     const tokenEnv = `OMCP_FEDERATION_TOKEN_${name.toUpperCase().replace(/[-.]/g, "_")}`;

--- a/mcp-server/src/federation/upstream.test.ts
+++ b/mcp-server/src/federation/upstream.test.ts
@@ -50,6 +50,17 @@ test("UpstreamClient: explicit transport='http' is also accepted", () => {
   assert.equal(c.transportKind, "http");
 });
 
+test("UpstreamClient: ws transport surfaces the ws:// URL", () => {
+  const cfg: UpstreamConfig = {
+    transport: "ws",
+    name: "gw",
+    url: "wss://gw.example.com/mcp/ws",
+  };
+  const c = new UpstreamClient(cfg);
+  assert.equal(c.transportKind, "ws");
+  assert.equal(c.url, "wss://gw.example.com/mcp/ws");
+});
+
 test("UpstreamClient: empty args defaults to [] on stdio", () => {
   const cfg: UpstreamConfig = {
     transport: "stdio",

--- a/mcp-server/src/federation/upstream.ts
+++ b/mcp-server/src/federation/upstream.ts
@@ -11,6 +11,12 @@
 //               channels. The classic MCP transport, useful when the
 //               upstream is a CLI-style server (omcp inspector-config,
 //               a local-only MCP, an in-cluster sidecar).
+//   - "ws"    — WebSocket to a ws:// or wss:// URL. Useful when the
+//               upstream gateway exposes MCP via the WS subprotocol
+//               rather than streamable HTTP. No bearer-auth header
+//               (the SDK transport only accepts a URL); operators
+//               that need auth append it as a query string or run
+//               the gateway behind an authenticating reverse proxy.
 //
 // Auth forwarding modes:
 //   - "none" — no auth header on outbound calls
@@ -23,6 +29,7 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { WebSocketClientTransport } from "@modelcontextprotocol/sdk/client/websocket.js";
 
 interface UpstreamCommonConfig {
   /** Stable source name (used in the namespace prefix + audit entries). */
@@ -56,7 +63,16 @@ export interface UpstreamStdioConfig extends UpstreamCommonConfig {
   env?: Record<string, string>;
 }
 
-export type UpstreamConfig = UpstreamHttpConfig | UpstreamStdioConfig;
+export interface UpstreamWebsocketConfig extends UpstreamCommonConfig {
+  transport: "ws";
+  /** Upstream WebSocket URL — `ws://` or `wss://`. */
+  url: string;
+}
+
+export type UpstreamConfig =
+  | UpstreamHttpConfig
+  | UpstreamStdioConfig
+  | UpstreamWebsocketConfig;
 
 export interface UpstreamToolInfo {
   /** Local namespaced name: `<prefix>.<upstreamName>`. */
@@ -79,7 +95,7 @@ export class UpstreamClient {
    *  so the UI doesn't have to special-case the transport kind. */
   readonly url: string;
   readonly namespacePrefix: string;
-  readonly transportKind: "http" | "stdio";
+  readonly transportKind: "http" | "stdio" | "ws";
   private cfg: UpstreamConfig;
   private client?: Client;
   // `unknown` because the SDK exposes a different concrete type per
@@ -95,8 +111,14 @@ export class UpstreamClient {
   constructor(cfg: UpstreamConfig) {
     this.cfg = cfg;
     this.name = cfg.name;
-    this.transportKind = cfg.transport === "stdio" ? "stdio" : "http";
-    this.url = this.transportKind === "http" ? (cfg as UpstreamHttpConfig).url : `stdio:${(cfg as UpstreamStdioConfig).command}`;
+    this.transportKind =
+      cfg.transport === "stdio" ? "stdio" :
+      cfg.transport === "ws" ? "ws" :
+      "http";
+    this.url =
+      this.transportKind === "stdio" ? `stdio:${(cfg as UpstreamStdioConfig).command}` :
+      this.transportKind === "ws" ? (cfg as UpstreamWebsocketConfig).url :
+      (cfg as UpstreamHttpConfig).url;
     this.namespacePrefix = cfg.namespacePrefix ?? cfg.name;
     this.refreshIntervalMs = cfg.refreshIntervalMs ?? 5 * 60 * 1000;
   }
@@ -200,6 +222,11 @@ export class UpstreamClient {
         args: cfg.args ?? [],
         env: cfg.env,
       });
+    }
+
+    if (this.transportKind === "ws") {
+      const cfg = this.cfg as UpstreamWebsocketConfig;
+      return new WebSocketClientTransport(new URL(cfg.url));
     }
 
     const cfg = this.cfg as UpstreamHttpConfig;

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1167,7 +1167,9 @@ async function main() {
     const client = new UpstreamClient(
       cfg.kind === "stdio"
         ? { transport: "stdio", name: cfg.name, command: cfg.command, args: cfg.args }
-        : { name: cfg.name, url: cfg.url, bearerToken: cfg.bearerToken },
+        : cfg.kind === "ws"
+          ? { transport: "ws", name: cfg.name, url: cfg.url }
+          : { name: cfg.name, url: cfg.url, bearerToken: cfg.bearerToken },
     );
     federationRegistry.add(client);
     client.connect().catch((err: unknown) => {


### PR DESCRIPTION
Closes the WS half of C6. Extends UpstreamConfig with UpstreamWebsocketConfig. `wss?://` URL parser branch. No bearer header on ws (SDK transport only accepts a URL). 4 new tests, 841/841 full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)