### PR TITLE
feat(q21): Health-tab anomaly-score sparkline (last hour)

### DIFF
--- a/docs/anomaly-history.md
+++ b/docs/anomaly-history.md
@@ -83,6 +83,15 @@ works without code changes.
 - **Retention** is the TSDB's job. The gateway never deletes —
   configure the receiver's retention to match your post-mortem
   window (e.g. 30 days).
-- **No live UI sparkline yet** — the Health-tab "score history" view
-  is a separate follow-up. Today the data is consumable via the MCP
-  tool, the operator's Grafana, or any PromQL client.
+- **Health-tab sparkline (since v3.1).** Each Health card renders an
+  inline sparkline of the last hour of `omcp_anomaly_score` for that
+  service, served from `GET /api/health/anomaly-sparklines`. The data
+  comes from an in-process ring the `AnomalyHistory` sink keeps
+  alongside the remote-write tier, so the sparkline works as soon as
+  the gateway records anomalies — it does **not** require the
+  remote-write TSDB round-trip. The series is tenant-scoped and capped
+  to a one-hour window. When no scores have been recorded yet the card
+  falls back to a short-lived client-side trend of the live health
+  score. The remote-write sink remains the durable, queryable store
+  (`get_anomaly_history`, Grafana, any PromQL client) for longer
+  windows and post-mortems.

--- a/mcp-server/src/analysis/history.test.ts
+++ b/mcp-server/src/analysis/history.test.ts
@@ -81,6 +81,60 @@ test("flush: bearer token forwarded as Authorization header", async () => {
   assert.equal(captured.headers["authorization"], "Bearer tok-abc");
 });
 
