### PR TITLE
chore(release): v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,21 @@ graph so a single service collapses across providers.
   `AnomalyHistory` sink (`GET /api/health/anomaly-sparklines`); no
   TSDB round-trip required.
 
+### Added — agent log analytics (issue #415)
+
+- **`query_logs` structured label filters** — a `labels` map of
+  exact-match filters (method/status/url/ip/environment, …), AND'd
+  together, compiled to LogQL label filters after `| json`. Far more
+  reliable than regex on structured JSON logs, where `GET /` never
+  appears verbatim. `environment` filtering falls out for free. Log
+  `level` is now also derived from HTTP status (5xx→error, 4xx→warn)
+  when no explicit level field exists.
+- **`query_logs` server-side aggregation** — an `aggregate`
+  ({op: count_over_time|sum|topk, by, k, step}) that pushes counting
+  down to LogQL metric queries, so an agent gets a number (top paths,
+  per-status totals, a count time series) instead of pulling raw rows
+  and hitting `limit`.
+
 ### Added — security hardening
 
 - **Session revocation blocklist** — `POST /api/auth/revocations`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,6 +18,7 @@ per-capability detail and
 - ✅ S3-compatible audit sink + Redis-backed transport session map (sticky-ingress-free multi-replica)
 - ✅ In-product Playground tab + Health-tab anomaly sparkline
 - ✅ Security hardening: session revocation, per-account lockout, password policy, Content-Security-Policy
+- ✅ Agent log analytics (issue #415): `query_logs` structured label filters + server-side aggregation (count/sum/topk)
 
 ### v3.2 — candidates
 
@@ -27,7 +28,7 @@ Discussions):
 - A custom postmortem template engine (persistence + the Postmortems UI tab already ship)
 - SCIM filter/search on the collection endpoints + a UI Provisioning sub-tab
 - Strict-mode MkDocs build (resolve the cross-repo link warnings)
