### PR TITLE
feat(q19): password policy for basic-auth credential minting

### DIFF
--- a/docs/auth-basic.md
+++ b/docs/auth-basic.md
@@ -34,6 +34,11 @@ node scripts/hash-password.mjs alice --name "Alice" --roles operator
 # }
 ```
 
+The helper checks the password against the policy (see
+[Password policy](#password-policy) below) before hashing and refuses a
+weak one. Pass `--force` (or set `OMCP_PASSWORD_POLICY_DISABLED=true`) to
+override.
+
 **2. Build the users file** at any path the server can read:
 
 ```json
@@ -82,6 +87,10 @@ badge appears in the masthead.
 | `OMCP_AUTH_LOCKOUT_BASE` | optional | First lock duration in seconds; doubles each subsequent lock (default `60`). |
 | `OMCP_AUTH_LOCKOUT_MAX` | optional | Cap on a single lock duration in seconds (default `3600`). |
 | `OMCP_AUTH_LOCKOUT_DISABLED` | optional | Set truthy to turn the per-account lockout off entirely. |
+| `OMCP_PASSWORD_MIN_LENGTH` | optional | Minimum password length the minting helper enforces (default `12`). |
+| `OMCP_PASSWORD_MIN_CLASSES` | optional | Minimum character classes (lower/upper/digit/symbol) required, 1–4 (default `3`). |
+| `OMCP_PASSWORD_DENYLIST_DISABLED` | optional | Set truthy to skip the common-password denylist check. |
+| `OMCP_PASSWORD_POLICY_DISABLED` | optional | Set truthy to skip the password policy entirely. |
 
 If `OMCP_USERS_FILE` is missing/unreadable/empty when `OMCP_AUTH=basic`,
 the server **refuses to start** (process exit code 1) so a misconfigured
