### PR TITLE
feat(q18): per-account login lockout with progressive backoff

### DIFF
--- a/docs/auth-basic.md
+++ b/docs/auth-basic.md
@@ -77,6 +77,11 @@ badge appears in the masthead.
 | `OMCP_USERS_FILE` | basic only | absolute path to a users JSON file (format above) |
 | `OMCP_SESSION_SECRET` | recommended | ≥ 32-char symmetric secret used to sign cookies. If unset in basic mode, the server generates one for the process lifetime and logs a warning — sessions will not survive a restart. |
 | `OMCP_AUTH_ALLOW_FALLBACK` | optional | When `true` and basic-mode prereqs are missing/invalid, the server falls back to anonymous mode instead of refusing to start. Off by default — production deployments should let the start fail loudly. |
+| `OMCP_AUTH_LOCKOUT_MAX_FAILURES` | optional | Failed logins for one account before it locks (default `5`). |
+| `OMCP_AUTH_LOCKOUT_WINDOW` | optional | Sliding window in seconds over which failures accumulate (default `900`). |
+| `OMCP_AUTH_LOCKOUT_BASE` | optional | First lock duration in seconds; doubles each subsequent lock (default `60`). |
+| `OMCP_AUTH_LOCKOUT_MAX` | optional | Cap on a single lock duration in seconds (default `3600`). |
+| `OMCP_AUTH_LOCKOUT_DISABLED` | optional | Set truthy to turn the per-account lockout off entirely. |
 
 If `OMCP_USERS_FILE` is missing/unreadable/empty when `OMCP_AUTH=basic`,
 the server **refuses to start** (process exit code 1) so a misconfigured
