### PR TITLE
feat(q12): fire resource + prompt hooks at the MCP seam

### DIFF
--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -250,8 +250,12 @@ export default async function (
 ): Promise<{ allow: boolean; payload?: Record<string, unknown>; reason?: string }>;
 ```
 
-- `allow: false` short-circuits the chain. The caller sees an `isError`
-  `CallToolResult` carrying the `reason` text.
+- `allow: false` short-circuits the chain. The caller sees:
+  - **tool**: an `isError` `CallToolResult` carrying the `reason` text.
+  - **resource**: a `ReadResourceResult` with `isError: true` and one
+    `text/plain` contents entry holding the `reason`.
+  - **prompt**: a `GetPromptResult` with `isError: true`, the `reason`
+    as its description, and `messages: []`.
 - A returned `payload` REPLACES the current payload. Use this to redact
   / transform / enrich.
 - Throwing in `enforce` mode (the default) blocks the call with the

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -91,6 +91,7 @@ import { selfRegistry, withToolMetrics, apiRequests, mcpActiveSessions, auditDlq
 import { initOtel } from "./observability/otel.js";
 import { WebSocketServerTransport } from "./transport/websocket.js";
 import { HookRegistry } from "./sdk/hooks.js";
+import { wrapToolHandler, wrapResourceHandler, wrapPromptHandler } from "./sdk/hook-wrappers.js";
 import { UpstreamClient } from "./federation/upstream.js";
 import { FederationRegistry, parseFederationEnv } from "./federation/registry.js";
 import { buildCsrfIssuer, buildCsrfEnforcer, csrfBypassFromEnv } from "./auth/csrf.js";
@@ -381,43 +382,48 @@ async function main() {
   const registerTool = ((name: string, ...rest: unknown[]) => {
     if (!allowsTool(ctx.allowedTools, name)) return undefined as never;
     if (rest.length > 0 && typeof rest[rest.length - 1] === "function") {
-      const originalHandler = rest[rest.length - 1] as (...a: unknown[]) => unknown;
-      const wrappedHandler = async (args: unknown, extra: unknown) => {
-        const hookCtxBase = {
-          principal: ctx.principalId,
-          tenant: ctx.tenant || "default",
-          target: name,
-        };
-        const pre = await hookRegistry.fire(
-          "tool_pre_invoke",
-          { ...hookCtxBase, kind: "tool_pre_invoke" as const },
-          { args },
-        );
-        if (!pre.allow) {
-          return {
-            content: [{ type: "text", text: pre.reason ?? "denied by plugin hook" }],
-            isError: true,
-          };
-        }
-        const effectiveArgs = (pre.payload as { args?: unknown } | undefined)?.args ?? args;
-        const result = await originalHandler(effectiveArgs, extra);
-        const post = await hookRegistry.fire(
-          "tool_post_invoke",
-          { ...hookCtxBase, kind: "tool_post_invoke" as const },
-          { args: effectiveArgs, result },
-        );
-        if (!post.allow) {
-          return {
-            content: [{ type: "text", text: post.reason ?? "denied by plugin hook" }],
-            isError: true,
-          };
-        }
-        return (post.payload as { result?: unknown } | undefined)?.result ?? result;
-      };
-      rest[rest.length - 1] = wrappedHandler;
+      const originalHandler = rest[rest.length - 1] as (args: unknown, extra: unknown) => unknown;
+      rest[rest.length - 1] = wrapToolHandler(
+        hookRegistry,
+        { principal: ctx.principalId, tenant: ctx.tenant || "default", target: name },
+        originalHandler,
+      );
     }
     return (mcpServer.tool as unknown as (...a: unknown[]) => unknown)(name, ...rest) as never;
   }) as typeof mcpServer.tool;
+
+  // Q12: resource + prompt registrations get the same hook-fan-out
+  // treatment so a plugin's resource_pre_fetch / resource_post_fetch /
+  // prompt_pre_fetch / prompt_post_fetch handlers actually fire when
+  // a future resource/prompt registration lands. The wrappers stay
+  // thin pass-throughs when no hooks are registered (the OSS default).
+  // Wrappers are tested in mcp-server/src/sdk/hook-wrappers.test.ts.
+  const registerResource = ((name: string, ...rest: unknown[]) => {
+    if (rest.length > 0 && typeof rest[rest.length - 1] === "function") {
+      const originalHandler = rest[rest.length - 1] as (uri: URL | string, extra?: unknown) => unknown;
+      rest[rest.length - 1] = wrapResourceHandler(
+        hookRegistry,
+        { principal: ctx.principalId, tenant: ctx.tenant || "default", target: name },
+        originalHandler,
+      );
+    }
+    return (mcpServer.resource as unknown as (...a: unknown[]) => unknown)(name, ...rest) as never;
+  }) as typeof mcpServer.resource;
+
+  const registerPrompt = ((name: string, ...rest: unknown[]) => {
+    if (rest.length > 0 && typeof rest[rest.length - 1] === "function") {
+      const originalHandler = rest[rest.length - 1] as (args: unknown, extra?: unknown) => unknown;
+      rest[rest.length - 1] = wrapPromptHandler(
+        hookRegistry,
+        { principal: ctx.principalId, tenant: ctx.tenant || "default", target: name },
+        originalHandler,
+      );
+    }
+    return (mcpServer.prompt as unknown as (...a: unknown[]) => unknown)(name, ...rest) as never;
+  }) as typeof mcpServer.prompt;
+  // Suppress unused-warn — kept for the moment registrations land.
+  void registerResource;
+  void registerPrompt;
 
   registerTool(
     "list_sources",

--- a/mcp-server/src/sdk/hook-wrappers.test.ts
+++ b/mcp-server/src/sdk/hook-wrappers.test.ts
@@ -1,0 +1,227 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { HookRegistry } from "./hooks.js";
+import {
+  wrapToolHandler,
+  wrapResourceHandler,
+  wrapPromptHandler,
+  type HookCtxBase,
+} from "./hook-wrappers.js";
+
+const CTX: HookCtxBase = { principal: "alice", tenant: "default", target: "x" };
+
+// --- tool ------------------------------------------------------------
+
+test("wrapToolHandler: no hooks → pass-through", async () => {
+  const reg = new HookRegistry();
+  const wrapped = wrapToolHandler(reg, CTX, async (args) => ({ content: [{ type: "text", text: `got ${JSON.stringify(args)}` }] }));
+  const r = await wrapped({ q: 1 }, undefined);
+  assert.deepEqual(r, { content: [{ type: "text", text: 'got {"q":1}' }] });
+});
+
+test("wrapToolHandler: pre-invoke denial → isError + reason; handler NOT called", async () => {
+  const reg = new HookRegistry();
+  let called = false;
+  reg.register({
+    pluginName: "guard",
+    kind: "tool_pre_invoke",
+    handler: () => ({ allow: false, reason: "blocked" }),
+  });
+  const wrapped = wrapToolHandler(reg, CTX, async () => {
+    called = true;
+    return { content: [] };
+  });
+  const r = await wrapped({}, undefined);
+  assert.equal(called, false);
+  assert.deepEqual(r, { content: [{ type: "text", text: "blocked" }], isError: true });
+});
+
+test("wrapToolHandler: pre-invoke args mutation flows into handler", async () => {
+  const reg = new HookRegistry();
+  reg.register({
+    pluginName: "enrich",
+    kind: "tool_pre_invoke",
+    handler: (_ctx, payload) => ({
+      allow: true,
+      payload: { args: { ...(payload.args as object), injected: true } },
+    }),
+  });
+  let observedArgs: unknown;
+  const wrapped = wrapToolHandler(reg, CTX, async (args) => {
+    observedArgs = args;
+    return { content: [] };
+  });
+  await wrapped({ original: 1 }, undefined);
+  assert.deepEqual(observedArgs, { original: 1, injected: true });
+});
+
+test("wrapToolHandler: post-invoke result mutation flows back to caller", async () => {
+  const reg = new HookRegistry();
+  reg.register({
+    pluginName: "redact",
+    kind: "tool_post_invoke",
+    handler: () => ({ allow: true, payload: { result: { content: [{ type: "text", text: "REDACTED" }] } } }),
+  });
+  const wrapped = wrapToolHandler(reg, CTX, async () => ({
+    content: [{ type: "text", text: "secret-value" }],
+  }));
+  const r = await wrapped({}, undefined);
+  assert.deepEqual(r, { content: [{ type: "text", text: "REDACTED" }] });
+});
+
+// --- resource --------------------------------------------------------
+
+test("wrapResourceHandler: no hooks → pass-through with original URI", async () => {
+  const reg = new HookRegistry();
+  let observed: unknown;
+  const wrapped = wrapResourceHandler(reg, CTX, async (uri) => {
+    observed = uri;
+    return { contents: [{ uri: String(uri), text: "hi" }] };
+  });
+  const r = await wrapped("file:///a", undefined);
+  assert.equal(observed, "file:///a");
+  assert.deepEqual(r, { contents: [{ uri: "file:///a", text: "hi" }] });
+});
+
+test("wrapResourceHandler: pre-fetch denial returns structured error; handler NOT called", async () => {
+  const reg = new HookRegistry();
+  let called = false;
+  reg.register({
+    pluginName: "guard",
+    kind: "resource_pre_fetch",
+    handler: () => ({ allow: false, reason: "forbidden uri" }),
+  });
+  const wrapped = wrapResourceHandler(reg, CTX, async () => {
+    called = true;
+    return { contents: [] };
+  });
+  const r = await wrapped("file:///secret", undefined);
+  assert.equal(called, false);
+  assert.deepEqual(r, {
+    contents: [{ uri: "file:///secret", mimeType: "text/plain", text: "forbidden uri" }],
+    isError: true,
+  });
+});
+
+test("wrapResourceHandler: pre-fetch URI mutation flows into handler", async () => {
+  const reg = new HookRegistry();
+  reg.register({
+    pluginName: "canon",
+    kind: "resource_pre_fetch",
+    handler: () => ({ allow: true, payload: { uri: "file:///canonical" } }),
+  });
+  let observed: unknown;
+  const wrapped = wrapResourceHandler(reg, CTX, async (uri) => {
+    observed = uri;
+    return { contents: [{ uri: String(uri), text: "ok" }] };
+  });
+  await wrapped("file:///raw", undefined);
+  assert.equal(observed, "file:///canonical");
+});
+
+test("wrapResourceHandler: URL instance preserved across mutation", async () => {
+  const reg = new HookRegistry();
+  reg.register({
+    pluginName: "canon",
+    kind: "resource_pre_fetch",
+    handler: () => ({ allow: true, payload: { uri: "https://new.example/path" } }),
+  });
+  let observed: unknown;
+  const wrapped = wrapResourceHandler(reg, CTX, async (uri) => {
+    observed = uri;
+    return { contents: [{ uri: String(uri), text: "ok" }] };
+  });
+  await wrapped(new URL("https://old.example/path"), undefined);
+  assert.ok(observed instanceof URL, "mutated URI should still be a URL when caller passed one");
+  assert.equal(String(observed), "https://new.example/path");
+});
+
+test("wrapResourceHandler: post-fetch contents replacement", async () => {
+  const reg = new HookRegistry();
+  reg.register({
+    pluginName: "censor",
+    kind: "resource_post_fetch",
+    handler: () => ({ allow: true, payload: { contents: [{ uri: "file:///x", text: "[censored]" }] } }),
+  });
+  const wrapped = wrapResourceHandler(reg, CTX, async () => ({
+    contents: [{ uri: "file:///x", text: "raw" }],
+    _meta: { kept: true },
+  }));
+  const r = (await wrapped("file:///x", undefined)) as { contents: unknown; _meta: unknown };
+  assert.deepEqual(r.contents, [{ uri: "file:///x", text: "[censored]" }]);
+  // Other top-level keys survive the mutation
+  assert.deepEqual(r._meta, { kept: true });
+});
+
+// --- prompt ----------------------------------------------------------
+
+test("wrapPromptHandler: no hooks → pass-through", async () => {
+  const reg = new HookRegistry();
+  const wrapped = wrapPromptHandler(reg, { ...CTX, target: "greet" }, async (args) => ({
+    description: "ok",
+    messages: [{ role: "user", content: { type: "text", text: `hi ${JSON.stringify(args)}` } }],
+  }));
+  const r = await wrapped({ who: "world" }, undefined);
+  assert.deepEqual(r, {
+    description: "ok",
+    messages: [{ role: "user", content: { type: "text", text: 'hi {"who":"world"}' } }],
+  });
+});
+
+test("wrapPromptHandler: pre-fetch denial returns structured error; handler NOT called", async () => {
+  const reg = new HookRegistry();
+  let called = false;
+  reg.register({
+    pluginName: "guard",
+    kind: "prompt_pre_fetch",
+    handler: () => ({ allow: false, reason: "denied" }),
+  });
+  const wrapped = wrapPromptHandler(reg, CTX, async () => {
+    called = true;
+    return { description: "x", messages: [] };
+  });
+  const r = await wrapped({}, undefined);
+  assert.equal(called, false);
+  assert.deepEqual(r, { description: "denied", messages: [], isError: true });
+});
+
+test("wrapPromptHandler: pre-fetch arguments mutation flows into handler", async () => {
+  const reg = new HookRegistry();
+  reg.register({
+    pluginName: "augment",
+    kind: "prompt_pre_fetch",
+    handler: (_ctx, payload) => ({
+      allow: true,
+      payload: { name: (payload as { name: string }).name, arguments: { ...(payload.arguments as object), extra: 1 } },
+    }),
+  });
+  let observed: unknown;
+  const wrapped = wrapPromptHandler(reg, CTX, async (args) => {
+    observed = args;
+    return { description: "", messages: [] };
+  });
+  await wrapped({ original: true }, undefined);
+  assert.deepEqual(observed, { original: true, extra: 1 });
+});
+
+test("wrapPromptHandler: post-fetch messages replacement", async () => {
+  const reg = new HookRegistry();
+  reg.register({
+    pluginName: "rewrite",
+    kind: "prompt_post_fetch",
+    handler: () => ({
+      allow: true,
+      payload: {
+        messages: [{ role: "system", content: { type: "text", text: "rewritten" } }],
+      },
+    }),
+  });
+  const wrapped = wrapPromptHandler(reg, CTX, async () => ({
+    description: "ok",
+    messages: [{ role: "user", content: { type: "text", text: "raw" } }],
+  }));
+  const r = (await wrapped({}, undefined)) as { description: string; messages: unknown };
+  assert.equal(r.description, "ok");
+  assert.deepEqual(r.messages, [{ role: "system", content: { type: "text", text: "rewritten" } }]);
+});

--- a/mcp-server/src/sdk/hook-wrappers.ts
+++ b/mcp-server/src/sdk/hook-wrappers.ts
@@ -1,0 +1,164 @@
+// Reusable hook-fire wrappers around the MCP SDK's tool / resource /
+// prompt callbacks.
+//
+// Each wrapper fires the matching `*_pre_*` hook before the original
+// handler runs and `*_post_*` after it returns. Hooks can:
+//   - deny the call (allow:false → caller sees a structured error)
+//   - mutate the payload before dispatch (args / uri / arguments)
+//   - mutate the result before it reaches the caller (contents /
+//     messages / tool result)
+//
+// When no hooks are registered (the default in the OSS demo) the
+// wrappers are thin pass-throughs.
+//
+// The wrappers are pure — they take the HookRegistry + a ctx object
+// and a handler, and return the wrapped handler. They never touch
+// the McpServer SDK directly, so they're trivially unit-testable.
+
+import type { HookContext, HookRegistry, HookResult } from "./hooks.js";
+
+export interface HookCtxBase {
+  /** Principal sub identifier from the caller's RequestContext. */
+  principal: string;
+  /** Tenant the caller is acting under. */
+  tenant: string;
+  /** Tool / resource / prompt target identifier. */
+  target: string;
+}
+
+type ToolHandler = (args: unknown, extra: unknown) => Promise<unknown> | unknown;
+type ResourceHandler = (uri: URL | string, extra?: unknown) => Promise<unknown> | unknown;
+type PromptHandler = (args: unknown, extra?: unknown) => Promise<unknown> | unknown;
+
+/** Shape an MCP tool dispatch returns on a hook denial. */
+function deniedToolResult(reason?: string): unknown {
+  return {
+    content: [{ type: "text", text: reason ?? "denied by plugin hook" }],
+    isError: true,
+  };
+}
+
+/** Shape an MCP resource read returns on a hook denial. */
+function deniedResourceResult(uri: string, reason?: string): unknown {
+  return {
+    contents: [
+      { uri, mimeType: "text/plain", text: reason ?? "denied by plugin hook" },
+    ],
+    isError: true,
+  };
+}
+
+/** Shape an MCP prompt fetch returns on a hook denial. */
+function deniedPromptResult(reason?: string): unknown {
+  return {
+    description: reason ?? "denied by plugin hook",
+    messages: [],
+    isError: true,
+  };
+}
+
+/**
+ * Wrap a tool handler with `tool_pre_invoke` + `tool_post_invoke`
+ * hooks. Existing wire-up in index.ts is inlined; extracting it here
+ * for parity with the new resource + prompt wrappers and so tests
+ * can exercise the path without spinning up the full server.
+ */
+export function wrapToolHandler(
+  registry: HookRegistry,
+  ctx: HookCtxBase,
+  handler: ToolHandler,
+): ToolHandler {
+  return async (args, extra) => {
+    const pre = await registry.fire(
+      "tool_pre_invoke",
+      { ...ctx, kind: "tool_pre_invoke" as const } satisfies HookContext,
+      { args },
+    );
+    if (!pre.allow) return deniedToolResult(pre.reason);
+    const effectiveArgs = (pre.payload as { args?: unknown } | undefined)?.args ?? args;
+    const result = await handler(effectiveArgs, extra);
+    const post = await registry.fire(
+      "tool_post_invoke",
+      { ...ctx, kind: "tool_post_invoke" as const } satisfies HookContext,
+      { args: effectiveArgs, result },
+    );
+    if (!post.allow) return deniedToolResult(post.reason);
+    return (post.payload as { result?: unknown } | undefined)?.result ?? result;
+  };
+}
+
+/**
+ * Wrap a resource readCallback with `resource_pre_fetch` +
+ * `resource_post_fetch` hooks.
+ *
+ * Pre-fetch sees `{uri}`; the payload's `uri` can be mutated (e.g. a
+ * canonicalising plugin) and the override flows into the original
+ * handler. Post-fetch sees `{uri, contents}`; the post-payload's
+ * `contents` (if set) replaces the response.
+ */
+export function wrapResourceHandler(
+  registry: HookRegistry,
+  ctx: HookCtxBase,
+  handler: ResourceHandler,
+): ResourceHandler {
+  return async (uri, extra) => {
+    const uriStr = uri instanceof URL ? uri.toString() : String(uri);
+    const pre = await registry.fire(
+      "resource_pre_fetch",
+      { ...ctx, kind: "resource_pre_fetch" as const } satisfies HookContext,
+      { uri: uriStr },
+    );
+    if (!pre.allow) return deniedResourceResult(uriStr, pre.reason);
+    const effectiveUri = (pre.payload as { uri?: string } | undefined)?.uri ?? uriStr;
+    // Preserve URL vs string typing the SDK expects.
+    const forwardedUri = uri instanceof URL && effectiveUri !== uriStr ? new URL(effectiveUri) : (uri instanceof URL ? uri : effectiveUri);
+    const result = await handler(forwardedUri, extra);
+    const post = await registry.fire(
+      "resource_post_fetch",
+      { ...ctx, kind: "resource_post_fetch" as const } satisfies HookContext,
+      { uri: effectiveUri, contents: (result as { contents?: unknown } | undefined)?.contents },
+    );
+    if (!post.allow) return deniedResourceResult(effectiveUri, post.reason);
+    const overrideContents = (post.payload as { contents?: unknown } | undefined)?.contents;
+    if (overrideContents !== undefined && result && typeof result === "object") {
+      return { ...(result as Record<string, unknown>), contents: overrideContents };
+    }
+    return result;
+  };
+}
+
+/**
+ * Wrap a prompt callback with `prompt_pre_fetch` + `prompt_post_fetch`
+ * hooks.
+ *
+ * Pre-fetch sees `{name, arguments}`; the override flows in. Post-fetch
+ * sees `{name, arguments, messages}`; the post-payload's `messages`
+ * (if set) replaces the response messages.
+ */
+export function wrapPromptHandler(
+  registry: HookRegistry,
+  ctx: HookCtxBase,
+  handler: PromptHandler,
+): PromptHandler {
+  return async (args, extra) => {
+    const pre = await registry.fire(
+      "prompt_pre_fetch",
+      { ...ctx, kind: "prompt_pre_fetch" as const } satisfies HookContext,
+      { name: ctx.target, arguments: args },
+    );
+    if (!pre.allow) return deniedPromptResult(pre.reason);
+    const effectiveArgs = (pre.payload as { arguments?: unknown } | undefined)?.arguments ?? args;
+    const result = await handler(effectiveArgs, extra);
+    const post = await registry.fire(
+      "prompt_post_fetch",
+      { ...ctx, kind: "prompt_post_fetch" as const } satisfies HookContext,
+      { name: ctx.target, arguments: effectiveArgs, messages: (result as { messages?: unknown } | undefined)?.messages },
+    );
+    if (!post.allow) return deniedPromptResult(post.reason);
+    const overrideMessages = (post.payload as { messages?: unknown } | undefined)?.messages;
+    if (overrideMessages !== undefined && result && typeof result === "object") {
+      return { ...(result as Record<string, unknown>), messages: overrideMessages };
+    }
+    return result;
+  };
+}


### PR DESCRIPTION
Extracts wrapToolHandler into a reusable helper alongside wrapResourceHandler + wrapPromptHandler. Adds registerResource + registerPrompt analogs to createMcpServer. 13 new tests. 873/873 full suite. Tool wrapper behaviour identical; resource + prompt hooks now actually fire when registrations land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)