@@ -126,6 +135,29 @@ TTL); without it the lockout is per-process and resets on restart.
 A lockout is a temporary, automatic throttle — to permanently disable an
 account, remove it from `OMCP_USERS_FILE` (and revoke its live sessions,
 see [access-control.md](access-control.md#session-revocation)).
+
+### Password policy
+
+The minting helper (`scripts/hash-password.mjs`) checks each password
+against a small policy before hashing it:
+
+- **length** ≥ `OMCP_PASSWORD_MIN_LENGTH` (default 12),
+- **character classes** ≥ `OMCP_PASSWORD_MIN_CLASSES` of {lowercase,
+  uppercase, digit, symbol} (default 3),
+- not on a builtin **common-password denylist** (the usual `password123`
+  / `qwerty` set plus a few app-specific ones), and
+- does not **contain the username**.
+
+A weak password is refused with the list of violations; `--force` or
+`OMCP_PASSWORD_POLICY_DISABLED=true` overrides it.
+
+The check lives at the **minting** step because that is the only place a
+management password exists in plaintext — the users file stores scrypt
+hashes only, so there is nothing to re-validate at load time, and login
+never re-checks policy (that would lock out users whose passwords predate
+a tightened rule). The same rules are available as a reusable module
+(`mcp-server/src/auth/password-policy.ts`) for any future
+change-password endpoint.
 
 ## What's gated, what isn't
 

--- a/mcp-server/src/auth/password-policy.test.ts
+++ b/mcp-server/src/auth/password-policy.test.ts
@@ -1,0 +1,134 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  validatePassword,
+  passwordPolicyFromEnv,
+  passwordPolicyDisabledFromEnv,
+  DEFAULT_PASSWORD_POLICY,
+  COMMON_PASSWORD_DENYLIST,
+} from "./password-policy.js";
+
+test("a strong password passes the default policy", () => {
+  const r = validatePassword("Tr0ub4dour&3xtra");
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.errors, []);
+});
+
+test("too-short password is rejected with a length error", () => {
+  const r = validatePassword("Ab1!xy");
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes("at least 12")));
+});
+
+test("insufficient character classes is rejected", () => {
+  // 16 lowercase letters — long enough, but only one class.
+  const r = validatePassword("abcdefghijklmnop");
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes("at least 3 of")));
+});
+
+test("two classes still fails the default min of three", () => {
+  const r = validatePassword("abcdefghijkl1234"); // lower + digit only
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes("at least 3 of")));
+});
+
+test("exactly three classes passes", () => {
+  const r = validatePassword("abcdefghABCD1234"); // lower+upper+digit = 3
+  assert.equal(r.ok, true);
+});
+
+test("common-password denylist is enforced case-insensitively", () => {
+  // Permissive length/classes so ONLY the denylist can reject — the
+  // denylist matches the whole password exactly (case-insensitively).
+  const permissive = { minLength: 1, maxLength: 1024, minClasses: 1, denylistEnabled: true };
+  const r = validatePassword("PaSsWoRd123", permissive);
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes("denylist")));
+});
+
+test("denylist entries themselves are all rejected when long enough is waived", () => {
+  // Sanity: the canonical app-specific entries are present.
+  assert.ok(COMMON_PASSWORD_DENYLIST.has("observability-mcp"));
+  assert.ok(COMMON_PASSWORD_DENYLIST.has("prometheus"));
+});
+
+test("password containing the username is rejected", () => {
+  const r = validatePassword("alice-Secret-99x", DEFAULT_PASSWORD_POLICY, "alice");
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes("username")));
+});
+
+test("short usernames (<3 chars) do not trigger the username check", () => {
+  // "al" is too short to meaningfully match; password is otherwise strong.
+  const r = validatePassword("alXyZ12345678!", DEFAULT_PASSWORD_POLICY, "al");
+  assert.equal(r.ok, true);
+});
+
+test("code-point length counts multibyte characters as one", () => {
+  // 11 emoji = 11 code points < 12 → too short despite a large byte length.
+  const eleven = "😀".repeat(11);
+  assert.equal(validatePassword(eleven).ok, false);
+  // 12 of them clears length; emoji count as the "symbol" class only → 1 class.
+  const twelve = "😀".repeat(12);
+  const r = validatePassword(twelve);
+  assert.equal(r.ok, false); // fails on classes, not length
+  assert.ok(r.errors.some((e) => e.includes("at least 3 of")));
+  assert.ok(!r.errors.some((e) => e.includes("at least 12")));
+});
+
+test("over-long password is rejected (scrypt DoS guard)", () => {
+  const r = validatePassword("Aa1!".repeat(300)); // 1200 chars > 1024
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.includes("at most")));
+});
+
+test("disabling the denylist lets a denylisted password through", () => {
+  const permissive = { minLength: 1, maxLength: 1024, minClasses: 1, denylistEnabled: false };
+  // 'password123' is on the denylist; with it disabled only length/classes
+  // apply, which this permissive policy waives.
+  assert.equal(validatePassword("password123", permissive).ok, true);
+});
+
+test("passwordPolicyFromEnv parses overrides and ignores bad input", () => {
+  const p = passwordPolicyFromEnv({
+    OMCP_PASSWORD_MIN_LENGTH: "16",
+    OMCP_PASSWORD_MIN_CLASSES: "bad",
+    OMCP_PASSWORD_DENYLIST_DISABLED: "true",
+  } as NodeJS.ProcessEnv);
+  assert.equal(p.minLength, 16);
+  assert.equal(p.minClasses, DEFAULT_PASSWORD_POLICY.minClasses); // bad → default
+  assert.equal(p.denylistEnabled, false);
+});
+
+test("passwordPolicyDisabledFromEnv recognises truthy values", () => {
+  assert.equal(passwordPolicyDisabledFromEnv({ OMCP_PASSWORD_POLICY_DISABLED: "1" } as NodeJS.ProcessEnv), true);
+  assert.equal(passwordPolicyDisabledFromEnv({ OMCP_PASSWORD_POLICY_DISABLED: "false" } as NodeJS.ProcessEnv), false);
+  assert.equal(passwordPolicyDisabledFromEnv({} as NodeJS.ProcessEnv), false);
+});
+
+test("CLI hash-password.mjs stays in sync with the canonical policy", () => {
+  // The CLI deliberately duplicates the policy to stay dependency-free
+  // (same precedent as the scrypt params). This guard fails loudly if the
+  // two drift: every canonical denylist entry + the defaults must appear
+  // verbatim in the script. (__dirname → mcp-server/src/auth)
+  const here = dirname(fileURLToPath(import.meta.url));
+  const cliPath = join(here, "..", "..", "..", "scripts", "hash-password.mjs");
+  const cli = readFileSync(cliPath, "utf8");
+  for (const entry of COMMON_PASSWORD_DENYLIST) {
+    assert.ok(cli.includes(`"${entry}"`), `CLI denylist is missing "${entry}"`);
+  }
+  assert.ok(cli.includes(`"OMCP_PASSWORD_MIN_LENGTH", ${DEFAULT_PASSWORD_POLICY.minLength}`), "CLI minLength default drifted");
+  assert.ok(cli.includes(`"OMCP_PASSWORD_MIN_CLASSES", ${DEFAULT_PASSWORD_POLICY.minClasses}`), "CLI minClasses default drifted");
+  assert.ok(cli.includes(`PW_MAX_LENGTH = ${DEFAULT_PASSWORD_POLICY.maxLength}`), "CLI maxLength default drifted");
+});
+
+test("multiple violations are all reported", () => {
+  const r = validatePassword("admin"); // short, 1 class, on denylist
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.length >= 2);
+});

