### PR TITLE
docs(q22-24): v3.1.0 CHANGELOG + migration guide + ROADMAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,124 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.1.0] — 2026-06-08
+
+Incremental release — the **Phase Q sprint** closes the
+"Deferred to v3.x" backlog from 3.0. Every item is opt-in via env /
+Helm value; migrating from 3.0 is **purely additive** (3.0.1 was a
+republish-only version bump with no behaviour change). See
+[`docs/migrations/3.0-to-3.1.md`](docs/migrations/3.0-to-3.1.md).
+
+### Added — topology providers
+
+Five concrete providers on the F14a multi-cloud merger foundation.
+Each ships as a filesystem connector (lazy-loaded SDK, manifest
+integrity + hub catalog entry) and merges into the unified topology
+graph so a single service collapses across providers.
+
+- **AWS** (`connectors/aws/`) — EC2 instances, ECS services/tasks,
+  EKS clusters/nodepools → `cloud_service` / `cloud_node` resources
+  with `OWNED_BY` / `RUNS_ON` edges. Standard AWS SDK credential
+  chain.
+- **GCP** (`connectors/gcp/`) — GKE clusters/nodepools, Cloud Run
+  services, Compute Engine instances.
+- **Istio** (`connectors/istio/`) — `CALLS` edges derived from
+  `istio_requests_total` in the mesh's Prometheus.
+- **Linkerd** (`connectors/linkerd/`) — `CALLS` edges from the viz
+  `response_total` series.
+- **Consul** (`connectors/consul/`) — Consul Connect service graph
+  via the catalog + health HTTP API.
+
+### Added — federation transports
+
+- **Stdio upstream** — federate an upstream MCP server spawned as a
+  child process (`name=stdio:<command>`).
+- **WebSocket upstream** — federate over the WS transport
+  (`name=ws://host/mcp/ws`). Both share the existing
+  `UpstreamClient` interface and the federation E2E harness.
+
+### Added — plugin / hook system
+
+- **Manifest-driven hook auto-registration** — `manifest.hooks[]`
+  entries register into the `HookRegistry` at load; plugins no
+  longer need programmatic wiring.
+- **Resource + prompt hooks at the MCP seam** —
+  `resource_pre_fetch` / `resource_post_fetch` / `prompt_pre_fetch`
+  / `prompt_post_fetch` now fire around `resources/read` and
+  `prompts/get`, mirroring the tool hooks.
+
+### Added — provisioning (SCIM 2.0)
+
+- **Redis-backed SCIM store** — `OMCP_SCIM_BACKEND=redis` shares a
+  single snapshot across replicas (file remains the default).
+- **PATCH add/remove on `members[]` + `emails[]`**, including the
+  `members[value eq "x"]` filter path Entra/Okta emit.
+- **Full SCIM 2.0 compliance suite** (`scim/compliance.test.ts`,
+  env-gated) — discovery, the 401 gate, the User+Group lifecycle,
+  409/404 with the SCIM error schema. Surfaced + fixed two
+  production wiring bugs (`application/scim+json` body parsing; the
+  Redis backend not reaching prod).
+
+### Added — operability
+
+- **S3-compatible audit sink** — per-minute JSONL rollups to
+  S3 / MinIO / R2 / B2 (`audit.s3.*`).
+- **Redis-backed transport session map** — multi-replica gateways
+  no longer need sticky ingress for Streamable HTTP sessions.
+- **In-product Playground tab** — pick a live tool, render its
+  input schema as a form, invoke, and view a pretty / table / raw
+  response. Backed by `POST /api/playground/invoke`.
+- **Health-tab anomaly sparkline** — each card shows the last hour
+  of `omcp_anomaly_score` from an in-process ring on the
+  `AnomalyHistory` sink (`GET /api/health/anomaly-sparklines`); no
+  TSDB round-trip required.
+
+### Added — security hardening
+
+- **Session revocation blocklist** — `POST /api/auth/revocations`
+  revokes a single session (`sid`) or every session for a subject;
+  checked on each request. On-disk JSONL
+  (`OMCP_AUTH_REVOCATION_FILE`).
+- **Per-account login lockout** — failed-login counter with
+  progressive backoff, on top of the per-IP rate limit; backed by
+  the shared session store. `OMCP_AUTH_LOCKOUT_*`.
+- **Password policy** for basic-auth credential minting — length /
+  character-class / common-password-denylist checks in
+  `hash-password.mjs`. `OMCP_PASSWORD_*`.
+- **Content-Security-Policy** for the Web UI — an enforced
+  lockdown policy (`default-src 'self'`, `object-src 'none'`, …)
+  plus per-request nonces and an opt-in strict report-only policy
+  (`OMCP_CSP_STRICT_REPORT`) that reports to `/api/csp-violations`.
+
+### Added — post-3.0 increments (first released here)
+
+These landed on `main` shortly after the 3.0.0 tag but were never cut
+into a release (3.0.1 was republish-only), so they ship to users for
+the first time in 3.1.0:
+
+- **Policies "Batch evaluate" panel** — a Policies-tab sub-view over
+  the existing `POST /api/policy/dry-run-batch` API (matrix / CSV).
+- **Postmortems persistence + UI tab** — `/api/postmortems` now
+  persists (`OMCP_POSTMORTEMS_FILE`) and a Postmortems nav page
+  lists + renders generated reports. (A custom template engine
+  remains future work.)
+
+### Changed — tooling
+
+- **SDK source-sync tooling** (`make sdk-sync` / `make sdk-parity`)
+  replaces hand-maintenance of the vendored SDK copy; a CI parity
+  gate prevents drift.
+
+### Backwards compatibility
+
+Every 3.1 capability is opt-in via env or Helm value. The default
+single-replica anonymous-auth demo runs identically on 3.0 and 3.1.
+
+## [3.0.1] — 2026-06-08
+
+Republish-only version bump (Helm chart + npm) to resolve an
+ArtifactHub image-scan mismatch. No code or behaviour changes.
+
 ## [3.0.0] — 2026-06-06
 
 Major release. v3.0 is the **moat-extension sprint** on top of the
