### PR TITLE
feat(q-metrics): query_metrics labels equality filter (issue #415 #4)

### DIFF
--- a/mcp-server/src/conformance/mcp-2025-11-25.test.ts
+++ b/mcp-server/src/conformance/mcp-2025-11-25.test.ts
@@ -154,6 +154,18 @@ test("MCP 2025-11-25: query_logs advertises labels + aggregate params (issue #41
   assert.ok("aggregate" in props, "query_logs must advertise an `aggregate` param (issue #415 #2)");
 });
 
+test("MCP 2025-11-25: query_metrics advertises labels param (issue #415 #4)", opts, async () => {
+  const session = await newSession();
+  const { response } = await jsonRpc("tools/list", {}, { id: 2, session });
+  const r = response.result as {
+    tools?: Array<{ name?: string; inputSchema?: { properties?: Record<string, unknown> } }>;
+  };
+  const queryMetrics = r.tools?.find((t) => t.name === "query_metrics");
+  assert.ok(queryMetrics, "query_metrics tool must be advertised");
+  const props = queryMetrics.inputSchema?.properties ?? {};
+  assert.ok("labels" in props, "query_metrics must advertise a `labels` param (issue #415 #4)");
+});
+
 test("MCP 2025-11-25: tools/call dispatches and returns CallToolResult", opts, async () => {
   const session = await newSession();
   const { response } = await jsonRpc(

--- a/mcp-server/src/connectors/prometheus.test.ts
+++ b/mcp-server/src/connectors/prometheus.test.ts
@@ -136,5 +136,62 @@ describe("PrometheusConnector", () => {
       const { promql } = await proto.buildQuery.call(connector, "api", "custom");
       assert.equal(promql, 'my_custom_metric{svc="api"}');
     });
+
+    it("AND's labels into the {{selector}} (issue #415 #4)", async () => {
+      const connector = new PrometheusConnector();
+      await connector.connect({
+        ...fakeSource,
+        metrics: [{ name: "reqs", query: "http_requests_total{ {{selector}} }", unit: "", description: "" }],
+      });
+      // Stub the network label-resolver so the test is hermetic.
+      (connector as unknown as { resolveServiceLabel: () => Promise<string> }).resolveServiceLabel =
+        async () => "job";
+      const { promql } = await proto.buildQuery.call(connector, "api", "reqs", undefined, {
+        status: "500",
+        route: "/checkout",
+      });
+      // Insertion order preserved: status then route, after the service matcher.
+      assert.equal(promql, 'http_requests_total{ job="api", status="500", route="/checkout" }');
+    });
+
+    it("escapes quotes/backslashes in label values (PromQL injection guard)", async () => {
+      const connector = new PrometheusConnector();
+      await connector.connect({
+        ...fakeSource,
+        metrics: [{ name: "reqs", query: "http_requests_total{ {{selector}} }", unit: "", description: "" }],
+      });
+      (connector as unknown as { resolveServiceLabel: () => Promise<string> }).resolveServiceLabel =
+        async () => "job";
+      const { promql } = await proto.buildQuery.call(connector, "api", "reqs", undefined, {
+        path: 'a"b\\c',
+      });
+      assert.equal(promql, 'http_requests_total{ job="api", path="a\\"b\\\\c" }');
+    });
+
+    it("escapes newlines/control chars in label values (Loki parity)", async () => {
+      const connector = new PrometheusConnector();
+      await connector.connect({
+        ...fakeSource,
+        metrics: [{ name: "reqs", query: "http_requests_total{ {{selector}} }", unit: "", description: "" }],
+      });
+      (connector as unknown as { resolveServiceLabel: () => Promise<string> }).resolveServiceLabel =
+        async () => "job";
+      const { promql } = await proto.buildQuery.call(connector, "api", "reqs", undefined, {
+        note: "a\nb\tc",
+      });
+      assert.equal(promql, 'http_requests_total{ job="api", note="a\\nb\\tc" }');
+    });
+
+    it("ignores labels when the template has no {{selector}}", async () => {
+      const connector = new PrometheusConnector();
+      await connector.connect({
+        ...fakeSource,
+        metrics: [{ name: "explicit", query: 'm{job="{{service}}"}', unit: "", description: "" }],
+      });
+      const { promql } = await proto.buildQuery.call(connector, "svc", "explicit", undefined, {
+        status: "500",
+      });
+      assert.equal(promql, 'm{job="svc"}');
+    });
   });
 });