-- Raw PromQL/LogQL passthrough + log label-selectors/aggregation for agent analytics (see issue #415) — gated behind a `raw_query` capability
+- Raw PromQL/LogQL passthrough for agent analytics (issue #415 item #3) — gated behind a `raw_query` capability (label-selectors + aggregation already shipped in 3.1)
 
 ## v3.0 — shipped 2026-06-06
 

--- a/docs/migrations/3.0-to-3.1.md
+++ b/docs/migrations/3.0-to-3.1.md
@@ -48,6 +48,15 @@ They merge into the same topology graph as the built-in Kubernetes
 source, so a service that appears in multiple providers collapses to
 one node.
 
+## Enhanced MCP tools
+
+- **`query_logs`** gains two optional, additive params (issue #415):
+  `labels` (exact-match filters on backend-extracted fields like
+  method/status/url/environment) and `aggregate`
+  (`count_over_time`/`sum`/`topk` pushed down to LogQL metric queries).
+  Existing `query_logs` calls are unchanged. See
+  [loki.md](../loki.md#structured-label-filters-labels).
+
 ## New endpoints
 
 - `GET /api/health/anomaly-sparklines` — per-service last-hour

--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,11 +4,11 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 2.0.2
+version: 2.1.0
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
-appVersion: "3.0.1"
+appVersion: "3.1.0"
 
 home: https://github.com/ThoTischner/observability-mcp
 sources:
@@ -51,38 +51,26 @@ annotations:
     url: https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc
   artifacthub.io/images: |
     - name: observability-mcp
-      image: ghcr.io/thotischner/observability-mcp:3.0.1
+      image: ghcr.io/thotischner/observability-mcp:3.1.0
       platforms:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
-    - kind: fixed
-      description: artifacthub.io/images now points at the current 3.0.0 image (was stale at 1.8.1, causing ArtifactHub to scan an old image with 4 medium-severity findings — the 3.0.0 image scans clean)
-    - kind: added
-      description: plugins.persistence — back /app/plugins with a PVC so connectors installed at runtime (Web UI / bundle upload / omcp) survive pod restarts
-    - kind: added
-      description: plugins.uiInstall — enable the fail-closed Web UI / API connector install + upload endpoints (ENABLE_UI_INSTALL; requires a plugin trust root)
     - kind: changed
-      description: plugins.image now defaults to the official signed bundle (ghcr.io/thotischner/observability-mcp-plugins:latest) — connectors available on a plain helm install; set plugins.image="" to opt out
+      description: appVersion → 3.1.0 (Phase Q sprint); chart points at the 3.1.0 image
     - kind: added
-      description: Connector Hub link (https://thotischner.github.io/observability-mcp/hub/)
+      description: SCIM Redis-backed store (scim.backend=redis) for multi-replica provisioning
     - kind: added
-      description: plugins.image init-container extraction + plugins.verify (VERIFY_PLUGINS + trust-root) for airgapped connectors
-    - kind: fixed
-      description: Chart packages are now actually GPG-signed (.prov shipped) — signing key regenerated, CI import fixed
-    - kind: fixed
-      description: Chart icon points at an existing SVG (logo.png 404 fixed)
+      description: S3-compatible audit sink (audit.s3.*) — S3 / MinIO / R2 / B2
     - kind: added
-      description: GPG signing of chart packages — \"signed\" badge on ArtifactHub
-    - kind: fixed
-      description: Chart icon points at an existing SVG (logo.png 404 fixed)
+      description: Session revocation blocklist, per-account login lockout, and basic-auth password policy
     - kind: added
-      description: values.schema.json — Helm validates input types before render
+      description: Content-Security-Policy on the Web UI (enforced + opt-in strict report-only)
     - kind: added
-      description: Helm test pod (`helm test <release>`) that probes /readyz on the service
+      description: Redis-backed transport session map — multi-replica gateways no longer need sticky ingress
     - kind: added
-      description: Optional prometheus.io/scrape annotations on the Service for clusters without prometheus-operator
+      description: Health-tab anomaly-score sparkline + in-product Playground tab
     - kind: added
-      description: NOTES.txt with post-install instructions
+      description: Federation upstream transports (stdio + WebSocket); manifest-driven plugin hook auto-registration
     - kind: added
-      description: artifacthub.io/images and artifacthub.io/changes annotations
+      description: query_logs structured label filters + server-side aggregation (count/sum/topk) for agent log analytics (issue #415)

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thotischner/observability-mcp",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -30,8 +30,8 @@ for the full plugin contract.
 
 ## Compatibility
 
-Version-tracks the parent gateway. SDK `2.x` works with
-observability-mcp `2.x`; the manifest `schemaVersion` is the
+Version-tracks the parent gateway. SDK `3.x` works with
+observability-mcp `3.x`; the manifest `schemaVersion` is the
 authoritative compat marker — see
 [`docs/plugin-architecture.md`](https://github.com/ThoTischner/observability-mcp/blob/main/docs/plugin-architecture.md).
 

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thotischner/observability-mcp-sdk",
-  "version": "2.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thotischner/observability-mcp-sdk",
-      "version": "2.0.0",
+      "version": "3.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^4.4.3"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp-sdk",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Plugin SDK for observability-mcp — types + Zod schemas + lifecycle-hook helpers for authoring connectors and post-tool hooks.",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## v3.1.0 — Phase Q sprint release

The dedicated release closing the entire Phase Q sprint (Q1–Q24) plus the agent log-analytics work from **issue #415** (Q-LOG1/Q-LOG2). All changes are additive / opt-in; migrating from 3.0 is purely additive (3.0.1 was a republish-only bump).

### Version bumps
- `mcp-server` **3.0.1 → 3.1.0**
- `@thotischner/observability-mcp-sdk` **3.0.0 → 3.1.0**
- Helm chart **2.0.2 → 2.1.0** (appVersion `3.1.0`, image tag `3.1.0`, `artifacthub.io/changes` refreshed)

### What shipped in 3.1 (highlights)
- Topology providers: AWS, GCP, Istio, Linkerd, Consul
- Federation upstream transports (stdio + WebSocket); manifest-driven plugin hooks
- SCIM Redis store + PATCH add/remove + full compliance suite
- S3 audit sink; Redis-backed transport session map
- Playground tab; Health-tab anomaly sparkline
- Security hardening: session revocation, account lockout, password policy, CSP
- **Agent log analytics (#415):** `query_logs` structured label filters + server-side aggregation (count/sum/topk)

Full detail in [CHANGELOG `[3.1.0]`](../blob/release/v3.1.0/CHANGELOG.md) and [docs/migrations/3.0-to-3.1.md](../blob/release/v3.1.0/docs/migrations/3.0-to-3.1.md).

### Release mechanics
On squash-merge this `chore(release): v3.1.0` commit triggers `tag-on-release.yml` → tags `v3.1.0` → docker/npm/helm publish. (The SDK gets a separate `sdk-v3.1.0` tag after merge.)

Reviewer-agent gate: **SHIP** — version coherence verified (locks touch only own version), doc claims cross-checked against code on main, artifacthub annotation valid, sensitive-data clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)