### PR TITLE
fix(q-log): advertise query_logs labels/aggregate over MCP (v3.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.1.1] — 2026-06-09
+
+Patch release — fixes a ship gap in 3.1.0 reported from real-world use
+(issue #415).
+
+### Fixed
+
+- **`query_logs` `labels` and `aggregate` params are now reachable over
+  MCP.** In 3.1.0 the handler and connector code for structured label
+  filters (#1) and server-side aggregation (#2) shipped, but the inline
+  MCP input schema in the tool registration never advertised the two
+  params — so the MCP SDK stripped them from incoming calls before they
+  reached the handler. A `tools/list` handshake omitted them and passing
+  them was a silent no-op (raw, unfiltered rows returned). The
+  registration now declares both, so `labels` / `aggregate` work over
+  MCP exactly as documented in [loki.md](docs/loki.md). No API change —
+  this only makes the already-documented 3.1.0 surface actually
+  callable. A conformance assertion (live `tools/list`) plus a static
+  registration guard now prevent this class of regression.
+
 ## [3.1.0] — 2026-06-08
 
 Incremental release — the **Phase Q sprint** closes the

--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,11 +4,11 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 2.1.0
+version: 2.1.1
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
-appVersion: "3.1.0"
+appVersion: "3.1.1"
 
 home: https://github.com/ThoTischner/observability-mcp
 sources:
@@ -51,26 +51,10 @@ annotations:
     url: https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc
   artifacthub.io/images: |
     - name: observability-mcp
-      image: ghcr.io/thotischner/observability-mcp:3.1.0
+      image: ghcr.io/thotischner/observability-mcp:3.1.1
       platforms:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
-    - kind: changed
-      description: appVersion → 3.1.0 (Phase Q sprint); chart points at the 3.1.0 image
-    - kind: added
-      description: SCIM Redis-backed store (scim.backend=redis) for multi-replica provisioning
-    - kind: added
-      description: S3-compatible audit sink (audit.s3.*) — S3 / MinIO / R2 / B2
-    - kind: added
-      description: Session revocation blocklist, per-account login lockout, and basic-auth password policy
-    - kind: added
-      description: Content-Security-Policy on the Web UI (enforced + opt-in strict report-only)
-    - kind: added
-      description: Redis-backed transport session map — multi-replica gateways no longer need sticky ingress
-    - kind: added
-      description: Health-tab anomaly-score sparkline + in-product Playground tab
-    - kind: added
-      description: Federation upstream transports (stdio + WebSocket); manifest-driven plugin hook auto-registration
-    - kind: added
-      description: query_logs structured label filters + server-side aggregation (count/sum/topk) for agent log analytics (issue #415)
+    - kind: fixed
+      description: "query_logs labels/aggregate params are now advertised over MCP and reach the handler (3.1.0 ship gap, issue #415); chart points at the 3.1.1 image"

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thotischner/observability-mcp",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
   "license": "Apache-2.0",

--- a/mcp-server/src/conformance/mcp-2025-11-25.test.ts
+++ b/mcp-server/src/conformance/mcp-2025-11-25.test.ts
@@ -137,6 +137,23 @@ test("MCP 2025-11-25: tools/list returns a Tool[] each with name + inputSchema",
   }
 });
 
+test("MCP 2025-11-25: query_logs advertises labels + aggregate params (issue #415)", opts, async () => {
+  // Regression guard for the v3.1.0 ship gap: the labels/aggregate handler
+  // code existed but the inline MCP schema in createMcpServer never declared
+  // them, so a live tools/list omitted them and the SDK stripped them from
+  // calls — a silent no-op. Assert the live server advertises both.
+  const session = await newSession();
+  const { response } = await jsonRpc("tools/list", {}, { id: 2, session });
+  const r = response.result as {
+    tools?: Array<{ name?: string; inputSchema?: { properties?: Record<string, unknown> } }>;
+  };
+  const queryLogs = r.tools?.find((t) => t.name === "query_logs");
+  assert.ok(queryLogs, "query_logs tool must be advertised");
+  const props = queryLogs.inputSchema?.properties ?? {};
+  assert.ok("labels" in props, "query_logs must advertise a `labels` param (issue #415 #1)");
+  assert.ok("aggregate" in props, "query_logs must advertise an `aggregate` param (issue #415 #2)");
+});
+
 test("MCP 2025-11-25: tools/call dispatches and returns CallToolResult", opts, async () => {
   const session = await newSession();
   const { response } = await jsonRpc(

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -565,6 +565,12 @@ async function main() {
         .describe(
           "Optional. Filter expression matched against the log message; regular expressions are supported. Omit to return all entries in the window.",
         ),
+      labels: z
+        .record(z.string(), z.string())
+        .optional()
+        .describe(
+          "Optional. Exact-match filters on backend-extracted log fields (e.g. {\"method\":\"GET\",\"status\":\"200\",\"url\":\"/\",\"environment\":\"prod\"}). All AND'd together and compiled to LogQL label filters applied after `| json`, so structured JSON fields become first-class selectors — far more reliable than regex on the raw message. Combine with `aggregate` to filter then group. Backends without label extraction ignore it.",
+        ),
       duration: z
         .string()
         .optional()
@@ -577,13 +583,43 @@ async function main() {
         .describe(
           "Optional. Return only entries at this severity. Default: all levels.",
         ),
+      aggregate: z
+        .object({
+          op: z
+            .enum(["count_over_time", "sum", "topk"])
+            .describe(
+              "count_over_time = time series of counts per `step` bucket; sum = single total per group over the window; topk = the top `k` groups by total.",
+            ),
+          by: z
+            .array(z.string())
+            .optional()
+            .describe(
+              "Label names to group by, e.g. [\"url\"] or [\"status\"]. Required for topk.",
+            ),
+          k: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe("For topk: how many top groups to return (1-1000)."),
+          step: z
+            .string()
+            .optional()
+            .describe(
+              "For count_over_time: bucket width as <number><unit> m|h|d (e.g. '15m'). Default auto-derived from duration.",
+            ),
+        })
+        .optional()
+        .describe(
+          "Optional. Server-side aggregation pushed down to LogQL metric queries — returns grouped counts, not raw rows, so you get a number instead of a haystack (and never hit `limit`). Honours `labels`/`query` filters. Example: {\"op\":\"topk\",\"by\":[\"url\"],\"k\":10} for the busiest paths; {\"op\":\"count_over_time\",\"step\":\"15m\"} for a request-count time series.",
+        ),
       limit: z
         .number()
         .int()
         .positive()
         .optional()
         .describe(
-          "Optional. Maximum number of log entries to return (most recent first). Default: 100.",
+          "Optional. Maximum number of log entries to return (most recent first). Default: 100. Ignored when `aggregate` is set.",
         ),
       bypass_redaction: z
         .boolean()

--- a/mcp-server/src/tools/query-logs-schema.test.ts
+++ b/mcp-server/src/tools/query-logs-schema.test.ts
@@ -1,0 +1,51 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Regression guard for issue #415: the query_logs handler (query-logs.ts)
+// reads `labels` and `aggregate` from its args, and validateLogLabels /
+// validateLogAggregate enforce them — but the MCP-facing input schema is
+// declared INLINE in createMcpServer's registerTool("query_logs", …) block
+// in index.ts. In v3.1.0 that inline schema was never updated to advertise
+// `labels`/`aggregate`, so the MCP SDK stripped those keys before they
+// reached the handler: the params were unreachable over MCP and passing
+// them was a silent no-op. The handler unit tests passed because they call
+// the handler directly, bypassing the SDK schema layer.
+//
+// This test parses index.ts and asserts the query_logs registration block
+// declares both fields as schema entries, so the SDK validates and forwards
+// them. The live equivalent (real tools/list handshake) lives in the
+// conformance suite; this is the fast, server-less guard.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const INDEX_TS = join(here, "..", "index.ts");
+
+function registerToolBlock(src: string, tool: string): string {
+  const start = src.indexOf(`registerTool(\n    "${tool}"`);
+  assert.notEqual(start, -1, `registerTool("${tool}", …) not found in index.ts`);
+  // The block ends at the next registerTool( call (or EOF).
+  const next = src.indexOf("registerTool(", start + 1);
+  return src.slice(start, next === -1 ? undefined : next);
+}
+
+test("query_logs MCP schema advertises `labels` (issue #415 #1)", () => {
+  const block = registerToolBlock(readFileSync(INDEX_TS, "utf8"), "query_logs");
+  assert.match(
+    block,
+    /\blabels:\s*z\b/,
+    "query_logs registration in index.ts must declare a `labels` schema field " +
+      "so the MCP SDK forwards it to the handler (else it is silently stripped).",
+  );
+});
+
+test("query_logs MCP schema advertises `aggregate` (issue #415 #2)", () => {
+  const block = registerToolBlock(readFileSync(INDEX_TS, "utf8"), "query_logs");
+  assert.match(
+    block,
+    /\baggregate:\s*z\b/,
+    "query_logs registration in index.ts must declare an `aggregate` schema field " +
+      "so the MCP SDK forwards it to the handler (else it is silently stripped).",
+  );
+});


### PR DESCRIPTION
## Hotfix v3.1.1 — issue #415

A real-world tester verified against the shipped `:3.1.0` image that `query_logs` does **not** advertise the `labels`/`aggregate` params, even though the 3.1.0 notes claimed they shipped. Passing them was a **silent no-op** (raw, unfiltered rows returned).

### Root cause
The `query_logs` MCP input schema is declared **inline** in `createMcpServer`'s `registerTool("query_logs", …)` block in `index.ts`. The Q-LOG1/Q-LOG2 work added `labels`/`aggregate` to the *handler* (`tools/query-logs.ts`) and connector, but never to that inline schema. The MCP SDK validates incoming args against the inline schema and **strips unknown keys** before the handler runs — so a `tools/list` omitted the params and calls dropped them. (`queryLogsDefinition` in `tools/query-logs.ts` is exported but imported nowhere — dead code.) Handler unit tests passed because they call the handler directly, bypassing the SDK schema layer.

### Fix
- Add `labels` (`z.record(z.string(), z.string())`) and `aggregate` (`{op, by, k, step}`) to the inline schema. Handler validators (`validateLogLabels`/`validateLogAggregate`) remain the fail-closed authority.
- **Regression guards** so this class of bug can't recur silently:
  - static — `query-logs-schema.test.ts` parses `index.ts` and asserts the registration block declares both fields.
  - live — conformance suite asserts a real `tools/list` advertises both.

### Verified end-to-end
Booted the server and ran the tester's exact check — now passes:
```
query_logs params: aggregate, bypass_redaction, duration, labels, level, limit, query, service
has labels: true      (was False)
has aggregate: true   (was False)
```

No API change — this only makes the already-documented 3.1.0 surface actually callable. Gateway-only patch; SDK stays at 3.1.0. Reviewer-agent: SHIP (quality + sensitive-data scan clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)