+// --- Q21: in-process ring (Health-tab sparkline) ----------------------
+
+const NOW = Date.parse("2026-06-06T12:00:00.000Z");
+function at(msAgo: number): string {
+  return new Date(NOW - msAgo).toISOString();
+}
+
+test("ring captures records even when remote-write is disabled", async () => {
+  const h = new AnomalyHistory({ now: () => NOW });
+  assert.equal(h.isEnabled(), false);
+  await h.record(entry({ ts: at(0), score: 0.5 }));
+  const recent = h.recent();
+  assert.equal(recent.length, 1);
+  assert.equal(recent[0].score, 0.5);
+  // ...but the remote-write buffer stays empty when disabled.
+  assert.equal(h.bufferSize(), 0);
+});
+
+test("recent: drops records outside the retention window", async () => {
+  const h = new AnomalyHistory({ now: () => NOW, retentionMs: 60 * 60 * 1000 });
+  await h.record(entry({ ts: at(30 * 60 * 1000) })); // 30m ago — kept
+  await h.record(entry({ ts: at(90 * 60 * 1000) })); // 90m ago — evicted on next push/prune
+  const recent = h.recent();
+  assert.equal(recent.length, 1);
+  assert.equal(recent[0].ts, at(30 * 60 * 1000));
+});
+
+test("recent: oldest-first and filterable by service + tenant", async () => {
+  const h = new AnomalyHistory({ now: () => NOW });
+  await h.record(entry({ ts: at(3000), service: "payment", tenant: "a", score: 0.1 }));
+  await h.record(entry({ ts: at(1000), service: "payment", tenant: "a", score: 0.3 }));
+  await h.record(entry({ ts: at(2000), service: "orders", tenant: "a", score: 0.2 }));
+  await h.record(entry({ ts: at(500), service: "payment", tenant: "b", score: 0.9 }));
+
+  const pay = h.recent({ service: "payment", tenant: "a" });
+  assert.deepEqual(pay.map((r) => r.score), [0.1, 0.3], "oldest-first, service+tenant filtered");
+
+  const tenantA = h.recentServices("a").sort();
+  assert.deepEqual(tenantA, ["orders", "payment"]);
+  assert.deepEqual(h.recentServices("b"), ["payment"]);
+});
+
+test("ring honours the hard cap (ringMax)", async () => {
+  const h = new AnomalyHistory({ now: () => NOW, ringMax: 3 });
+  for (let i = 0; i < 10; i++) await h.record(entry({ ts: at(10_000 - i), score: i / 10 }));
+  const recent = h.recent();
+  assert.equal(recent.length, 3, "ring capped at ringMax");
+});
+
+test("windowMs surfaces the retention window", () => {
+  assert.equal(new AnomalyHistory({ retentionMs: 1234 }).windowMs, 1234);
+  assert.equal(new AnomalyHistory({}).windowMs, 60 * 60 * 1000);
+});
+
 test("flush: clears the buffer on success", async () => {
   const h = new AnomalyHistory({
     url: "https://tsdb/api/v1/write",

--- a/mcp-server/src/analysis/history.ts
+++ b/mcp-server/src/analysis/history.ts
@@ -44,6 +44,14 @@ export interface AnomalyHistoryConfig {
   requestTimeoutMs?: number;
   /** Inject fetch for tests. */
   fetchImpl?: typeof fetch;
+  /** In-process ring retention window (ms). Default 3 600 000 (1h).
+   *  Powers the Health-tab sparkline; independent of remote-write. */
+  retentionMs?: number;
+  /** Hard cap on ring entries (defends memory under a score storm).
+   *  Default 5 000. */
+  ringMax?: number;
+  /** Clock injection for tests. Returns epoch ms. */
+  now?: () => number;
 }
 
 export function fromEnv(env: NodeJS.ProcessEnv = process.env): AnomalyHistoryConfig {
@@ -78,7 +86,14 @@ export class AnomalyHistory {
   private readonly maxBufferSize: number;
   private readonly requestTimeoutMs: number;
   private readonly fetchImpl: typeof fetch;
+  private readonly retentionMs: number;
+  private readonly ringMax: number;
+  private readonly nowFn: () => number;
   private buffer: AnomalyRecord[] = [];
+  /** Bounded, time-windowed in-process tier of the sink — powers the
+   *  Health-tab sparkline. Captured on every record() regardless of
+   *  remote-write so the sparkline works out of the box. */
+  private ring: AnomalyRecord[] = [];
   private timer?: NodeJS.Timeout;
   private flushing = false;
 
@@ -90,6 +105,9 @@ export class AnomalyHistory {
     this.maxBufferSize = cfg.maxBufferSize ?? 500;
     this.requestTimeoutMs = cfg.requestTimeoutMs ?? 5_000;
     this.fetchImpl = cfg.fetchImpl ?? fetch;
+    this.retentionMs = cfg.retentionMs ?? 60 * 60 * 1000;
+    this.ringMax = cfg.ringMax ?? 5_000;
+    this.nowFn = cfg.now ?? Date.now;
   }
 
   /** Whether the history sink is enabled (URL configured). */
@@ -118,14 +136,62 @@ export class AnomalyHistory {
     if (this.isEnabled()) await this.flush().catch(() => undefined);
   }
 
-  /** Add one anomaly to the buffer. Silently drops when disabled.
-   *  Triggers a synchronous flush if the buffer crosses maxBufferSize. */
+  /** Add one anomaly. Always captured into the in-process ring (powers
+   *  the sparkline); additionally buffered for remote-write only when the
+   *  sink is enabled. Triggers a synchronous flush past maxBufferSize. */
   async record(entry: AnomalyRecord): Promise<void> {
+    this.pushRing(entry);
     if (!this.isEnabled()) return;
     this.buffer.push(entry);
     if (this.buffer.length >= this.maxBufferSize) {
       await this.flush().catch(() => undefined);
     }
+  }
+
+  /** Append to the ring + evict anything outside the retention window or
+   *  beyond the hard cap. O(n) prune is fine — anomaly records are
+   *  infrequent and n is bounded by ringMax. */
+  private pushRing(entry: AnomalyRecord): void {
+    this.ring.push(entry);
+    const cutoff = this.nowFn() - this.retentionMs;
+    this.ring = this.ring.filter((r) => {
+      const t = Date.parse(r.ts);
+      return Number.isFinite(t) && t >= cutoff;
+    });
+    if (this.ring.length > this.ringMax) {
+      this.ring = this.ring.slice(this.ring.length - this.ringMax);
+    }
+  }
+
+  /**
+   * Recent records from the in-process ring, oldest-first. Filters by
+   * service and/or tenant when supplied and drops anything older than the
+   * retention window. Returns a fresh array (safe for the caller to map).
+   */
+  recent(opts: { service?: string; tenant?: string } = {}): AnomalyRecord[] {
+    const cutoff = this.nowFn() - this.retentionMs;
+    return this.ring
+      .filter((r) => {
+        const t = Date.parse(r.ts);
+        if (!Number.isFinite(t) || t < cutoff) return false;
+        if (opts.service && r.service !== opts.service) return false;
+        if (opts.tenant && r.tenant !== opts.tenant) return false;
+        return true;
+      })
+      .sort((a, b) => Date.parse(a.ts) - Date.parse(b.ts));
+  }
+
+  /** Distinct services with at least one record in the retention window,
+   *  optionally tenant-scoped. */
+  recentServices(tenant?: string): string[] {
+    const seen = new Set<string>();
+    for (const r of this.recent({ tenant })) seen.add(r.service);
+    return [...seen];
+  }
+
+  /** Retention window in ms — surfaced so the API/UI can label the range. */
+  get windowMs(): number {
+    return this.retentionMs;
   }
 
   /** Send the current buffer to the remote-write endpoint. Drops the

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -3048,6 +3048,31 @@ async function main() {
     });
   });
 
+  // Q21 — per-service anomaly-score sparklines for the Health tab. Reads
+  // the in-process ring of the anomaly-history sink (last hour), tenant-
+  // scoped. MUST be registered before "/api/health/:service" so the
+  // literal path isn't captured as a service name. `enabled` is true once
+  // any score exists; the UI falls back to its client-side trend otherwise.
+  app.get("/api/health/anomaly-sparklines", (req, res) => {
+    const sess = (req as AuthedRequest).session;
+    const callerTenant = sess?.tenant || "default";
+    // Anonymous (single-tenant) mode: no tenant filter, see everything.
+    const tenant = sess ? callerTenant : undefined;
+    const records = anomalyHistory.recent({ tenant });
+    const series: Record<string, Array<{ t: number; score: number }>> = {};
+    for (const r of records) {
+      const t = Date.parse(r.ts);
+      if (!Number.isFinite(t)) continue;
+      (series[r.service] ??= []).push({ t, score: r.score });
+    }
+    res.json({
+      enabled: records.length > 0,
+      remoteWrite: anomalyHistory.isEnabled(),
+      windowMs: anomalyHistory.windowMs,
+      series,
+    });
+  });
+
   // Health endpoint for UI dashboard
   app.get("/api/health/:service", async (req, res) => {
     try {

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -6251,9 +6251,8 @@ function saveMetric() {
 // --- Health Dashboard ---
 let healthData={};
 let healthInterval=null;
-// Score history per service, kept client-side. The server doesn't yet
-// expose a per-service score timeseries — this gives an at-a-glance trend
-// for the last ~7.5 minutes (30 points × 15s refresh).
+// Client-side live-score trend, kept as a fallback for when the server's
+// anomaly-history sink isn't active. ~7.5 minutes (30 points × 15s refresh).
 const SPARK_MAX = 30;
 const scoreHistory = {};
 function pushScore(name, score) {
@@ -6262,31 +6261,59 @@ function pushScore(name, score) {
   arr.push(score);
   if (arr.length > SPARK_MAX) arr.shift();
 }
-function sparkSvg(name, status) {
-  const pts = scoreHistory[name] || [];
+// Server-side anomaly-score history (Q21). Populated from
+// /api/health/anomaly-sparklines — the last hour of omcp_anomaly_score
+// from the anomaly-history sink. Survives reloads; preferred over the
+// client-side trend when present.
+let anomalySpark = { enabled:false, windowMs:0, series:{} };
+
+function drawSpark(values, status, domainMax, title){
   const w = 100, h = 36, pad = 2;
-  if (pts.length < 2) {
-    // Placeholder dashed midline until we have ≥2 samples.
+  if (!values || values.length < 2) {
     return `<svg class="hc-spark ${status}" viewBox="0 0 ${w} ${h}" preserveAspectRatio="none" aria-hidden="true">`
       + `<line class="spark-empty" x1="0" y1="${h/2}" x2="${w}" y2="${h/2}"/></svg>`;
   }
-  const min = 0, max = 100;
-  const step = (w - pad*2) / (pts.length - 1);
-  const y = v => h - pad - ((v - min) / (max - min)) * (h - pad*2);
-  const coords = pts.map((v, i) => `${pad + i*step},${y(v)}`);
+  const min = 0, max = domainMax;
+  const step = (w - pad*2) / (values.length - 1);
+  const y = v => h - pad - ((Math.max(min, Math.min(max, v)) - min) / (max - min || 1)) * (h - pad*2);
+  const coords = values.map((v, i) => `${pad + i*step},${y(v)}`);
   const line = coords.join(' ');
-  const area = `M${coords[0]} L${line.split(' ').join(' L')} L${pad + (pts.length-1)*step},${h-pad} L${pad},${h-pad} Z`;
+  const area = `M${coords[0]} L${line.split(' ').join(' L')} L${pad + (values.length-1)*step},${h-pad} L${pad},${h-pad} Z`;
   const last = coords[coords.length - 1].split(',');
   return `<svg class="hc-spark ${status}" viewBox="0 0 ${w} ${h}" preserveAspectRatio="none" aria-hidden="true">`
+    + (title?`<title>${esc(title)}</title>`:'')
     + `<path class="spark-fill" d="${area}"/>`
     + `<polyline class="spark-line" points="${line}"/>`
     + `<circle class="spark-dot" cx="${last[0]}" cy="${last[1]}" r="1.8"/>`
     + `</svg>`;
 }
 
+function sparkSvg(name, status) {
+  // Prefer the server anomaly-score series (real omcp_anomaly_score, last
+  // hour, survives reload). Anomaly scores are 0..1; widen the domain if a
+  // score ever exceeds 1 so spikes aren't clipped.
+  const series = (anomalySpark.series && anomalySpark.series[name]) || [];
+  if (series.length >= 2) {
+    const scores = series.map(p => p.score);
+    const domainMax = Math.max(1, ...scores);
+    const mins = anomalySpark.windowMs ? Math.round(anomalySpark.windowMs/60000) : 60;
+    return drawSpark(scores, status, domainMax, `anomaly score · ${series.length} pts · last ${mins}m`);
+  }
+  // Fallback: client-side live health-score trend (0..100).
+  return drawSpark(scoreHistory[name] || [], status, 100, 'live score trend');
+}
+
 async function loadHealthData() {
   try {
-    healthData=await(await fetch('/api/health')).json();
+    // Fetch health + the server-side anomaly-score sparkline data in
+    // parallel. The sparkline endpoint is best-effort: if it fails we
+    // simply fall back to the client-side live-score trend.
+    const [h, spark] = await Promise.all([
+      fetch('/api/health').then(r=>r.json()),
+      fetch('/api/health/anomaly-sparklines').then(r=>r.ok?r.json():null).catch(()=>null),
+    ]);
+    healthData=h;
+    if (spark && spark.series) anomalySpark = spark;
     renderHealthCards();
   } catch(e){ document.getElementById('health-cards').innerHTML='<div class="empty">Failed to load health data.</div>'; }
   if(!healthInterval) healthInterval=setInterval(()=>{ if(document.getElementById('page-health').classList.contains('active')) loadHealthData(); },15000);


### PR DESCRIPTION
## Q21 — Health-tab anomaly sparkline

Each Health card now shows an inline sparkline of the **last hour of `omcp_anomaly_score`** for that service.

### The gap
The `AnomalyHistory` sink only remote-wrote to a TSDB and dropped its buffer, so the Health tab's existing sparkline was a client-side, ~7.5-minute trend that vanished on reload (its own comment said *"the server doesn't yet expose a per-service score timeseries"*).

### What this adds
- **`analysis/history.ts`** — a bounded, time-windowed **in-process ring** tier on the sink. `record()` always populates it (independent of remote-write), so the sparkline works as soon as the gateway records anomalies — no TSDB round-trip required. 1h retention default, `ringMax` hard cap, clock-injectable for tests. New `recent()` / `recentServices()` / `windowMs` getters.
- **`index.ts`** — `GET /api/health/anomaly-sparklines`: per-service last-hour series, **tenant-scoped**. Registered **before** `/api/health/:service` so the literal path isn't captured as a service name.
- **`ui/index.html`** — `sparkSvg` prefers the server anomaly series (real scores 0..1, survives reload) and **falls back** to the existing client-side live-score trend; the sparkline fetch is best-effort and degrades cleanly if it fails.
- **`docs/anomaly-history.md`** — documents the sparkline + endpoint; replaces the stale "no live UI sparkline yet" note.

The durable remote-write sink remains the queryable store (`get_anomaly_history`, Grafana, PromQL) for longer windows and post-mortems — the ring is just the local tier that powers the at-a-glance trend.

### Verification
E2E: endpoint returns `{enabled, remoteWrite, windowMs, series}` and resolves correctly (not shadowed by `:service`). 17 history-sink tests (ring capture-when-disabled, retention eviction, service/tenant filter + ordering, `ringMax` cap, `windowMs`). Full suite: **964 tests, 0 fail, 24 skips**. `tsc --noEmit` clean.

Reviewer-agent gate: **SHIP** (no must-fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)