### PR TITLE
feat(q14): SCIM PATCH add/remove on members[] + emails[]

### DIFF
--- a/docs/scim-provisioning.md
+++ b/docs/scim-provisioning.md
@@ -118,15 +118,37 @@ single-key snapshot model matches SCIM's source-of-truth
 semantics. Within a replica, persists are serialised so two
 concurrent route handlers can't race each other to the write.
 
+## PATCH operations
+
+The `PATCH /scim/v2/{Users,Groups}/:id` endpoint supports the
+RFC 7644 §3.5.2 PatchOp forms the major IdPs emit:
+
+| op | path | effect |
+|---|---|---|
+| `replace` | _(none)_ | merge the allow-listed attributes in `value` |
+| `replace` | `displayName` | set that attribute |
+| `add` | _(none)_ | merge `value`; array attrs append (deduped), scalars set |
+| `add` | `members` | append member(s) to the group (deduped by `value`) |
+| `remove` | `members[value eq "<id>"]` | drop the matching member |
+| `remove` | `members` | clear the whole array |
+
+`members` and `emails` are the multi-valued attributes that honour
+element add/remove + the `[sub eq "x"]` filter segment. Chained ops
+in one request compose against the running value (Entra sends an
+`add` + a filtered `remove` in a single PatchOp body). Every
+attribute name written is gated through an allow-list, and filter
+sub-attributes are read-only, so a crafted path can't reach
+`__proto__` / `constructor` (a path that names a non-allow-listed
+attribute is skipped fail-closed).
+
 ## Scope split — deferred to v3.x
 
-- Filter / search support (Entra and Okta both support push-only
-  without filter; needed if you want Pull provisioning from a
-  third-party admin).
-- Add / Remove patch ops on members[] / emails[] arrays (Q14
-  ships this; the file/redis backends already store the data
-  correctly — Q14 only adds the parser for the SCIM 2.0 op
-  forms).
+- Filter / search support on the collection endpoints (Entra and
+  Okta both support push-only without filter; needed if you want
+  Pull provisioning from a third-party admin).
+- `replace` of a single member's sub-attribute via a filtered path
+  (`members[value eq "x"].display`) — rare; the IdPs remove + re-add
+  instead.
 - UI "Provisioning" sub-tab under Access Control showing recent
   SCIM operations + the active group→role map.
 - Full SCIM 2.0 compliance test suite (Q15 ships this).