@@ -81,26 +199,17 @@ is opt-in via env / Helm value. See
 
 ### Deferred to v3.x (incremental)
 
-- Concrete AWS / GCP / Consul / Istio / Linkerd topology-provider
-  connectors (F14a foundation ships; F14b–f are the providers).
-- Detector-side hook that fills the anomaly-history buffer from
-  the live `detect_anomalies` path (F15b — writer + tool already
-  live).
-- UI "Batch evaluate" panel in the Policies tab (F16b — API is
-  fully usable today).
-- F17b strict-mode mkdocs build (clean up the 14 cross-repo links
+> Most of this list shipped in **3.1.0** (the Phase Q sprint) — see
+> that section above. The items below remain open after 3.1:
+
+- F17b strict-mode mkdocs build (clean up the cross-repo links
   flagged as warnings).
-- Playground UI tab that mirrors Inspector inline (F18b — the
-  real Inspector via `omcp inspector-config` is the supported
-  path today).
-- `/api/postmortems` persistence, UI Postmortems tab, custom
-  template engine (F19b/c — tool is fully usable today).
-- npm-workspace setup so the SDK package becomes the canonical
-  source and mcp-server depends on it instead of vendoring
-  (F20b — current setup uses a CI parity check).
-- SCIM filter/search, member[] add/remove patch ops,
-  Redis-backed store, UI Provisioning sub-tab, full SCIM 2.0
-  compliance suite (F21b/c — push-only Entra+Okta work today).
+- A custom postmortem template engine (F19c — persistence and the
+  Postmortems UI tab already shipped; today templates are built-in).
+- SCIM filter/search on the collection endpoints + a UI
+  Provisioning sub-tab (F21 — push-only Entra+Okta provisioning
+  works today; PATCH add/remove, the Redis store, and the full
+  compliance suite all shipped in 3.1).
 
 ### Backwards compatibility
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,31 @@ Where the project is going at a thematic level. For the connector-plugin enginee
 
 Items here are **directions, not promises** — order will shift based on what users actually need. If something here matters to you, open a Discussion or an Issue.
 
+## v3.1 — shipped 2026-06-08
+
+The **Phase Q** sprint — closes the "Deferred to v3.x" backlog from
+3.0. All additive / opt-in. See [CHANGELOG.md](CHANGELOG.md) for
+per-capability detail and
+[`docs/migrations/3.0-to-3.1.md`](docs/migrations/3.0-to-3.1.md).
+
+- ✅ Concrete topology providers: AWS, GCP, Istio, Linkerd, Consul (on the v3.0 merger foundation)
+- ✅ Federation upstream transports: stdio + WebSocket
+- ✅ SCIM 2.0: Redis-backed store, PATCH add/remove on `members[]`/`emails[]`, full compliance suite
+- ✅ Manifest-driven plugin hook auto-registration + resource/prompt hooks at the MCP seam
+- ✅ S3-compatible audit sink + Redis-backed transport session map (sticky-ingress-free multi-replica)
+- ✅ In-product Playground tab + Health-tab anomaly sparkline
+- ✅ Security hardening: session revocation, per-account lockout, password policy, Content-Security-Policy
+
+### v3.2 — candidates
+
+The remaining 3.0 deferred items, still open after 3.1 (vote via
+Discussions):
+
+- A custom postmortem template engine (persistence + the Postmortems UI tab already ship)
+- SCIM filter/search on the collection endpoints + a UI Provisioning sub-tab
+- Strict-mode MkDocs build (resolve the cross-repo link warnings)
+- Raw PromQL/LogQL passthrough + log label-selectors/aggregation for agent analytics (see issue #415) — gated behind a `raw_query` capability
+
 ## v3.0 — shipped 2026-06-06
 
 The moat-extension sprint on top of v2.0. See

--- a/docs/migrations/3.0-to-3.1.md
+++ b/docs/migrations/3.0-to-3.1.md
@@ -1,0 +1,86 @@
+# Migrating from 3.0 to 3.1
+
+3.1 is the **Phase Q** incremental release on top of 3.0. The
+migration is **purely additive** — every new capability is opt-in via
+env or Helm value, and the default
+`docker compose --profile demo up` runs identically on 3.0 and 3.1.
+No behaviour flips required. (3.0.1 was a republish-only version bump
+with no behaviour change.)
+
+## tl;dr
+
+| You are running… | Required action |
+|---|---|
+| The OSS demo (`docker compose --profile demo up`) | None — defaults unchanged. |
+| `helm install obs ./helm/observability-mcp` (defaults) | None — still single-replica, no Redis, no SCIM, anonymous auth. |
+| Any custom Helm values from 3.0 | None. The new value blocks below are all off by default. |
+| Basic-auth (`OMCP_AUTH=basic`) | None. The new password policy is enforced only when you *mint* a password via `hash-password.mjs`; existing hashes keep working. Account lockout is on by default but only triggers after repeated failures (tunable / disablable). |
+| A plugin author | Optionally adopt `manifest.hooks[]` auto-registration; programmatic registration still works. |
+
+## New opt-in capabilities
+
+| Env / Value | What it does | Docs |
+|---|---|---|
+| `OMCP_SCIM_BACKEND=redis` + `OMCP_SCIM_REDIS_URL` | Shared SCIM snapshot across replicas (file remains default). | [scim-provisioning.md](../scim-provisioning.md) |
+| `OMCP_AUTH_REVOCATION_FILE=<path>` | Persist the session revocation blocklist across restarts. | [access-control.md](../access-control.md#session-revocation) |
+| `OMCP_AUTH_LOCKOUT_*` | Tune per-account login lockout (`MAX_FAILURES` / `WINDOW` / `BASE` / `MAX`); `OMCP_AUTH_LOCKOUT_DISABLED=true` turns it off. | [auth-basic.md](../auth-basic.md#account-lockout) |
+| `OMCP_PASSWORD_*` | Tune the credential-minting password policy (`MIN_LENGTH` / `MIN_CLASSES` / `DENYLIST_DISABLED` / `POLICY_DISABLED`). | [auth-basic.md](../auth-basic.md#password-policy) |
+| `OMCP_CSP_STRICT_REPORT=true` | Emit the strict report-only CSP (surfaces inline-handler debt; off by default to avoid console noise). | [auth-and-tls.md](../auth-and-tls.md#content-security-policy-web-ui) |
+| `OMCP_REDIS_URL` (already in 3.0) | Now also backs the Streamable HTTP **transport session map** and the **account-lockout** store — multi-replica gateways no longer need sticky ingress. | [horizontal-scaling.md](../horizontal-scaling.md) |
+| `audit.s3.*` (Helm) / `OMCP_AUDIT_S3_*` | S3-compatible audit sink (S3 / MinIO / R2 / B2). | [audit-sinks.md](../audit-sinks.md) |
+| `OMCP_FEDERATION_UPSTREAMS=name=stdio:<cmd>` / `name=ws://…` | Federate upstream MCP servers over stdio or WebSocket. | [federation.md](../federation.md) |
+
+## New topology providers
+
+Five concrete providers on the 3.0 multi-cloud merger foundation —
+each a filesystem connector installed from the hub or mounted under
+`plugins/`:
+
+| Provider | Discovers | Edges |
+|---|---|---|
+| `aws` | EC2 / ECS / EKS | `OWNED_BY`, `RUNS_ON` |
+| `gcp` | GCE / Cloud Run / GKE | `OWNED_BY`, `RUNS_ON` |
+| `istio` | mesh services (via Prometheus) | `CALLS` |
+| `linkerd` | mesh services (via viz) | `CALLS` |
+| `consul` | Consul Connect services | `CALLS` |
+
+They merge into the same topology graph as the built-in Kubernetes
+source, so a service that appears in multiple providers collapses to
+one node.
+
+## New endpoints
+
+- `GET /api/health/anomaly-sparklines` — per-service last-hour
+  anomaly-score series for the Health-tab sparkline.
+- `POST /api/auth/revocations` / `GET /api/auth/revocations` —
+  session revocation (admin).
+- `POST /api/csp-violations` — CSP report sink (browser-posted).
+- `POST /api/playground/invoke` — backs the in-product Playground tab.
+
+## New UI
+
+- **Playground** tab — invoke any live tool from a generated form.
+- **Health** cards now render an anomaly-score sparkline (last hour).
+
+These are inert until you use them; no existing view changed shape.
+
+## Security defaults that changed
+
+Two hardening features are **on by default** but designed to be
+invisible in normal use:
+
+- **Account lockout** — only triggers after
+  `OMCP_AUTH_LOCKOUT_MAX_FAILURES` (default 5) failed logins for one
+  username inside the window. Set `OMCP_AUTH_LOCKOUT_DISABLED=true` to
+  opt out.
+- **Content-Security-Policy** — the enforced policy keeps the UI fully
+  working (it allows the inline handlers the single-file UI relies on).
+  If you embed the UI in an iframe, note `frame-ancestors 'none'`.
+
+Everything else (revocation persistence, strict CSP report-only,
+password policy tuning, Redis backends) is opt-in.
+
+## Nothing removed
+
+No env var, Helm value, endpoint, MCP tool, or CLI command was
+removed or renamed in 3.1. The 3.0 surface is a strict subset of 3.1.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
   - Migrations:
       - 1.x → 2.0: migrations/1.x-to-2.0.md
       - 2.x → 3.0: migrations/2.x-to-3.0.md
+      - 3.0 → 3.1: migrations/3.0-to-3.1.md
 
 extra:
   social:


### PR DESCRIPTION
## Q22–Q24 — release-prep docs for v3.1.0

Bundled the three release-prep doc slices (all tightly coupled, feed the Q25 release):

- **Q22 — CHANGELOG** `[3.1.0]` entry covering the Phase Q sprint (Q1–Q21): topology providers (AWS/GCP/Istio/Linkerd/Consul), federation transports (stdio/ws), SCIM (Redis store + PATCH add/remove + compliance suite), plugin/hook system, S3 audit sink, Redis transport map, Playground tab, Health sparkline, security hardening (revocation/lockout/password-policy/CSP), SDK tooling. Plus a `[3.0.1]` republish-only note and a pruned "Deferred to v3.x" list.
- **Q23 — `docs/migrations/3.0-to-3.1.md`** — additive-only migration guide: tl;dr table, new opt-in env/Helm, new endpoints/UI, and the two on-by-default-but-invisible security features (lockout, CSP).
- **Q24 — ROADMAP** — v3.1 marked shipped; v3.2 candidates section.
- mkdocs nav entry for the new migration doc.

### Reviewer-agent gate
Caught two **false "deferred" claims** — the Policies batch-evaluate UI panel (#385) and postmortems persistence + UI tab (#387) had already shipped to main (after the 3.0.0 tag, never released). Fixed: removed them from the deferred/candidate lists and documented them in the 3.1.0 "post-3.0 increments first released here" subsection. All env vars / endpoints / connectors / doc links spot-checked against the code; sensitive-data scan clean. Verdict after fixes: SHIP.

Docs-only; no code changes. The `Build site` CI validates the mkdocs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)