@@ -94,6 +99,33 @@ and re-reads it when the mtime has changed since the previous attempt
 OMCP_USERS_FILE changed — reloaded N user(s)` line each time the file
 reloads. A transient read error (network FS hiccup) keeps the cached
 set so logins continue to work with the last known users.
+
+### Account lockout
+
+Two independent brute-force defences guard `POST /api/auth/login`:
+
+- **Per-IP rate limit** — 20 attempts/min/IP (fixed). Blunts a noisy
+  single source.
+- **Per-account lockout** — after `OMCP_AUTH_LOCKOUT_MAX_FAILURES`
+  failed attempts on one username inside the sliding window, that
+  account is temporarily locked regardless of source IP, so a slow or
+  distributed grind on a single account is bounded too. Each subsequent
+  lock lasts twice as long (`BASE`, `2·BASE`, `4·BASE`, … capped at
+  `MAX`). A successful login clears the streak immediately.
+
+A locked login returns `429` with a `Retry-After` header; the response
+is identical whether or not the username exists, so it can't be used as
+a user-enumeration oracle, and the lock is checked **before** the scrypt
+verify so a locked account can't be used to burn CPU. Lock events are
+written to the audit log (`actor=<username>`, `status=429`).
+
+State lives in the shared session store — set `OMCP_REDIS_URL` and the
+lockout is enforced consistently across replicas (and self-expires via
+TTL); without it the lockout is per-process and resets on restart.
+
+A lockout is a temporary, automatic throttle — to permanently disable an
+account, remove it from `OMCP_USERS_FILE` (and revoke its live sessions,
+see [access-control.md](access-control.md#session-revocation)).
 
 ## What's gated, what isn't
 

--- a/mcp-server/src/auth/lockout.test.ts
+++ b/mcp-server/src/auth/lockout.test.ts
@@ -1,0 +1,154 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { InMemorySessionStore } from "../transport/sessionStore.js";
+import {
+  AccountLockout,
+  lockoutConfigFromEnv,
+  lockoutDisabledFromEnv,
+  DEFAULT_LOCKOUT_CONFIG,
+} from "./lockout.js";
+
+const cfg = { maxFailures: 3, windowSeconds: 100, baseLockSeconds: 60, maxLockSeconds: 600 };
+
+function mk(now: { t: number }) {
+  return new AccountLockout(new InMemorySessionStore(), cfg, () => now.t);
+}
+
+test("unknown account is not locked and reports full remaining attempts", async () => {
+  const now = { t: 1000 };
+  const lock = mk(now);
+  const status = await lock.check("alice");
+  assert.equal(status.locked, false);
+  assert.equal(status.remainingAttempts, 3);
+});
+
+test("failures below the threshold decrement remaining attempts", async () => {
+  const now = { t: 1000 };
+  const lock = mk(now);
+  assert.deepEqual(await lock.recordFailure("alice"), { locked: false, remainingAttempts: 2 });
+  assert.deepEqual(await lock.recordFailure("alice"), { locked: false, remainingAttempts: 1 });
+});
+
+test("the Nth failure trips a lock with the base duration", async () => {
+  const now = { t: 1000 };
+  const lock = mk(now);
+  await lock.recordFailure("alice");
+  await lock.recordFailure("alice");
+  const tripped = await lock.recordFailure("alice");
+  assert.equal(tripped.locked, true);
+  assert.equal(tripped.retryAfterSeconds, 60);
+
+  // check() reflects the lock and counts down with the clock.
+  now.t += 10;
+  const status = await lock.check("alice");
+  assert.equal(status.locked, true);
+  assert.equal(status.retryAfterSeconds, 50);
+});
+
+test("a lapsed lock clears and lets attempts resume", async () => {
+  const now = { t: 1000 };
+  const lock = mk(now);
+  await lock.recordFailure("alice");
+  await lock.recordFailure("alice");
+  await lock.recordFailure("alice"); // locked for 60s
+  now.t += 61;
+  const status = await lock.check("alice");
+  assert.equal(status.locked, false);
+});
+
+test("progressive backoff doubles each lock, capped at maxLockSeconds", async () => {
+  const now = { t: 0 };
+  const lock = mk(now);
+  async function tripLock(): Promise<number> {
+    let last = { locked: false } as { locked: boolean; retryAfterSeconds?: number };
+    for (let i = 0; i < cfg.maxFailures; i++) last = await lock.recordFailure("bob");
+    return last.retryAfterSeconds!;
+  }
+  // Level 1 → 60, level 2 → 120, level 3 → 240, level 4 → 480, level 5 → 600 (capped).
+  const durations: number[] = [];
+  for (let lvl = 0; lvl < 5; lvl++) {
+    const d = await tripLock();
+    durations.push(d);
+    now.t += d + 1; // wait out the lock before the next streak
+  }
+  assert.deepEqual(durations, [60, 120, 240, 480, 600]);
+});
+
+test("a blocked attempt during an active lock does not extend it", async () => {
+  const now = { t: 1000 };
+  const lock = mk(now);
+  await lock.recordFailure("alice");
+  await lock.recordFailure("alice");
+  const tripped = await lock.recordFailure("alice"); // locked 60s at t=1000
+  assert.equal(tripped.retryAfterSeconds, 60);
+
+  now.t += 30;
+  const blocked = await lock.recordFailure("alice"); // still locked, t=1030
+  assert.equal(blocked.locked, true);
+  // Deadline unchanged (1060) → 30s left, NOT re-extended to 60.
+  assert.equal(blocked.retryAfterSeconds, 30);
+});
+
+test("failures outside the window reset the streak", async () => {
+  const now = { t: 1000 };
+  const lock = mk(now);
+  await lock.recordFailure("alice"); // failures=1, firstFailureAt=1000
+  await lock.recordFailure("alice"); // failures=2
+  now.t += cfg.windowSeconds + 1;     // window lapsed
+  const status = await lock.recordFailure("alice"); // resets to failures=1
+  assert.equal(status.locked, false);
+  assert.equal(status.remainingAttempts, 2);
+});
+
+test("recordSuccess clears the streak", async () => {
+  const now = { t: 1000 };
+  const lock = mk(now);
+  await lock.recordFailure("alice");
+  await lock.recordFailure("alice");
+  await lock.recordSuccess("alice");
+  const status = await lock.check("alice");
+  assert.equal(status.locked, false);
+  assert.equal(status.remainingAttempts, 3);
+});
+
+test("lockout is tracked per username — one account's lock doesn't touch another", async () => {
+  const now = { t: 1000 };
+  const lock = mk(now);
+  await lock.recordFailure("alice");
+  await lock.recordFailure("alice");
+  await lock.recordFailure("alice"); // alice locked
+  assert.equal((await lock.check("alice")).locked, true);
+  assert.equal((await lock.check("bob")).locked, false);
+  assert.equal((await lock.check("bob")).remainingAttempts, 3);
+});
+
+test("state persists with a TTL so it self-cleans", async () => {
+  const store = new InMemorySessionStore();
+  const now = { t: 1000 };
+  const lock = new AccountLockout(store, cfg, () => now.t);
+  await lock.recordFailure("alice");
+  // One key written under the lockout: prefix.
+  const keys = await store.keys("lockout:");
+  assert.deepEqual(keys, ["lockout:alice"]);
+});
+
+test("lockoutConfigFromEnv parses overrides and falls back on bad input", () => {
+  const parsed = lockoutConfigFromEnv({
+    OMCP_AUTH_LOCKOUT_MAX_FAILURES: "10",
+    OMCP_AUTH_LOCKOUT_WINDOW: "300",
+    OMCP_AUTH_LOCKOUT_BASE: "nonsense",
+    OMCP_AUTH_LOCKOUT_MAX: "-5",
+  } as NodeJS.ProcessEnv);
+  assert.equal(parsed.maxFailures, 10);
+  assert.equal(parsed.windowSeconds, 300);
+  assert.equal(parsed.baseLockSeconds, DEFAULT_LOCKOUT_CONFIG.baseLockSeconds); // bad → default
+  assert.equal(parsed.maxLockSeconds, DEFAULT_LOCKOUT_CONFIG.maxLockSeconds);   // negative → default
+});
+
+test("lockoutDisabledFromEnv recognises truthy values", () => {
+  assert.equal(lockoutDisabledFromEnv({ OMCP_AUTH_LOCKOUT_DISABLED: "true" } as NodeJS.ProcessEnv), true);
+  assert.equal(lockoutDisabledFromEnv({ OMCP_AUTH_LOCKOUT_DISABLED: "1" } as NodeJS.ProcessEnv), true);
+  assert.equal(lockoutDisabledFromEnv({ OMCP_AUTH_LOCKOUT_DISABLED: "no" } as NodeJS.ProcessEnv), false);
+  assert.equal(lockoutDisabledFromEnv({} as NodeJS.ProcessEnv), false);
+});

--- a/mcp-server/src/auth/lockout.ts
+++ b/mcp-server/src/auth/lockout.ts
@@ -1,0 +1,180 @@
+/**
+ * Local-account lockout for the management-plane "basic" auth login.
+ *
+ * The per-IP rate limiter on /api/auth/login (20/min) blunts a noisy
+ * brute-force, but it's keyed on the source IP — a distributed attempt, or
+ * a slow drip under the IP cap, can still grind a single account's
+ * password. This adds a per-username failed-login counter with progressive
+ * backoff: after N failures inside a sliding window the account is
+ * temporarily locked, and each subsequent lock lasts longer
+ * (base · 2^(level-1), capped). A successful login clears the streak.
+ *
+ * State lives in the shared {@link SessionStore} so a Redis-backed
+ * deployment locks consistently across replicas (and self-cleans via TTL).
+ * The in-memory default keeps the single-process behaviour with no new dep.
+ *
+ * Lockout is tracked by the *submitted* username, whether or not it exists,
+ * so it can't be used as a user-enumeration oracle and a known username
+ * can't be singled out. Read-modify-write is best-effort under concurrency
+ * (matching the store's eventually-consistent contract) — the worst case is
+ * a couple of extra attempts slipping past the threshold, which the IP rate
+ * limiter still bounds. It is never a lockout bypass for the *locked* state:
+ * once `lockedUntil` is written, every replica that reads it honours it.
+ */
+
+import type { SessionStore } from "../transport/sessionStore.js";
+
+export interface LockoutConfig {
+  /** Consecutive failures within the window before a lock triggers. */
+  maxFailures: number;
+  /** Sliding window (seconds) over which failures accumulate. */
+  windowSeconds: number;
+  /** First lock duration (seconds). Doubles each subsequent lock. */
+  baseLockSeconds: number;
+  /** Upper bound on a single lock duration (seconds). */
+  maxLockSeconds: number;
+}
+
+export const DEFAULT_LOCKOUT_CONFIG: LockoutConfig = {
+  maxFailures: 5,
+  windowSeconds: 15 * 60,
+  baseLockSeconds: 60,
+  maxLockSeconds: 60 * 60,
+};
+
+/** Persisted per-username state. */
+interface LockoutState {
+  /** Failure count in the current streak. */
+  failures: number;
+  /** Epoch seconds of the first failure in the current streak. */
+  firstFailureAt: number;
+  /** Epoch seconds until which the account is locked. Absent = not locked. */
+  lockedUntil?: number;
+  /** How many times this account has been locked — drives the backoff. */
+  lockLevel: number;
+}
+
+export interface LockoutStatus {
+  locked: boolean;
+  /** Seconds the caller must wait, when locked. */
+  retryAfterSeconds?: number;
+  /** Attempts left before a lock, when not locked. */
+  remainingAttempts?: number;
+}
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+/** Resolve config from env, falling back to the defaults. */
+export function lockoutConfigFromEnv(env: NodeJS.ProcessEnv = process.env): LockoutConfig {
+  const num = (raw: string | undefined, fallback: number): number => {
+    if (raw === undefined) return fallback;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+  };
+  return {
+    maxFailures: num(env.OMCP_AUTH_LOCKOUT_MAX_FAILURES, DEFAULT_LOCKOUT_CONFIG.maxFailures),
+    windowSeconds: num(env.OMCP_AUTH_LOCKOUT_WINDOW, DEFAULT_LOCKOUT_CONFIG.windowSeconds),
+    baseLockSeconds: num(env.OMCP_AUTH_LOCKOUT_BASE, DEFAULT_LOCKOUT_CONFIG.baseLockSeconds),
+    maxLockSeconds: num(env.OMCP_AUTH_LOCKOUT_MAX, DEFAULT_LOCKOUT_CONFIG.maxLockSeconds),
+  };
+}
+
+/** True when OMCP_AUTH_LOCKOUT_DISABLED is set to a truthy value. */
+export function lockoutDisabledFromEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = env.OMCP_AUTH_LOCKOUT_DISABLED?.trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes";
+}
+
+export class AccountLockout {
+  private readonly store: SessionStore;
+  private readonly cfg: LockoutConfig;
+  private readonly now: () => number;
+  /** TTL applied to every persisted entry so stale streaks self-clean. */
+  private readonly ttlSeconds: number;
+
+  constructor(store: SessionStore, cfg: Partial<LockoutConfig> = {}, now: () => number = nowSeconds) {
+    this.store = store;
+    this.cfg = { ...DEFAULT_LOCKOUT_CONFIG, ...cfg };
+    this.now = now;
+    // Outlast both the streak window and the longest possible lock so an
+    // abandoned entry always expires, but a live lock never does early.
+    this.ttlSeconds = Math.max(this.cfg.windowSeconds, this.cfg.maxLockSeconds) + 60;
+  }
+
+  private key(username: string): string {
+    return `lockout:${username}`;
+  }
+
+  /** Lock duration for a given (1-based) lock level, capped. */
+  private lockDuration(level: number): number {
+    const exp = this.cfg.baseLockSeconds * Math.pow(2, Math.max(0, level - 1));
+    return Math.min(this.cfg.maxLockSeconds, Math.floor(exp));
+  }
+
+  /**
+   * Inspect lock state without mutating it. Call before verifying the
+   * password — a locked account should never reach the (expensive) hash
+   * comparison.
+   */
+  async check(username: string): Promise<LockoutStatus> {
+    const state = await this.store.get<LockoutState>(this.key(username));
+    const now = this.now();
+    if (state?.lockedUntil && state.lockedUntil > now) {
+      return { locked: true, retryAfterSeconds: state.lockedUntil - now };
+    }
+    const failures = this.activeFailures(state, now);
+    return { locked: false, remainingAttempts: Math.max(0, this.cfg.maxFailures - failures) };
+  }
+
+  /** Failures still inside the sliding window (0 if the window lapsed). */
+  private activeFailures(state: LockoutState | undefined, now: number): number {
+    if (!state) return 0;
+    if (now - state.firstFailureAt > this.cfg.windowSeconds) return 0;
+    return state.failures;
+  }
+
+  /**
+   * Record a failed login. Returns the resulting status — `locked: true`
+   * when this failure tripped (or fell inside) a lock.
+   */
+  async recordFailure(username: string): Promise<LockoutStatus> {
+    const k = this.key(username);
+    const now = this.now();
+    const prev = await this.store.get<LockoutState>(k);
+
+    // If an existing lock is still active, just report it — don't extend
+    // it on every blocked attempt (that would let an attacker grow the
+    // legitimate user's lock unboundedly).
+    if (prev?.lockedUntil && prev.lockedUntil > now) {
+      return { locked: true, retryAfterSeconds: prev.lockedUntil - now };
+    }
+
+    // Continue the streak only if the window is still open; otherwise reset.
+    const windowOpen = prev && now - prev.firstFailureAt <= this.cfg.windowSeconds;
+    const next: LockoutState = windowOpen
+      ? { ...prev!, failures: prev!.failures + 1 }
+      : { failures: 1, firstFailureAt: now, lockLevel: prev?.lockLevel ?? 0 };
+
+    if (next.failures >= this.cfg.maxFailures) {
+      // Trip a lock: escalate the level, set the deadline, reset the
+      // counter so the next batch of failures earns a longer lock.
+      next.lockLevel += 1;
+      const duration = this.lockDuration(next.lockLevel);
+      next.lockedUntil = now + duration;
+      next.failures = 0;
+      next.firstFailureAt = now;
+      await this.store.setEx(k, this.ttlSeconds, next);
+      return { locked: true, retryAfterSeconds: duration };
+    }
+
+    await this.store.setEx(k, this.ttlSeconds, next);
+    return { locked: false, remainingAttempts: this.cfg.maxFailures - next.failures };
+  }
+
+  /** Clear the streak on a successful login. Keeps no history. */
+  async recordSuccess(username: string): Promise<void> {
+    await this.store.del(this.key(username));
+  }
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -61,6 +61,12 @@ import {
 import { resolveOidcConfig, buildOidcRuntime } from "./auth/oidc/runtime.js";
 import { registerOidcRoutes } from "./auth/oidc/endpoints.js";
 import { RevocationStore } from "./auth/revocation.js";
+import {
+  AccountLockout,
+  lockoutConfigFromEnv,
+  lockoutDisabledFromEnv,
+} from "./auth/lockout.js";
+import { resolveSessionStore } from "./transport/sessionStore.js";
 import { createScimStore } from "./scim/store.js";
 import { registerScimRoutes } from "./scim/routes.js";
 import { BuiltinPolicyEngine, type PolicyEngine } from "./auth/policy/engine.js";
@@ -2065,6 +2071,22 @@ async function main() {
     }
   }
 
+  // Q18 — per-username failed-login lockout with progressive backoff.
+  // Complements the per-IP loginRateLimit above: that bounds a noisy
+  // single source, this bounds a slow / distributed grind on one
+  // account. Backed by the shared SessionStore so a Redis deployment
+  // locks consistently across replicas (and self-cleans via TTL).
+  // Basic mode only — OIDC delegates auth (and lockout) to the IdP.
+  let lockout: AccountLockout | undefined;
+  if (authRuntime.mode === "basic" && !lockoutDisabledFromEnv()) {
+    const lockoutStore = await resolveSessionStore();
+    const lockoutCfg = lockoutConfigFromEnv();
+    lockout = new AccountLockout(lockoutStore, lockoutCfg);
+    console.log(
+      `[auth] account lockout active — ${lockoutCfg.maxFailures} failures / ${lockoutCfg.windowSeconds}s → lock ${lockoutCfg.baseLockSeconds}s (×2 up to ${lockoutCfg.maxLockSeconds}s), backend=${lockoutStore.backend}`,
+    );
+  }
+
   app.post("/api/auth/login", loginRateLimit, async (req, res) => {
     if (authRuntime.mode !== "basic" || !sessionCfg || !usersStore) {
       res.status(503).json({ error: "auth mode does not accept logins" });
@@ -2078,11 +2100,56 @@ async function main() {
       res.status(400).json({ error: "username and password are required" });
       return;
     }
+    // Gate on the lock BEFORE the (expensive) scrypt verify so a locked
+    // account can't be used to burn CPU. A locked account is a 429 with
+    // Retry-After, never a credential oracle — the response is identical
+    // whether or not the username exists.
+    if (lockout) {
+      const status = await lockout.check(username);
+      if (status.locked) {
+        res.setHeader("Retry-After", String(status.retryAfterSeconds ?? 0));
+        res.status(429).json({
+          error: "account temporarily locked due to repeated failed logins",
+          retryAfterSeconds: status.retryAfterSeconds,
+        });
+        void mgmtAudit.record({
+          actor: { sub: username },
+          tenant: "default",
+          resource: "users",
+          action: "write",
+          method: "POST",
+          path: "/api/auth/login",
+          status: 429,
+        }).catch(() => {});
+        return;
+      }
+    }
     const user = authenticate(username, password, usersStore);
     if (!user) {
+      if (lockout) {
+        const after = await lockout.recordFailure(username);
+        if (after.locked) {
+          res.setHeader("Retry-After", String(after.retryAfterSeconds ?? 0));
+          res.status(429).json({
+            error: "account temporarily locked due to repeated failed logins",
+            retryAfterSeconds: after.retryAfterSeconds,
+          });
+          void mgmtAudit.record({
+            actor: { sub: username },
+            tenant: "default",
+            resource: "users",
+            action: "write",
+            method: "POST",
+            path: "/api/auth/login",
+            status: 429,
+          }).catch(() => {});
+          return;
+        }
+      }
       res.status(401).json({ error: "invalid credentials" });
       return;
     }
+    if (lockout) await lockout.recordSuccess(user.username);
     const { cookie } = issueSession(
       { sub: user.username, name: user.name, roles: user.roles, tenant: user.tenant },
       sessionCfg,


### PR DESCRIPTION
## Q18 — Local account lockout

The per-IP rate limit on `POST /api/auth/login` (20/min) blunts a noisy single source, but a slow drip under the cap — or a distributed attempt — can still grind one account's password. This adds a second, orthogonal defence: a **per-username** failed-login counter with progressive backoff.

### Behaviour
- After `OMCP_AUTH_LOCKOUT_MAX_FAILURES` (default 5) failures on one username inside a sliding window (default 15m), the account locks.
- Each subsequent lock lasts twice as long: `BASE`, `2·BASE`, `4·BASE`, … capped at `MAX` (defaults 60s → 3600s).
- A successful login clears the streak immediately.
- A blocked attempt during an active lock does **not** extend the deadline (an attacker can't grow a victim's lock unboundedly).

### Security properties
- Lock is checked **before** the scrypt verify → a locked account can't be used to burn CPU.
- `429` + `Retry-After`; the response is **identical** whether or not the username exists → no user-enumeration oracle.
- Lock events are written to the audit log (`actor=<username>`, `status=429`).

### Storage
Backed by the shared `SessionStore`: set `OMCP_REDIS_URL` and the lockout is enforced consistently across replicas and self-expires via TTL; without it, it's per-process and resets on restart.

### Config
`OMCP_AUTH_LOCKOUT_{MAX_FAILURES,WINDOW,BASE,MAX}`; disable entirely with `OMCP_AUTH_LOCKOUT_DISABLED`. Documented in `docs/auth-basic.md`.

### Tests
12 new unit tests: progressive-backoff cap, sliding-window reset, per-username isolation, active-lock-not-extended, success-clears-streak, env parsing/disable flag. Full suite: **931 tests, 0 fail, 24 env-gated skips**. `tsc --noEmit` clean.

Reviewer-agent gate: **SHIP** (no correctness/security findings; one cosmetic comment nit fixed before push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)