--- a/mcp-server/src/connectors/prometheus.ts
+++ b/mcp-server/src/connectors/prometheus.ts
@@ -250,7 +250,7 @@ export class PrometheusConnector implements ObservabilityConnector {
   }
 
   async queryMetrics(params: MetricQuery): Promise<MetricResult> {
-    const { promql, label, candidate } = await this.buildQuery(params.service, params.metric, params.groupBy);
+    const { promql, label, candidate } = await this.buildQuery(params.service, params.metric, params.groupBy, params.labels);
     const { start, end, step } = this.parseTimeRange(params.duration, params.step);
 
     const data = await this.apiGet<{ data: PromQueryRangeResult }>(
@@ -326,7 +326,8 @@ export class PrometheusConnector implements ObservabilityConnector {
   private async buildQuery(
     service: string,
     metric: string,
-    groupBy?: string
+    groupBy?: string,
+    labels?: Record<string, string>
   ): Promise<{ promql: string; label: string; candidate: MetricCandidate | null }> {
     // Resolve the service-filter label first. Candidate probing uses this
     // label to scope existence checks per-service rather than per-source.
@@ -346,13 +347,38 @@ export class PrometheusConnector implements ObservabilityConnector {
       template = def?.query || `${metric}{ {{selector}} }`;
     }
 
+    // Extra exact-match label filters (caller-supplied), AND'd into every
+    // {{selector}} occurrence. Label names are constrained to the safe
+    // Prometheus identifier set (the tool layer already validated them, but
+    // we re-constrain here so the connector is safe in isolation); values are
+    // escaped for the surrounding PromQL double-quoted string, same as the
+    // service value above.
+    let extraMatchers = "";
+    if (labels) {
+      const parts: string[] = [];
+      for (const [k, v] of Object.entries(labels)) {
+        if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(k)) continue;
+        // Escape backslash first, then quote, then control chars — matches
+        // the Loki escapeLogQLValue sibling so a value with a newline yields
+        // a valid PromQL string literal rather than a 400 parse error.
+        const ev = v
+          .replace(/\\/g, "\\\\")
+          .replace(/"/g, '\\"')
+          .replace(/\n/g, "\\n")
+          .replace(/\r/g, "\\r")
+          .replace(/\t/g, "\\t");
+        parts.push(`${k}="${ev}"`);
+      }
+      if (parts.length) extraMatchers = ", " + parts.join(", ");
+    }
+
     let promql = template;
     if (template.includes("{{selector}}")) {
       // Resolve label here for non-candidate paths that haven't done it yet.
       if (label === "job" && !PROMETHEUS_METRIC_CANDIDATES[metric]) {
         label = await this.resolveServiceLabel(service);
       }
-      const selector = `${label}="${escaped}"`;
+      const selector = `${label}="${escaped}"${extraMatchers}`;
       promql = promql.replace(/\{\{selector\}\}/g, selector);
     }
     if (groupBy && template.includes("{{groupBy}}")) {

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -537,6 +537,12 @@ async function main() {
         .describe(
           "Optional. Metric label to break the result down by, e.g. 'instance', 'pod', 'node'. When set, the response contains one series per distinct label value under `groups`. Default: a single aggregated series.",
         ),
+      labels: z
+        .record(z.string(), z.string())
+        .optional()
+        .describe(
+          "Optional. Exact-match label filters (e.g. {\"status\":\"500\",\"route\":\"/checkout\"}) AND'd into the metric's series selector — the PromQL equivalent of the query_logs `labels` param. Use this to scope a curated metric to a subset of series (e.g. error_rate for one route/status) instead of the all-series aggregate. Combine with `groupBy` to filter then break down. Label names must be valid Prometheus identifiers.",
+        ),
     },
     async (args) => {
       await enforceEntitledAccess(ctx, { tool: "query_metrics", source: (args as any)?.source, service: (args as any)?.service });

--- a/mcp-server/src/tools/query-metrics.ts
+++ b/mcp-server/src/tools/query-metrics.ts
@@ -1,7 +1,7 @@
 import type { ConnectorRegistry } from "../connectors/registry.js";
 import { defaultContext, type RequestContext } from "../context.js";
 import type { MetricResult } from "../types.js";
-import { validateDuration, validateMetricName, validateServiceName, errorResponse } from "./validation.js";
+import { validateDuration, validateMetricName, validateServiceName, validateMetricLabels, errorResponse } from "./validation.js";
 
 export const queryMetricsDefinition = {
   name: "query_metrics" as const,
@@ -39,7 +39,7 @@ export const queryMetricsDefinition = {
 
 export async function queryMetricsHandler(
   registry: ConnectorRegistry,
-  args: { service: string; metric: string; duration?: string; source?: string; groupBy?: string },
+  args: { service: string; metric: string; duration?: string; source?: string; groupBy?: string; labels?: Record<string, string> },
   ctx: RequestContext = defaultContext()
 ) {
   // Coarse single-tenant source scoping: if the principal is restricted to a
@@ -65,6 +65,8 @@ export async function queryMetricsHandler(
       `Invalid groupBy "${args.groupBy}". Must be a valid Prometheus label name (alphanumeric + underscore, starting with letter/underscore).`
     );
   }
+  const labelsErr = validateMetricLabels(args.labels);
+  if (labelsErr) return errorResponse(labelsErr);
 
   // Tenant-scoped resolution: an explicit `source` from the agent
   // must belong to the caller's tenant (or be a global / untagged
@@ -100,6 +102,7 @@ export async function queryMetricsHandler(
         metric: args.metric,
         duration,
         groupBy: args.groupBy,
+        labels: args.labels,
       });
       results.push(result);
     } catch (err) {

--- a/mcp-server/src/tools/validation.test.ts
+++ b/mcp-server/src/tools/validation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { validateDuration, validateServiceName, sanitizeLabelValue, validateLogLabels, validateLogAggregate, errorResponse } from "./validation.js";
+import { validateDuration, validateServiceName, sanitizeLabelValue, validateLogLabels, validateLogAggregate, validateMetricLabels, errorResponse } from "./validation.js";
 
 describe("validateLogAggregate (Q-LOG2)", () => {
   it("accepts undefined and valid specs", () => {
@@ -53,6 +53,18 @@ describe("validateLogLabels (Q-LOG1)", () => {
     const many: Record<string, string> = {};
     for (let i = 0; i < 21; i++) many[`k${i}`] = "v";
     assert.ok(validateLogLabels(many));
+  });
+});
+
+describe("validateMetricLabels (R3, issue #415 #4)", () => {
+  it("accepts undefined and a valid map (same rules as log labels)", () => {
+    assert.equal(validateMetricLabels(undefined), null);
+    assert.equal(validateMetricLabels({ status: "500", route: "/checkout" }), null);
+  });
+  it("rejects invalid label names and bad values, fail-closed", () => {
+    assert.ok(validateMetricLabels({ "a-b": "x" }));
+    assert.ok(validateMetricLabels({ status: 500 as unknown as string }));
+    assert.ok(validateMetricLabels("nope"));
   });
 });
 

--- a/mcp-server/src/tools/validation.ts
+++ b/mcp-server/src/tools/validation.ts
@@ -80,6 +80,15 @@ export function validateLogLabels(labels: unknown): string | null {
   return null;
 }
 
+/**
+ * Validate a structured `labels` filter map for query_metrics. The rules are
+ * identical to the log-label validator (valid Prometheus label names, bounded
+ * map size + value length, fail-closed) — metric labels compile to PromQL
+ * label-equality matchers and the values are escaped for PromQL at injection
+ * time, exactly as the log path escapes for LogQL.
+ */
+export const validateMetricLabels = validateLogLabels;
+
 const AGGREGATE_OPS = new Set(["count_over_time", "sum", "topk"]);
 
 /**

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -99,6 +99,7 @@ export interface MetricQuery {
   duration: string; // "5m", "1h", "24h"
   step?: string;
   groupBy?: string; // label to break the result down by (e.g. "instance", "pod")
+  labels?: Record<string, string>; // exact-match label filters AND'd into the series selector
 }
 
 export interface LogQuery {


### PR DESCRIPTION
## R3 — issue #415 #4 (metrics side)

Adds an optional `labels` exact-match map to `query_metrics` — the PromQL equivalent of the `query_logs` `labels` param. Filters are AND'd into the metric's series selector, so an agent can scope a curated metric to a subset of series (e.g. `error_rate` for one `route`/`status`) instead of the all-series aggregate, and combine with `groupBy` to filter-then-break-down.

### Security (PromQL injection)
- Label **names** re-constrained at the connector level (regex, defense in depth) — not just trusting the tool layer.
- Label **values** escaped for the PromQL double-quoted string: backslash → quote → `\n\r\t` (matches the Loki `escapeLogQLValue` sibling). Adversarial values like `"} or up{` escape to a contained string literal — no breakout.
- `validateMetricLabels` (alias of the log-label validator) is the fail-closed authority: Prometheus label-name regex, max 20, value length cap.

### Correct wiring
`labels` is added to the **inline** `registerTool("query_metrics")` zod schema in `index.ts` — the layer the MCP SDK advertises and forwards — avoiding the v3.1.0 class of bug (param in handler but stripped on validate).

### Tests
Selector AND'ing + insertion order, quote/backslash/newline escaping, no-`{{selector}}` passthrough, `validateMetricLabels`, and a live `tools/list` conformance assertion. Verified end-to-end against a booted server (`query_metrics labels: true`). Reviewer-agent: SHIP (escaping adversarially checked). No release — bundles into v3.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)