### PR TITLE
chore(q16): SDK sync tooling — kill vendored-copy hand-maintenance

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -41,6 +41,8 @@ jobs:
         run: npm run build
 
       - name: Vendor parity check (packages/sdk mirrors mcp-server/src/sdk)
+        # Same check as `make sdk-parity`. If this fails, run
+        # `make sdk-sync` locally to regenerate the mirror, then commit.
         run: |
           diff -q mcp-server/src/sdk/hooks.ts packages/sdk/src/hooks.ts
           diff -q mcp-server/src/sdk/manifest-schema.ts packages/sdk/src/manifest-schema.ts

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,23 @@ lint: ## helm lint + tsc --noEmit
 	docker run --rm -w /app -v "$(PWD)/mcp-server:/app" node:20-alpine \
 	  sh -c "npm install --silent --no-audit --no-fund && npx tsc --noEmit"
 
+# The published SDK (packages/sdk) vendors two files from the
+# canonical in-tree copy (mcp-server/src/sdk): hooks.ts and
+# manifest-schema.ts. The package's index.ts + cli/ are
+# package-specific and NOT mirrored. `sdk-sync` regenerates the
+# mirror from the canonical source so you never hand-copy; the
+# sdk-publish workflow's `diff -q` parity check is the CI verifier.
+# Run this after editing either canonical file, then commit both.
+sdk-sync: ## Copy the canonical SDK files into the published packages/sdk mirror
+	cp mcp-server/src/sdk/hooks.ts           packages/sdk/src/hooks.ts
+	cp mcp-server/src/sdk/manifest-schema.ts packages/sdk/src/manifest-schema.ts
+	@echo "synced hooks.ts + manifest-schema.ts → packages/sdk/src/"
+
+sdk-parity: ## Verify the packages/sdk mirror matches the canonical SDK (same check as CI)
+	diff -q mcp-server/src/sdk/hooks.ts           packages/sdk/src/hooks.ts
+	diff -q mcp-server/src/sdk/manifest-schema.ts packages/sdk/src/manifest-schema.ts
+	@echo "SDK parity OK"
+
 # Proves the server boots and serves health with NO internet and NO sources
 # configured — the "verifiable offline mode" guarantee, end to end.
 test-offline: build ## Boot the image on an egress-blocked network and assert healthy

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -35,6 +35,31 @@ observability-mcp `2.x`; the manifest `schemaVersion` is the
 authoritative compat marker — see
 [`docs/plugin-architecture.md`](https://github.com/ThoTischner/observability-mcp/blob/main/docs/plugin-architecture.md).
 
+## Source layout (for contributors)
+
+This package vendors two files from the gateway's canonical in-tree
+SDK so the published types stay byte-identical to what the server
+actually enforces:
+
+| file | source of truth |
+|---|---|
+| `src/hooks.ts` | `mcp-server/src/sdk/hooks.ts` (canonical) |
+| `src/manifest-schema.ts` | `mcp-server/src/sdk/manifest-schema.ts` (canonical) |
+| `src/index.ts` | package-specific (re-export barrel + npm header) |
+| `src/cli/` | package-specific (the `create-connector` scaffolder) |
+
+After editing either canonical file, run **`make sdk-sync`** to
+regenerate the mirror, then commit both. The `sdk-publish` workflow
+runs the same `diff -q` parity check (`make sdk-parity`) as a required
+gate, so a forgotten sync can't ship.
+
+> The gateway is **not** wired to import this package as a workspace
+> dependency: `mcp-server` builds in an isolated Docker context
+> (`COPY mcp-server/ .`) and the project is Docker-first (no host
+> `npm install`), so a monorepo workspace link would add build-context
+> coupling for no runtime gain. Vendoring + the parity gate is the
+> deliberate trade.
+
 ## License
 
 Apache-2.0


### PR DESCRIPTION
Q16 scoped down from full npm-workspace (empirically breaks `npm ci` in packages/sdk → breaks sdk-publish gate; zero value in Docker-isolated, host-no-install repo) to the genuinely useful part: `make sdk-sync` / `make sdk-parity` + documented vendoring contract. Vendoring + CI parity gate stay (the right trade). Docs/tooling only, no pipeline behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)