### PR TITLE
feat(topology): explicit note when no topology connector is configured

### DIFF
--- a/mcp-server/src/tools/topology.test.ts
+++ b/mcp-server/src/tools/topology.test.ts
@@ -177,6 +177,23 @@ describe("get_topology tool", () => {
     assert.equal(out.truncated, true);
     assert.equal(out.total.resources, fixture().resources.length);
   });
+
+  it("does not attach the no-connector note when topology is present", async () => {
+    const reg = await makeRegistry();
+    const out = parseTool(await getTopologyHandler(reg, {}));
+    assert.equal(out.note, undefined);
+  });
+
+  it("returns an explicit note when no topology connector is configured (issue #415)", async () => {
+    // Empty registry — no topology-capable connector. The agent must get a
+    // clear signal, not a silent empty graph.
+    const reg = new ConnectorRegistry(new PluginLoader());
+    const out = parseTool(await getTopologyHandler(reg, {}));
+    assert.deepEqual(out.resources, []);
+    assert.deepEqual(out.edges, []);
+    assert.equal(out.sources.length, 0);
+    assert.match(out.note, /no topology-capable connector/i);
+  });
 });
 
 describe("get_blast_radius tool", () => {

--- a/mcp-server/src/tools/topology.ts
+++ b/mcp-server/src/tools/topology.ts
@@ -162,13 +162,34 @@ export async function getTopologyHandler(
     edges = edges.filter((e) => keep2.has(e.from) && keep2.has(e.to));
   }
 
-  const payload = {
+  const payload: {
+    sources: AggregatedTopology["sources"];
+    resources: typeof resources;
+    edges: typeof edges;
+    total: { resources: number; edges: number };
+    truncated: boolean;
+    note?: string;
+  } = {
     sources: agg.sources,
     resources,
     edges,
     total: { resources: agg.resources.length, edges: agg.edges.length },
     truncated,
   };
+  // Signal vs. silence: when NO topology-capable connector contributed a
+  // snapshot, an empty {resources:[],edges:[]} is ambiguous to an agent —
+  // it can't tell "graph is genuinely empty" from "no topology backend is
+  // wired up". Mirror query_traces' explicit "no backend" message so the
+  // agent gets a clear signal instead of silence (issue #415).
+  if (agg.sources.length === 0) {
+    payload.note =
+      "No topology-capable connector is configured, so the graph is empty. " +
+      "Topology comes from connectors like the built-in `kubernetes` source " +
+      "or the aws/gcp/istio/linkerd/consul providers — add one (see the " +
+      "Sources tab or docs/plugin-architecture) to populate this graph. " +
+      "A deployment with only metrics/logs backends (e.g. Prometheus/Loki) " +
+      "has no topology to report here.";
+  }
   return {
     content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
   };


### PR DESCRIPTION
## R2 — issue #415 (signal vs silence)

A tester on a Prometheus+Loki-only stack noted that `get_topology` returns a bare empty `{resources:[],edges:[]}`, whereas `query_traces` gives an explicit "No trace backends configured" message. The latter is friendlier for an agent — it can't otherwise tell "graph is genuinely empty" from "no topology backend is wired up".

### Change
When **no topology-capable connector contributed a snapshot** (`agg.sources.length === 0`), attach an explicit `note` to the payload pointing at the available providers (built-in `kubernetes`, or `aws`/`gcp`/`istio`/`linkerd`/`consul`). Purely additive: `sources/resources/edges/total/truncated` are unchanged; `note` is optional.

The condition keys off "did any topology connector contribute", not graph emptiness — a connector that exists but legitimately returns an empty graph yields `sources.length === 1` and gets **no** note.

### Tests
- present-topology → no note
- empty registry (no topology connector) → note present, matches `/no topology-capable connector/i`

Typecheck clean; topology suite 18/18. Reviewer-agent: SHIP. No release — bundles into v3.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)