--- a/mcp-server/src/scim/patch-ops.test.ts
+++ b/mcp-server/src/scim/patch-ops.test.ts
@@ -1,0 +1,146 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { applyPatchOps } from "./routes.js";
+import type { ScimGroup, ScimPatchRequest } from "./types.js";
+
+function group(members: Array<{ value: string; display?: string }> = []): ScimGroup {
+  return {
+    schemas: ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+    id: "g1",
+    displayName: "team",
+    members,
+    meta: { resourceType: "Group", created: "2026-06-06T00:00:00Z", lastModified: "2026-06-06T00:00:00Z" },
+  };
+}
+
+function patch(...ops: ScimPatchRequest["Operations"]): ScimPatchRequest {
+  return { schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"], Operations: ops };
+}
+
+// --- replace (existing behaviour preserved) --------------------------
+
+test("replace with no path merges allow-listed keys", () => {
+  const out = applyPatchOps(group(), patch({ op: "replace", value: { displayName: "renamed", externalId: "x" } }));
+  assert.equal(out.displayName, "renamed");
+  assert.equal((out as Record<string, unknown>).externalId, "x");
+});
+
+test("replace with path sets that attribute", () => {
+  const out = applyPatchOps(group(), patch({ op: "replace", path: "displayName", value: "n2" }));
+  assert.equal(out.displayName, "n2");
+});
+
+test("replace drops non-allowlisted keys (proto-pollution guard)", () => {
+  const out = applyPatchOps(group(), patch({ op: "replace", value: { __proto__: { polluted: true }, constructor: 1, displayName: "ok" } }));
+  assert.equal(out.displayName, "ok");
+  assert.equal(({} as Record<string, unknown>).polluted, undefined);
+  assert.equal(Object.prototype.hasOwnProperty.call(out, "__proto__"), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(out, "constructor"), false);
+});
+
+// --- add members -----------------------------------------------------
+
+test("add appends a member to an empty group", () => {
+  const out = applyPatchOps(group(), patch({ op: "add", path: "members", value: [{ value: "u1", display: "Alice" }] }));
+  assert.deepEqual(out.members, [{ value: "u1", display: "Alice" }]);
+});
+
+test("add appends to existing members and dedups by value", () => {
+  const out = applyPatchOps(
+    group([{ value: "u1" }]),
+    patch({ op: "add", path: "members", value: [{ value: "u1" }, { value: "u2" }] }),
+  );
+  assert.deepEqual((out.members as Array<{ value: string }>).map((m) => m.value), ["u1", "u2"]);
+});
+
+test("add accepts a single (non-array) value", () => {
+  const out = applyPatchOps(group([{ value: "u1" }]), patch({ op: "add", path: "members", value: { value: "u2" } }));
+  assert.deepEqual((out.members as Array<{ value: string }>).map((m) => m.value), ["u1", "u2"]);
+});
+
+test("pathless add appends array attrs + sets scalars", () => {
+  const out = applyPatchOps(
+    group([{ value: "u1" }]),
+    patch({ op: "add", value: { members: [{ value: "u2" }], displayName: "renamed" } }),
+  );
+  assert.deepEqual((out.members as Array<{ value: string }>).map((m) => m.value), ["u1", "u2"]);
+  assert.equal(out.displayName, "renamed");
+});
+
+// --- remove members --------------------------------------------------
+
+test("remove with a filter drops the matching member", () => {
+  const out = applyPatchOps(
+    group([{ value: "u1" }, { value: "u2" }, { value: "u3" }]),
+    patch({ op: "remove", path: 'members[value eq "u2"]' }),
+  );
+  assert.deepEqual((out.members as Array<{ value: string }>).map((m) => m.value), ["u1", "u3"]);
+});
+
+test("remove with a non-matching filter is a no-op on contents", () => {
+  const out = applyPatchOps(
+    group([{ value: "u1" }]),
+    patch({ op: "remove", path: 'members[value eq "ghost"]' }),
+  );
+  assert.deepEqual((out.members as Array<{ value: string }>).map((m) => m.value), ["u1"]);
+});
+
+test("remove of the whole members attr clears it", () => {
+  const out = applyPatchOps(group([{ value: "u1" }, { value: "u2" }]), patch({ op: "remove", path: "members" }));
+  assert.deepEqual(out.members, []);
+});
+
+// --- chained ops in one request (Entra-style) ------------------------
+
+test("add then remove in one request compose against the working value", () => {
+  const out = applyPatchOps(
+    group([{ value: "u1" }]),
+    patch(
+      { op: "add", path: "members", value: [{ value: "u2" }, { value: "u3" }] },
+      { op: "remove", path: 'members[value eq "u1"]' },
+    ),
+  );
+  assert.deepEqual((out.members as Array<{ value: string }>).map((m) => m.value), ["u2", "u3"]);
+});
+
+// --- security: filtered paths can't pollute --------------------------
+
+test("crafted __proto__ filter path is rejected (fail-closed no-op), no pollution", () => {
+  const out = applyPatchOps(
+    group([{ value: "u1" }]),
+    patch({ op: "remove", path: 'members[__proto__ eq "x"]' }),
+  );
+  // The sub-attribute regex requires a leading letter, so this path
+  // doesn't parse as a filter and isn't a bare allow-listed attr —
+  // the op is skipped entirely. No members key is emitted (no change)
+  // and nothing is polluted.
+  assert.equal(Object.prototype.hasOwnProperty.call(out, "members"), false);
+  assert.equal(({} as Record<string, unknown>).x, undefined);
+});
+
+test("add to a non-allowlisted path is ignored", () => {
+  const out = applyPatchOps(group(), patch({ op: "add", path: "__proto__", value: { polluted: true } }));
+  assert.equal(Object.keys(out).length, 0);
+  assert.equal(({} as Record<string, unknown>).polluted, undefined);
+});
+
+// --- emails array (same machinery) -----------------------------------
+
+test("add + remove works on emails too", () => {
+  const user = {
+    schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+    id: "u1",
+    userName: "a@x",
+    emails: [{ value: "a@x", primary: true }],
+    meta: { resourceType: "User" as const, created: "2026-06-06T00:00:00Z", lastModified: "2026-06-06T00:00:00Z" },
+  };
+  const added = applyPatchOps(user, patch({ op: "add", path: "emails", value: [{ value: "a2@x" }] }));
+  assert.deepEqual((added.emails as Array<{ value: string }>).map((e) => e.value), ["a@x", "a2@x"]);
+  const removed = applyPatchOps(user, patch({ op: "remove", path: 'emails[value eq "a@x"]' }));
+  assert.deepEqual((removed.emails as Array<{ value: string }>).map((e) => e.value), []);
+});
+
+test("missing target resource throws", () => {
+  assert.throws(() => applyPatchOps(undefined, patch({ op: "add", path: "members", value: [] })), /not found/);
+});

--- a/mcp-server/src/scim/routes.ts
+++ b/mcp-server/src/scim/routes.ts
@@ -238,12 +238,6 @@ function withGroups(u: ScimUser, store: IScimStore): ScimUser {
   return { ...u, groups: store.groupsContaining(u.id) };
 }
 
-/** Translate a SCIM PatchOp into a partial resource patch. Minimal:
- *  we accept `op: "replace"` with no path (whole-resource merge) or
- *  with a single-segment path naming a top-level attribute. `add` and
- *  `remove` for members/emails arrays are a follow-up — the
- *  Entra/Okta provisioning checklists exercise replace-only on the
- *  attributes we expose. */
 // Allow-list of attribute names patchable via SCIM PatchOp.
 // `applyPatchOps` writes into a plain object using a user-supplied
 // path/key — every key is gated through this set so a malicious
@@ -257,32 +251,142 @@ function safePatchKey(k: unknown): k is string {
   return typeof k === "string" && PATCH_ALLOWED_ATTRS.has(k);
 }
 
-/** Translate a SCIM PatchOp into a partial resource patch. Minimal:
- *  we accept `op: "replace"` with no path (whole-resource merge) or
- *  with a single-segment path naming a top-level attribute. `add` and
- *  `remove` for members/emails arrays are a follow-up — the
- *  Entra/Okta provisioning checklists exercise replace-only on the
- *  attributes we expose.
+// Multi-valued attributes that support add/remove element ops + filter
+// segments. Everything else is treated as a scalar (replace/set).
+const PATCH_ARRAY_ATTRS: ReadonlySet<string> = new Set(["members", "emails", "groups"]);
+
+/** Parse a PatchOp `path` into {attr, filter?}. Supports a bare
+ *  attribute (`members`) and a single `eq` filter segment
+ *  (`members[value eq "abc"]`). Returns null for anything that
+ *  doesn't name an allow-listed attribute or that we don't model —
+ *  the caller skips those ops (fail-closed). The sub-attribute in the
+ *  filter is only ever READ for comparison, never written, so it
+ *  can't drive prototype pollution. */
+function parsePatchPath(path: string): { attr: string; filter?: { sub: string; val: string } } | null {
+  const filterMatch = /^([A-Za-z][\w]*)\[\s*([A-Za-z][\w]*)\s+eq\s+"([^"]*)"\s*\]$/.exec(path);
+  if (filterMatch) {
+    const attr = filterMatch[1];
+    if (!safePatchKey(attr)) return null;
+    return { attr, filter: { sub: filterMatch[2], val: filterMatch[3] } };
+  }
+  if (safePatchKey(path)) return { attr: path };
+  return null;
+}
+
+// Always returns a FRESH array — never the caller's reference — so the
+// add/remove machinery can push/filter without mutating the current
+// resource in place (which would corrupt it across chained ops or
+// repeated calls).
+function asArray(v: unknown): unknown[] {
+  if (Array.isArray(v)) return v.slice();
+  if (v == null) return [];
+  return [v];
+}
+
+/** Element identity for dedup/removal on multi-valued attrs. SCIM
+ *  members/emails carry a `value` key; fall back to JSON equality. */
+function elemKey(e: unknown): string {
+  if (e && typeof e === "object" && "value" in (e as Record<string, unknown>)) {
+    return String((e as Record<string, unknown>).value);
+  }
+  return JSON.stringify(e);
+}
+
+/** Translate a SCIM PatchOp request into a partial resource patch.
+ *
+ *  Supported (RFC 7644 §3.5.2):
+ *   - replace, no path        → whole-resource merge of allow-listed keys
+ *   - replace, path=attr      → set that attribute
+ *   - add, no path            → merge; array attrs append (deduped), scalars set
+ *   - add, path=arrayAttr     → append value(s) to the array (deduped)
+ *   - add, path=scalarAttr    → set
+ *   - remove, path=arrayAttr  → clear the array
+ *   - remove, path=arrayAttr[sub eq "x"] → drop matching elements
+ *   - remove, path=scalarAttr → clear the attribute (set undefined)
+ *
+ *  Array ops are computed against the CURRENT resource value and the
+ *  full resulting array is returned in `out` (the store merges
+ *  shallowly, so out[attr] replaces current[attr] wholesale).
  *
  *  Every property name written into `out` is gated through
  *  `PATCH_ALLOWED_ATTRS` so a SCIM client can't inject __proto__ /
  *  constructor / arbitrary fields (CodeQL js/remote-property-injection +
- *  js/prototype-polluting-assignment). */
-function applyPatchOps<T extends { id: string }>(current: T | undefined, patch: ScimPatchRequest): Partial<T> {
+ *  js/prototype-polluting-assignment). Filter sub-attributes are
+ *  read-only. */
+export function applyPatchOps<T extends { id: string }>(current: T | undefined, patch: ScimPatchRequest): Partial<T> {
   if (!current) throw new ScimNotFoundError("target resource not found");
   if (!patch?.Operations || !Array.isArray(patch.Operations)) return {};
+  const cur = current as unknown as Record<string, unknown>;
   const out: Record<string, unknown> = {};
+  // Read the working value for an attr: prefer an in-progress value
+  // from a prior op in this same request, else the current resource.
+  const readAttr = (attr: string): unknown => (attr in out ? out[attr] : cur[attr]);
+
   for (const op of patch.Operations) {
-    if (op.op !== "replace") continue; // skip add/remove for F21a
-    if (!op.path) {
-      if (op.value && typeof op.value === "object") {
-        for (const [k, v] of Object.entries(op.value as Record<string, unknown>)) {
-          if (safePatchKey(k)) out[k] = v;
+    const verb = (op.op || "").toLowerCase();
+
+    if (verb === "replace") {
+      if (!op.path) {
+        if (op.value && typeof op.value === "object") {
+          for (const [k, v] of Object.entries(op.value as Record<string, unknown>)) {
+            if (safePatchKey(k)) out[k] = v;
+          }
         }
+        continue;
+      }
+      const parsed = parsePatchPath(op.path);
+      if (parsed && !parsed.filter) out[parsed.attr] = op.value;
+      continue;
+    }
+
+    if (verb === "add") {
+      if (!op.path) {
+        if (op.value && typeof op.value === "object") {
+          for (const [k, v] of Object.entries(op.value as Record<string, unknown>)) {
+            if (!safePatchKey(k)) continue;
+            if (PATCH_ARRAY_ATTRS.has(k)) {
+              const existing = asArray(readAttr(k));
+              const seen = new Set(existing.map(elemKey));
+              for (const item of asArray(v)) { if (!seen.has(elemKey(item))) { existing.push(item); seen.add(elemKey(item)); } }
+              out[k] = existing;
+            } else {
+              out[k] = v;
+            }
+          }
+        }
+        continue;
+      }
+      const parsed = parsePatchPath(op.path);
+      if (!parsed || parsed.filter) continue;
+      if (PATCH_ARRAY_ATTRS.has(parsed.attr)) {
+        const existing = asArray(readAttr(parsed.attr));
+        const seen = new Set(existing.map(elemKey));
+        for (const item of asArray(op.value)) { if (!seen.has(elemKey(item))) { existing.push(item); seen.add(elemKey(item)); } }
+        out[parsed.attr] = existing;
+      } else {
+        out[parsed.attr] = op.value;
       }
       continue;
     }
-    if (safePatchKey(op.path)) out[op.path] = op.value;
+
+    if (verb === "remove") {
+      if (!op.path) continue; // remove with no path is a no-op (nothing to target)
+      const parsed = parsePatchPath(op.path);
+      if (!parsed) continue;
+      if (parsed.filter && PATCH_ARRAY_ATTRS.has(parsed.attr)) {
+        const existing = asArray(readAttr(parsed.attr));
+        const { sub, val } = parsed.filter;
+        out[parsed.attr] = existing.filter((e) => {
+          const ev = e && typeof e === "object" ? (e as Record<string, unknown>)[sub] : undefined;
+          return String(ev) !== val;
+        });
+      } else if (PATCH_ARRAY_ATTRS.has(parsed.attr)) {
+        out[parsed.attr] = [];
+      } else {
+        out[parsed.attr] = undefined;
+      }
+      continue;
+    }
   }
   return out as Partial<T>;
 }


### PR DESCRIPTION
applyPatchOps gains RFC 7644 §3.5.2 add/remove on multi-valued attrs (members/emails/groups) incl. `members[value eq "x"]` filter paths. Dedup on add, fail-closed proto-pollution guard, fresh-array copy (no in-place mutation), chained-op composition. 15 new tests, 888/888 suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)