--- a/mcp-server/src/auth/password-policy.ts
+++ b/mcp-server/src/auth/password-policy.ts
@@ -1,0 +1,152 @@
+/**
+ * Password policy for the management-plane "basic" auth mode.
+ *
+ * Where this is enforced: the only point in the system that ever sees a
+ * management password in plaintext is where one is *minted* — the
+ * `scripts/hash-password.mjs` helper. The users file stores scrypt
+ * hashes only, so password strength cannot be re-evaluated at load time
+ * (there is no plaintext to check), and there is no runtime endpoint that
+ * accepts a plaintext password to set. This module is therefore the
+ * canonical, dependency-free policy that the minting path enforces — and
+ * that any future "change my password" endpoint should call before
+ * hashing. Login (`verifyPassword`) never re-checks policy: that would
+ * lock out users whose passwords predate a tightened policy.
+ *
+ * "Basic" ruleset: a minimum length, a minimum number of character
+ * classes, a small builtin common-password denylist, and a guard against
+ * passwords that just echo the username. Deliberately small — this is a
+ * footgun guard for self-hosted operators, not a compliance engine.
+ */
+
+export interface PasswordPolicy {
+  /** Minimum length in Unicode code points. */
+  minLength: number;
+  /** Maximum length — a sanity bound so a megabyte "password" can't be
+   *  fed into scrypt. */
+  maxLength: number;
+  /** How many of the four classes (lower/upper/digit/symbol) are required. */
+  minClasses: number;
+  /** When true, reject passwords on the builtin common-password list. */
+  denylistEnabled: boolean;
+}
+
+export const DEFAULT_PASSWORD_POLICY: PasswordPolicy = {
+  minLength: 12,
+  maxLength: 1024,
+  minClasses: 3,
+  denylistEnabled: true,
+};
+
+/**
+ * A small list of the most-abused passwords + obvious app-specific ones.
+ * Not exhaustive — the real defenders are length + classes. Lowercased;
+ * comparison is case-insensitive.
+ */
+export const COMMON_PASSWORD_DENYLIST: ReadonlySet<string> = new Set([
+  "password", "password1", "password123", "passw0rd", "p@ssw0rd", "p@ssword",
+  "123456", "1234567", "12345678", "123456789", "1234567890", "12345",
+  "qwerty", "qwerty123", "qwertyuiop", "asdfghjkl", "1q2w3e4r", "1qaz2wsx",
+  "letmein", "welcome", "welcome1", "admin", "admin123", "administrator",
+  "root", "toor", "changeme", "default", "guest", "iloveyou", "monkey",
+  "dragon", "sunshine", "princess", "football", "baseball", "abc123",
+  "654321", "111111", "000000", "superman", "trustno1", "master",
+  "hello123", "secret", "test", "test123", "user", "login", "passport",
+  "observability", "observability-mcp", "prometheus", "grafana", "loki",
+]);
+
+export interface PasswordCheckResult {
+  ok: boolean;
+  /** Human-readable reasons the password was rejected; empty when ok. */
+  errors: string[];
+}
+
+/**
+ * Count distinct character classes present. Classification is ASCII-based:
+ * a-z, A-Z, 0-9, and "everything else" (symbol). Non-ASCII letters (é, ü,
+ * emoji, CJK) therefore count as the symbol class, never lower/upper. This
+ * is deliberately conservative — it can only ever under-count classes, so
+ * it never lets a weaker password through than the rule implies.
+ */
+function countClasses(pw: string): number {
+  let lower = false, upper = false, digit = false, symbol = false;
+  for (const ch of pw) {
+    if (ch >= "a" && ch <= "z") lower = true;
+    else if (ch >= "A" && ch <= "Z") upper = true;
+    else if (ch >= "0" && ch <= "9") digit = true;
+    else symbol = true;
+  }
+  return Number(lower) + Number(upper) + Number(digit) + Number(symbol);
+}
+
+/** Length in code points (so emoji / multibyte count as one). */
+function codePointLength(s: string): number {
+  let n = 0;
+  for (const _ of s) n++;
+  return n;
+}
+
+/**
+ * Validate a plaintext password against the policy. `username`, when
+ * given, additionally rejects passwords that are (or merely contain) the
+ * username — the single most common weak choice.
+ */
+export function validatePassword(
+  password: string,
+  policy: PasswordPolicy = DEFAULT_PASSWORD_POLICY,
+  username?: string,
+): PasswordCheckResult {
+  const errors: string[] = [];
+  const len = codePointLength(password);
+
+  if (len < policy.minLength) {
+    errors.push(`must be at least ${policy.minLength} characters (got ${len})`);
+  }
+  if (len > policy.maxLength) {
+    errors.push(`must be at most ${policy.maxLength} characters`);
+  }
+  if (policy.minClasses > 1) {
+    const classes = countClasses(password);
+    if (classes < policy.minClasses) {
+      errors.push(
+        `must mix at least ${policy.minClasses} of: lowercase, uppercase, digit, symbol (got ${classes})`,
+      );
+    }
+  }
+  if (policy.denylistEnabled && COMMON_PASSWORD_DENYLIST.has(password.toLowerCase())) {
+    errors.push("is on the common-password denylist");
+  }
+  if (username) {
+    const u = username.toLowerCase();
+    const p = password.toLowerCase();
+    if (u.length >= 3 && p.includes(u)) {
+      errors.push("must not contain the username");
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+/** Resolve the policy from env, falling back to the defaults. */
+export function passwordPolicyFromEnv(env: NodeJS.ProcessEnv = process.env): PasswordPolicy {
+  const num = (raw: string | undefined, fallback: number): number => {
+    if (raw === undefined) return fallback;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+  };
+  const truthy = (raw: string | undefined): boolean => {
+    const v = raw?.trim().toLowerCase();
+    return v === "1" || v === "true" || v === "yes";
+  };
+  return {
+    minLength: num(env.OMCP_PASSWORD_MIN_LENGTH, DEFAULT_PASSWORD_POLICY.minLength),
+    maxLength: DEFAULT_PASSWORD_POLICY.maxLength,
+    minClasses: num(env.OMCP_PASSWORD_MIN_CLASSES, DEFAULT_PASSWORD_POLICY.minClasses),
+    denylistEnabled: !truthy(env.OMCP_PASSWORD_DENYLIST_DISABLED),
+  };
+}
+
+/** True when the policy is turned off entirely via env. */
+export function passwordPolicyDisabledFromEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = env.OMCP_PASSWORD_POLICY_DISABLED?.trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes";
+}

--- a/scripts/hash-password.mjs
+++ b/scripts/hash-password.mjs
@@ -20,6 +20,75 @@ const DEFAULT_R = 8;
 const DEFAULT_P = 1;
 const KEYLEN = 32;
 
+// --- Password policy ---------------------------------------------------
+// Mirror of mcp-server/src/auth/password-policy.ts (DEFAULT_PASSWORD_POLICY
+// + denylist). Duplicated here on purpose: this script stays dependency-
+// free and runnable from a source checkout, exactly like the scrypt params
+// above. Keep the two in sync — password-policy.test.ts is the canonical
+// spec. Override via the same OMCP_PASSWORD_* env vars; skip with --force.
+const PW_MIN_LENGTH = numEnv("OMCP_PASSWORD_MIN_LENGTH", 12);
+const PW_MAX_LENGTH = 1024;
+const PW_MIN_CLASSES = numEnv("OMCP_PASSWORD_MIN_CLASSES", 3);
+const PW_DENYLIST_DISABLED = truthyEnv("OMCP_PASSWORD_DENYLIST_DISABLED");
+const PW_POLICY_DISABLED = truthyEnv("OMCP_PASSWORD_POLICY_DISABLED");
+const PW_DENYLIST = new Set([
+  "password", "password1", "password123", "passw0rd", "p@ssw0rd", "p@ssword",
+  "123456", "1234567", "12345678", "123456789", "1234567890", "12345",
+  "qwerty", "qwerty123", "qwertyuiop", "asdfghjkl", "1q2w3e4r", "1qaz2wsx",
+  "letmein", "welcome", "welcome1", "admin", "admin123", "administrator",
+  "root", "toor", "changeme", "default", "guest", "iloveyou", "monkey",
+  "dragon", "sunshine", "princess", "football", "baseball", "abc123",
+  "654321", "111111", "000000", "superman", "trustno1", "master",
+  "hello123", "secret", "test", "test123", "user", "login", "passport",
+  "observability", "observability-mcp", "prometheus", "grafana", "loki",
+]);
+
+function numEnv(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+function truthyEnv(name) {
+  const v = process.env[name]?.trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes";
+}
+function codePointLength(s) {
+  let n = 0;
+  for (const _ of s) n++;
+  return n;
+}
+function countClasses(pw) {
+  let lower = false, upper = false, digit = false, symbol = false;
+  for (const ch of pw) {
+    if (ch >= "a" && ch <= "z") lower = true;
+    else if (ch >= "A" && ch <= "Z") upper = true;
+    else if (ch >= "0" && ch <= "9") digit = true;
+    else symbol = true;
+  }
+  return Number(lower) + Number(upper) + Number(digit) + Number(symbol);
+}
+function validatePassword(password, username) {
+  const errors = [];
+  const len = codePointLength(password);
+  if (len < PW_MIN_LENGTH) errors.push(`must be at least ${PW_MIN_LENGTH} characters (got ${len})`);
+  if (len > PW_MAX_LENGTH) errors.push(`must be at most ${PW_MAX_LENGTH} characters`);
+  if (PW_MIN_CLASSES > 1) {
+    const classes = countClasses(password);
+    if (classes < PW_MIN_CLASSES) {
+      errors.push(`must mix at least ${PW_MIN_CLASSES} of: lowercase, uppercase, digit, symbol (got ${classes})`);
+    }
+  }
+  if (!PW_DENYLIST_DISABLED && PW_DENYLIST.has(password.toLowerCase())) {
+    errors.push("is on the common-password denylist");
+  }
+  if (username) {
+    const u = username.toLowerCase();
+    if (u.length >= 3 && password.toLowerCase().includes(u)) errors.push("must not contain the username");
+  }
+  return errors;
+}
+
 function hashPassword(plaintext, opts = {}) {
   const N = opts.N ?? DEFAULT_N;
   const r = opts.r ?? DEFAULT_R;
@@ -80,6 +149,7 @@ function parseArgs(args) {
     else if (a.startsWith("--name=")) out.name = a.slice(7);
     else if (a === "--roles") out.roles = args[++i];
     else if (a.startsWith("--roles=")) out.roles = a.slice(8);
+    else if (a === "--force") out.force = true;
     else if (a === "-h" || a === "--help") out.help = true;
     else out.positional.push(a);
   }
@@ -88,10 +158,14 @@ function parseArgs(args) {
 
 function usage() {
   stderr.write(
-`Usage: node scripts/hash-password.mjs <username> [--name "Display Name"] [--roles operator,viewer]
+`Usage: node scripts/hash-password.mjs <username> [--name "Display Name"] [--roles operator,viewer] [--force]
 
 Reads the password from stdin (TTY-masked when interactive). Prints a JSON
 object suitable for inclusion under the "users:" key of OMCP_USERS_FILE.
+
+The password is checked against the policy (min length / character classes /
+common-password denylist; tune with OMCP_PASSWORD_* env vars). Pass --force
+or set OMCP_PASSWORD_POLICY_DISABLED=true to skip the check.
 `,
   );
 }
@@ -110,6 +184,15 @@ async function main() {
     : [];
   const password = await readPasswordHidden(`Password for ${username}: `);
   if (!password) { stderr.write("empty password — aborting\n"); exit(2); }
+  if (!PW_POLICY_DISABLED && !args.force) {
+    const violations = validatePassword(password, username);
+    if (violations.length > 0) {
+      stderr.write("password rejected by policy:\n");
+      for (const v of violations) stderr.write(`  - ${v}\n`);
+      stderr.write("Use a stronger password, or pass --force / set OMCP_PASSWORD_POLICY_DISABLED=true to override.\n");
+      exit(2);
+    }
+  }
   const passwordHash = hashPassword(password);
   const entry = { username, name, ...(roles.length ? { roles } : {}), passwordHash };
   stdout.write(JSON.stringify(entry, null, 2) + "\n");


### PR DESCRIPTION
## Q19 — Password policy (basic mode)

Adds a small "basic" password policy and enforces it where it actually matters.

### Where it's enforced (and why there)
The **only** point a management-plane password exists in plaintext is the minting helper `scripts/hash-password.mjs`. The users file stores scrypt hashes only — so there's nothing to re-validate at load time — and login only *verifies* (re-checking policy there would lock out users whose passwords predate a tightened rule). So the policy lives at the minting step, with a reusable module ready for any future change-password endpoint.

### The rules
- **length** ≥ `OMCP_PASSWORD_MIN_LENGTH` (default 12)
- **character classes** ≥ `OMCP_PASSWORD_MIN_CLASSES` of {lower, upper, digit, symbol} (default 3)
- not on a builtin **common-password denylist**
- does not **contain the username**

A weak password is refused with the full violation list; `--force` or `OMCP_PASSWORD_POLICY_DISABLED=true` overrides.

### Shape
- `mcp-server/src/auth/password-policy.ts` — canonical, dependency-free `validatePassword()` + env resolver + denylist.
- `scripts/hash-password.mjs` — enforces before hashing; rules duplicated inline to keep the script dependency-free and source-checkout-runnable (same precedent as the scrypt params already duplicated there). **A unit test guards against drift** between the two copies.
- Config: `OMCP_PASSWORD_{MIN_LENGTH,MIN_CLASSES,DENYLIST_DISABLED,POLICY_DISABLED}`. Documented in `docs/auth-basic.md`.

### Tests
16 unit tests: length (incl. multibyte code-point counting + over-long DoS guard), class counting, denylist case-insensitivity, username containment, env parsing/fallbacks, disable flag, and a CLI↔module drift guard. CLI verified end-to-end (weak rejected exit 2, strong accepted, `--force`/disable bypass). Full suite: **947 tests, 0 fail, 24 skips**. `tsc --noEmit` clean.

Reviewer-agent gate: **SHIP** (no must-fix; its two optional follow-ups — drift guard + documenting the non-ASCII→symbol classification — are both included here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)