### PR TITLE
feat(q-raw): raw PromQL/LogQL passthrough, capability-gated (issue #415 #3)

### DIFF
--- a/docs/raw-query.md
+++ b/docs/raw-query.md
@@ -1,0 +1,65 @@
+# Raw query passthrough (`raw_query`)
+
+The curated `query_metrics` / `query_logs` parameters cover the common
+cases safely, but an agent sometimes needs a query the catalog can't
+express — an arbitrary PromQL function, a metric outside the catalog,
+or a hand-written LogQL selector/pipeline. The `raw_query` escape hatch
+covers those, **gated behind an explicit operator capability and off by
+default**.
+
+## Enabling
+
+```bash
+OMCP_RAW_QUERY=on      # also accepts: true, 1
+```
+
+When unset (the default) any call that passes `raw_query` is refused
+with a clear message — the param is still *advertised* in `tools/list`
+(so an agent can discover it and explain the requirement), but the
+server will not execute it.
+
+## Usage
+
+`query_metrics` — verbatim PromQL run over the look-back range:
+
+```jsonc
+{ "raw_query": "topk(5, sum by(route) (rate(http_requests_total[5m])))", "duration": "1h" }
+```
+
+`query_logs` — verbatim LogQL log query:
+
+```jsonc
+{ "raw_query": "{app=\"checkout\", env=\"prod\"} | json | status>=`500`" }
+```
+
+When `raw_query` is set, the curated params are ignored:
+
+| Tool | Ignored when `raw_query` is set |
+|---|---|
+| `query_metrics` | `service`, `metric`, `groupBy`, `labels` |
+| `query_logs` | `service`, `labels`, `level`, `query` (and it is mutually exclusive with `aggregate` — express the aggregation in the LogQL itself) |
+
+`duration` (and `source`, on `query_metrics`) still apply. For **log aggregation**
+(counts, top-k) prefer the structured `aggregate` param on
+`query_logs` — it is available without the raw-query capability.
+
+## Why it is gated
+
+A raw query bypasses the curated safe surface:
+
+- it can hit any series/stream the backend exposes, not just the
+  catalog-scoped ones, so it sidesteps the metric allow-list;
+- it is still **tenant-scoped** (it only runs against backends in the
+  caller's tenant) and respects the per-credential **source
+  allow-list**, but within a reachable backend it can read anything;
+- `query_logs` raw output is still **redacted** like any other log
+  result (subject to the usual per-call bypass rules).
+
+Because of the widened read surface, enable `raw_query` only in trusted
+/ single-tenant deployments where the calling agents are allowed
+ad-hoc query access. Leave it off for shared multi-tenant gateways and
+rely on the curated `labels` / `aggregate` params instead.
+
+The query string is sent to the backend verbatim — there is no
+server-side syntax validation, so an invalid query simply returns the
+backend's own parse error.

--- a/mcp-server/src/conformance/mcp-2025-11-25.test.ts
+++ b/mcp-server/src/conformance/mcp-2025-11-25.test.ts
@@ -166,6 +166,19 @@ test("MCP 2025-11-25: query_metrics advertises labels param (issue #415 #4)", op
   assert.ok("labels" in props, "query_metrics must advertise a `labels` param (issue #415 #4)");
 });
 
+test("MCP 2025-11-25: query_metrics + query_logs advertise raw_query (issue #415 #3)", opts, async () => {
+  const session = await newSession();
+  const { response } = await jsonRpc("tools/list", {}, { id: 2, session });
+  const r = response.result as {
+    tools?: Array<{ name?: string; inputSchema?: { properties?: Record<string, unknown> } }>;
+  };
+  for (const name of ["query_metrics", "query_logs"]) {
+    const tool = r.tools?.find((t) => t.name === name);
+    assert.ok(tool, `${name} tool must be advertised`);
+    assert.ok("raw_query" in (tool.inputSchema?.properties ?? {}), `${name} must advertise a raw_query param`);
+  }
+});
+
 test("MCP 2025-11-25: tools/call dispatches and returns CallToolResult", opts, async () => {
   const session = await newSession();
   const { response } = await jsonRpc(

--- a/mcp-server/src/connectors/loki.test.ts
+++ b/mcp-server/src/connectors/loki.test.ts
@@ -99,6 +99,23 @@ describe("Q-LOG1: queryLogs LogQL assembly", () => {
     const q = await captureQuery({});
     assert.equal(q, '{service_name="payment"} | json');
   });
+
+  it("R4: rawQuery is sent verbatim, bypassing the curated selector", async () => {
+    const q = await captureQuery({
+      rawQuery: '{app="x", env="prod"} | json | status>=`500`',
+    });
+    assert.equal(q, '{app="x", env="prod"} | json | status>=`500`');
+  });
+
+  it("R4: rawQuery ignores service/labels/level/query", async () => {
+    const q = await captureQuery({
+      rawQuery: '{job="raw"}',
+      labels: { method: "GET" },
+      level: "error",
+      query: "ignored",
+    });
+    assert.equal(q, '{job="raw"}');
+  });
 });
 
 describe("Q-LOG2: parseDurationSeconds / defaultBucketSeconds", () => {

--- a/mcp-server/src/connectors/loki.ts
+++ b/mcp-server/src/connectors/loki.ts
@@ -209,22 +209,30 @@ export class LokiConnector implements ObservabilityConnector {
     const { start, end } = this.parseTimeRange(params.duration);
     const limit = Math.min(Math.max(params.limit || 100, 1), 1000);
 
-    // Resolve label + actual selector value. For the 'container' label the
-    // value stored in Loki may be '/my-app-1' while the caller passes the
-    // sanitized 'my-app-1' — return the prefixed form so the LogQL selector
-    // matches the real stream.
-    const { label: matchedLabel, value: rawValue } = await this.resolveServiceSelector(params.service);
-    const service = this.escapeLogQLValue(rawValue);
-    let logql = `{${matchedLabel}="${service}"} | json`;
-    if (params.level) {
-      logql += ` | level="${this.escapeLogQLValue(params.level)}"`;
-    }
-    // Structured equality filters (method/status/url/environment/…) — run
-    // after `| json` so backend-extracted fields are selectable.
-    logql += logqlLabelFilters(params.labels);
-    if (params.query) {
-      const query = this.escapeLogQLRegex(params.query);
-      logql += ` |~ \`${query}\``;
+    let logql: string;
+    if (params.rawQuery) {
+      // Raw LogQL passthrough (capability-gated at the tool layer): the caller
+      // supplied a verbatim log-selector query. Skip the curated stream
+      // selector / | json / label-filter construction and run it as-is.
+      logql = params.rawQuery;
+    } else {
+      // Resolve label + actual selector value. For the 'container' label the
+      // value stored in Loki may be '/my-app-1' while the caller passes the
+      // sanitized 'my-app-1' — return the prefixed form so the LogQL selector
+      // matches the real stream.
+      const { label: matchedLabel, value: rawValue } = await this.resolveServiceSelector(params.service);
+      const service = this.escapeLogQLValue(rawValue);
+      logql = `{${matchedLabel}="${service}"} | json`;
+      if (params.level) {
+        logql += ` | level="${this.escapeLogQLValue(params.level)}"`;
+      }
+      // Structured equality filters (method/status/url/environment/…) — run
+      // after `| json` so backend-extracted fields are selectable.
+      logql += logqlLabelFilters(params.labels);
+      if (params.query) {
+        const query = this.escapeLogQLRegex(params.query);
+        logql += ` |~ \`${query}\``;
+      }
     }
 
     const url =

--- a/mcp-server/src/connectors/prometheus.test.ts
+++ b/mcp-server/src/connectors/prometheus.test.ts
@@ -194,4 +194,33 @@ describe("PrometheusConnector", () => {
       assert.equal(promql, 'm{job="svc"}');
     });
   });
+
+  describe("queryMetrics rawQuery passthrough (R4, issue #415 #3)", () => {
+    const fakeSource = { name: "test", type: "prometheus" as const, url: "http://localhost:9090", enabled: true };
+
+    it("sends raw PromQL verbatim to query_range, bypassing the catalog", async () => {
+      const connector = new PrometheusConnector();
+      await connector.connect({ ...fakeSource });
+      let captured = "";
+      const orig = globalThis.fetch;
+      globalThis.fetch = (async (url: any) => {
+        captured = decodeURIComponent((String(url).match(/query=([^&]+)/) || [])[1] || "");
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ data: { result: [{ metric: { foo: "bar" }, values: [[1700000000, "42"]] }] } }),
+        } as any;
+      }) as any;
+      try {
+        const raw = "topk(5, sum by(route) (rate(http_requests_total[5m])))";
+        const result = await connector.queryMetrics({ service: "", metric: "", duration: "15m", rawQuery: raw });
+        assert.equal(captured, raw);
+        assert.equal(result.resolvedSeries, raw);
+        assert.equal(result.metric, "(raw)");
+        assert.equal(result.values[0].value, 42);
+      } finally {
+        globalThis.fetch = orig;
+      }
+    });
+  });
 });

--- a/mcp-server/src/connectors/prometheus.ts
+++ b/mcp-server/src/connectors/prometheus.ts
@@ -250,6 +250,12 @@ export class PrometheusConnector implements ObservabilityConnector {
   }
 
   async queryMetrics(params: MetricQuery): Promise<MetricResult> {
+    // Raw passthrough: the caller supplied verbatim PromQL (capability-gated
+    // at the tool layer). Skip the curated catalog/selector machinery and the
+    // breakdown-hint probe; run the query as-is over query_range.
+    if (params.rawQuery) {
+      return this.queryRaw(params.rawQuery, params.duration, params.step);
+    }
     const { promql, label, candidate } = await this.buildQuery(params.service, params.metric, params.groupBy, params.labels);
     const { start, end, step } = this.parseTimeRange(params.duration, params.step);
 
@@ -318,6 +324,48 @@ export class PrometheusConnector implements ObservabilityConnector {
       }
     }
 
+    return result;
+  }
+
+  // Raw PromQL passthrough — used by queryMetrics when params.rawQuery is set.
+  // Returns the same MetricResult shape: one group per returned series, the
+  // top-level values/summary mirroring the first series. service/metric are
+  // reported as "(raw)" since the curated catalog doesn't apply.
+  private async queryRaw(rawQuery: string, duration: string, step?: string): Promise<MetricResult> {
+    const { start, end, step: resolvedStep } = this.parseTimeRange(duration, step);
+    const data = await this.apiGet<{ data: PromQueryRangeResult }>(
+      `/api/v1/query_range?query=${encodeURIComponent(rawQuery)}&start=${start}&end=${end}&step=${resolvedStep}`
+    );
+    const seriesList = data?.data?.result || [];
+    const groups: MetricGroup[] = [];
+    for (const series of seriesList) {
+      const seriesValues: DataPoint[] = [];
+      const rawValues: number[] = [];
+      for (const [ts, val] of series.values || []) {
+        const numVal = parseFloat(val as string);
+        if (!isNaN(numVal)) {
+          seriesValues.push({ timestamp: new Date(ts * 1000).toISOString(), value: numVal });
+          rawValues.push(numVal);
+        }
+      }
+      groups.push({
+        key: this.groupKey(series.metric || {}),
+        values: seriesValues,
+        summary: this.computeSummary(rawValues),
+      });
+    }
+    const top = groups[0] || { values: [], summary: this.computeSummary([]) };
+    const result: MetricResult = {
+      source: this.name,
+      service: "(raw)",
+      metric: "(raw)",
+      unit: "",
+      values: top.values,
+      summary: top.summary,
+      resolvedSeries: rawQuery,
+      resolvedLabel: "",
+    };
+    if (groups.length > 1) result.groups = groups;
     return result;
   }
 

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -344,6 +344,12 @@ async function main() {
   }
 
   const REDACTION_ENABLED = String(process.env.OMCP_REDACTION ?? "on").toLowerCase() !== "off";
+  // Raw PromQL/LogQL passthrough capability — default OFF. A raw query bypasses
+  // the curated metric/log surface (catalog, selector scoping), so it is an
+  // explicit operator opt-in. Enable with OMCP_RAW_QUERY=on (or true/1).
+  const RAW_QUERY_ENABLED = ["on", "true", "1"].includes(
+    String(process.env.OMCP_RAW_QUERY ?? "off").toLowerCase()
+  );
   function redactToolText<T extends { content: Array<{ text: string }> }>(
     result: T,
     opts: { bypass?: boolean } = {},
@@ -511,13 +517,15 @@ async function main() {
     {
       service: z
         .string()
+        .optional()
         .describe(
-          "Required. Exact, case-sensitive service name exactly as returned by `list_services` (e.g. 'api-gateway', 'payment-service').",
+          "Required (unless `raw_query` is set). Exact, case-sensitive service name exactly as returned by `list_services` (e.g. 'api-gateway', 'payment-service').",
         ),
       metric: z
         .string()
+        .optional()
         .describe(
-          `Required. Exact metric name to query. One of: ${uniqueNames.join(", ")}.`,
+          `Required (unless `+"`raw_query`"+` is set). Exact metric name to query. One of: ${uniqueNames.join(", ")}.`,
         ),
       duration: z
         .string()
@@ -543,10 +551,16 @@ async function main() {
         .describe(
           "Optional. Exact-match label filters (e.g. {\"status\":\"500\",\"route\":\"/checkout\"}) AND'd into the metric's series selector — the PromQL equivalent of the query_logs `labels` param. Use this to scope a curated metric to a subset of series (e.g. error_rate for one route/status) instead of the all-series aggregate. Combine with `groupBy` to filter then break down. Label names must be valid Prometheus identifiers.",
         ),
+      raw_query: z
+        .string()
+        .optional()
+        .describe(
+          "Optional escape hatch: a verbatim PromQL expression, run as-is over the range — for ad-hoc queries the curated `metric` catalog can't express (any series, any function, broken down by any label). When set, `metric`/`service`/`groupBy`/`labels` are ignored. DISABLED by default; the operator must enable the raw-query capability (OMCP_RAW_QUERY=on) or the call is refused. Still tenant-scoped and source-allow-listed.",
+        ),
     },
     async (args) => {
       await enforceEntitledAccess(ctx, { tool: "query_metrics", source: (args as any)?.source, service: (args as any)?.service });
-      const result = await withToolMetrics("query_metrics", () => queryMetricsHandler(registry, args, ctx));
+      const result = await withToolMetrics("query_metrics", () => queryMetricsHandler(registry, args, ctx, { allowRawQuery: RAW_QUERY_ENABLED }));
       return chargeTokenBudget(result, ctx, "query_metrics");
     }
   );
@@ -562,8 +576,9 @@ async function main() {
     {
       service: z
         .string()
+        .optional()
         .describe(
-          "Required. Exact, case-sensitive service name exactly as returned by `list_services` (e.g. 'payment-service').",
+          "Required (unless `raw_query` is set). Exact, case-sensitive service name exactly as returned by `list_services` (e.g. 'payment-service').",
         ),
       query: z
         .string()
@@ -633,10 +648,16 @@ async function main() {
         .describe(
           "Optional. When true, request that PII/secret redaction be skipped for this single call. The server only honours this when the calling credential was explicitly authorised via OMCP_KEY_BYPASS_REDACTION; otherwise the request still gets redacted output. Default: false.",
         ),
+      raw_query: z
+        .string()
+        .optional()
+        .describe(
+          "Optional escape hatch: a verbatim LogQL log query, run as-is — for selectors/pipelines the curated params can't express. When set, `service`/`labels`/`level`/`query` are ignored and it is mutually exclusive with `aggregate` (express aggregation in the LogQL itself). DISABLED by default; the operator must enable the raw-query capability (OMCP_RAW_QUERY=on) or the call is refused. Redaction still applies to the returned log lines.",
+        ),
     },
     async (args) => {
       await enforceEntitledAccess(ctx, { tool: "query_logs", source: (args as any)?.source, service: (args as any)?.service });
-      const result = await withToolMetrics("query_logs", () => queryLogsHandler(registry, args, ctx));
+      const result = await withToolMetrics("query_logs", () => queryLogsHandler(registry, args, ctx, { allowRawQuery: RAW_QUERY_ENABLED }));
       // Redact PII / secrets from the log payload before it crosses the
       // MCP boundary into the agent's context. Per-call bypass kicks in
       // only when BOTH (a) the credential is OMCP_KEY_BYPASS_REDACTION

--- a/mcp-server/src/tools/query-logs.ts
+++ b/mcp-server/src/tools/query-logs.ts
@@ -1,7 +1,7 @@
 import type { ConnectorRegistry } from "../connectors/registry.js";
 import { defaultContext, type RequestContext } from "../context.js";
 import type { LogResult, LogAggregateResult, LogAggregateQuery } from "../types.js";
-import { validateDuration, validateServiceName, validateLogLabels, validateLogAggregate, errorResponse } from "./validation.js";
+import { validateDuration, validateServiceName, validateLogLabels, validateLogAggregate, validateRawQuery, errorResponse } from "./validation.js";
 
 export const queryLogsDefinition = {
   name: "query_logs" as const,
@@ -56,25 +56,46 @@ export const queryLogsDefinition = {
 export async function queryLogsHandler(
   registry: ConnectorRegistry,
   args: {
-    service: string;
+    service?: string;
     query?: string;
     duration?: string;
     level?: string;
     limit?: number;
     labels?: Record<string, string>;
     aggregate?: { op: "count_over_time" | "sum" | "topk"; by?: string[]; k?: number; step?: string };
+    raw_query?: string;
   },
-  ctx: RequestContext = defaultContext()
+  ctx: RequestContext = defaultContext(),
+  opts: { allowRawQuery?: boolean } = {}
 ) {
-  const svcErr = validateServiceName(args.service);
-  if (svcErr) return errorResponse(svcErr);
   const duration = args.duration || "5m";
   const durationErr = validateDuration(duration);
   if (durationErr) return errorResponse(durationErr);
-  const labelsErr = validateLogLabels(args.labels);
-  if (labelsErr) return errorResponse(labelsErr);
-  const aggErr = validateLogAggregate(args.aggregate);
-  if (aggErr) return errorResponse(aggErr);
+
+  // Raw LogQL passthrough — capability-gated, default off. Bypasses the curated
+  // stream-selector construction, so `service` is not required and is ignored.
+  // Mutually exclusive with `aggregate` (for metric LogQL use `aggregate`).
+  const rawErr = validateRawQuery(args.raw_query);
+  if (rawErr) return errorResponse(rawErr);
+  const isRaw = !!args.raw_query;
+  if (isRaw && !opts.allowRawQuery) {
+    return errorResponse(
+      "raw_query is disabled. The operator must enable the raw-query capability (OMCP_RAW_QUERY=on) to run verbatim LogQL — it bypasses the curated log surface, so it is off by default."
+    );
+  }
+  if (isRaw && args.aggregate) {
+    return errorResponse("raw_query and aggregate are mutually exclusive — a raw LogQL query expresses its own aggregation.");
+  }
+
+  if (!isRaw) {
+    if (!args.service) return errorResponse("service is required (or set raw_query).");
+    const svcErr = validateServiceName(args.service);
+    if (svcErr) return errorResponse(svcErr);
+    const labelsErr = validateLogLabels(args.labels);
+    if (labelsErr) return errorResponse(labelsErr);
+    const aggErr = validateLogAggregate(args.aggregate);
+    if (aggErr) return errorResponse(aggErr);
+  }
   const connectors = registry.getByTenant(ctx.tenant).filter((c) => c.signalType === "logs");
 
   if (connectors.length === 0) {
@@ -96,7 +117,7 @@ export async function queryLogsHandler(
       capable++;
       try {
         const q: LogAggregateQuery = {
-          service: args.service,
+          service: args.service ?? "",
           duration,
           labels: args.labels,
           query: args.query,
@@ -134,12 +155,13 @@ export async function queryLogsHandler(
     if (!connector.queryLogs) continue;
     try {
       const result = await connector.queryLogs({
-        service: args.service,
+        service: args.service ?? "",
         query: args.query,
         duration,
         level: args.level,
         limit: args.limit,
         labels: args.labels,
+        rawQuery: args.raw_query,
       });
       results.push(result);
     } catch (err) {

--- a/mcp-server/src/tools/query-metrics.ts
+++ b/mcp-server/src/tools/query-metrics.ts
@@ -1,7 +1,7 @@
 import type { ConnectorRegistry } from "../connectors/registry.js";
 import { defaultContext, type RequestContext } from "../context.js";
 import type { MetricResult } from "../types.js";
-import { validateDuration, validateMetricName, validateServiceName, validateMetricLabels, errorResponse } from "./validation.js";
+import { validateDuration, validateMetricName, validateServiceName, validateMetricLabels, validateRawQuery, errorResponse } from "./validation.js";
 
 export const queryMetricsDefinition = {
   name: "query_metrics" as const,
@@ -39,8 +39,9 @@ export const queryMetricsDefinition = {
 
 export async function queryMetricsHandler(
   registry: ConnectorRegistry,
-  args: { service: string; metric: string; duration?: string; source?: string; groupBy?: string; labels?: Record<string, string> },
-  ctx: RequestContext = defaultContext()
+  args: { service?: string; metric?: string; duration?: string; source?: string; groupBy?: string; labels?: Record<string, string>; raw_query?: string },
+  ctx: RequestContext = defaultContext(),
+  opts: { allowRawQuery?: boolean } = {}
 ) {
   // Coarse single-tenant source scoping: if the principal is restricted to a
   // source allow-list, deny an explicit out-of-scope source.
@@ -53,20 +54,37 @@ export async function queryMetricsHandler(
       `forbidden: source "${args.source}" is not in your allowed sources`
     );
   }
-  const svcErr = validateServiceName(args.service);
-  if (svcErr) return errorResponse(svcErr);
   const duration = args.duration || "5m";
   const durationErr = validateDuration(duration);
   if (durationErr) return errorResponse(durationErr);
-  const metricErr = validateMetricName(args.metric, registry);
-  if (metricErr) return errorResponse(metricErr);
-  if (args.groupBy && !/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(args.groupBy)) {
+
+  // Raw PromQL passthrough — capability-gated, default off. Bypasses the
+  // curated metric catalog/selector, so service/metric/groupBy/labels are not
+  // required and are ignored. Still tenant-scoped + source-allow-listed below.
+  const rawErr = validateRawQuery(args.raw_query);
+  if (rawErr) return errorResponse(rawErr);
+  const isRaw = !!args.raw_query;
+  if (isRaw && !opts.allowRawQuery) {
     return errorResponse(
-      `Invalid groupBy "${args.groupBy}". Must be a valid Prometheus label name (alphanumeric + underscore, starting with letter/underscore).`
+      "raw_query is disabled. The operator must enable the raw-query capability (OMCP_RAW_QUERY=on) to run verbatim PromQL — it bypasses the curated metric surface, so it is off by default."
     );
   }
-  const labelsErr = validateMetricLabels(args.labels);
-  if (labelsErr) return errorResponse(labelsErr);
+
+  if (!isRaw) {
+    if (!args.service) return errorResponse("service is required (or set raw_query).");
+    const svcErr = validateServiceName(args.service);
+    if (svcErr) return errorResponse(svcErr);
+    if (!args.metric) return errorResponse("metric is required (or set raw_query).");
+    const metricErr = validateMetricName(args.metric, registry);
+    if (metricErr) return errorResponse(metricErr);
+    if (args.groupBy && !/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(args.groupBy)) {
+      return errorResponse(
+        `Invalid groupBy "${args.groupBy}". Must be a valid Prometheus label name (alphanumeric + underscore, starting with letter/underscore).`
+      );
+    }
+    const labelsErr = validateMetricLabels(args.labels);
+    if (labelsErr) return errorResponse(labelsErr);
+  }
 
   // Tenant-scoped resolution: an explicit `source` from the agent
   // must belong to the caller's tenant (or be a global / untagged
@@ -98,11 +116,12 @@ export async function queryMetricsHandler(
     if (!connector?.queryMetrics) continue;
     try {
       const result = await connector.queryMetrics({
-        service: args.service,
-        metric: args.metric,
+        service: args.service ?? "",
+        metric: args.metric ?? "",
         duration,
         groupBy: args.groupBy,
         labels: args.labels,
+        rawQuery: args.raw_query,
       });
       results.push(result);
     } catch (err) {

--- a/mcp-server/src/tools/query-raw-gate.test.ts
+++ b/mcp-server/src/tools/query-raw-gate.test.ts
@@ -1,0 +1,79 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { ConnectorRegistry } from "../connectors/registry.js";
+import { PluginLoader } from "../connectors/loader.js";
+import { queryMetricsHandler } from "./query-metrics.js";
+import { queryLogsHandler } from "./query-logs.js";
+
+// R4 (issue #415 #3): raw_query is an escape hatch that bypasses the curated
+// metric/log surface, so it MUST be refused unless the operator enabled the
+// capability (opts.allowRawQuery, driven by OMCP_RAW_QUERY). These tests pin
+// the gate: the denial fires before any backend is touched, so an empty
+// registry is enough — and with the capability ON the call proceeds past the
+// gate to the normal "no backend configured" path.
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe("raw_query capability gate", () => {
+  const emptyRegistry = () => new ConnectorRegistry(new PluginLoader());
+
+  it("query_metrics refuses raw_query when capability is off (default)", async () => {
+    const out = parse(
+      await queryMetricsHandler(emptyRegistry(), { raw_query: "up" }, undefined, { allowRawQuery: false }),
+    );
+    assert.match(out.error, /raw_query is disabled/i);
+    assert.match(out.error, /OMCP_RAW_QUERY/);
+  });
+
+  it("query_metrics defaults to refusing raw_query when no opts passed", async () => {
+    const out = parse(await queryMetricsHandler(emptyRegistry(), { raw_query: "up" }));
+    assert.match(out.error, /raw_query is disabled/i);
+  });
+
+  it("query_logs refuses raw_query when capability is off (default)", async () => {
+    const out = parse(
+      await queryLogsHandler(emptyRegistry(), { raw_query: '{job="x"}' }, undefined, { allowRawQuery: false }),
+    );
+    assert.match(out.error, /raw_query is disabled/i);
+  });
+
+  it("query_metrics passes the gate when capability is on (reaches backend resolution)", async () => {
+    const out = parse(
+      await queryMetricsHandler(emptyRegistry(), { raw_query: "up" }, undefined, { allowRawQuery: true }),
+    );
+    // Past the gate → normal no-backend path, NOT the capability denial.
+    assert.doesNotMatch(out.error ?? "", /raw_query is disabled/i);
+    assert.match(out.error, /No metrics backends configured/i);
+  });
+
+  it("query_logs passes the gate when capability is on (reaches backend resolution)", async () => {
+    const out = parse(
+      await queryLogsHandler(emptyRegistry(), { raw_query: '{job="x"}' }, undefined, { allowRawQuery: true }),
+    );
+    assert.doesNotMatch(out.error ?? "", /raw_query is disabled/i);
+    assert.match(out.error, /No log backends configured/i);
+  });
+
+  it("query_logs rejects raw_query + aggregate as mutually exclusive", async () => {
+    const out = parse(
+      await queryLogsHandler(
+        emptyRegistry(),
+        { raw_query: '{job="x"}', aggregate: { op: "count_over_time" } },
+        undefined,
+        { allowRawQuery: true },
+      ),
+    );
+    assert.match(out.error, /mutually exclusive/i);
+  });
+
+  it("normal (non-raw) calls are unaffected by the capability flag", async () => {
+    // No raw_query → gate is a no-op even with capability off; falls through
+    // to normal validation/backend path.
+    const out = parse(
+      await queryMetricsHandler(emptyRegistry(), { service: "api", metric: "cpu" }, undefined, { allowRawQuery: false }),
+    );
+    assert.doesNotMatch(out.error ?? "", /raw_query/i);
+  });
+});

--- a/mcp-server/src/tools/validation.test.ts
+++ b/mcp-server/src/tools/validation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { validateDuration, validateServiceName, sanitizeLabelValue, validateLogLabels, validateLogAggregate, validateMetricLabels, errorResponse } from "./validation.js";
+import { validateDuration, validateServiceName, sanitizeLabelValue, validateLogLabels, validateLogAggregate, validateMetricLabels, validateRawQuery, errorResponse } from "./validation.js";
 
 describe("validateLogAggregate (Q-LOG2)", () => {
   it("accepts undefined and valid specs", () => {
@@ -53,6 +53,19 @@ describe("validateLogLabels (Q-LOG1)", () => {
     const many: Record<string, string> = {};
     for (let i = 0; i < 21; i++) many[`k${i}`] = "v";
     assert.ok(validateLogLabels(many));
+  });
+});
+
+describe("validateRawQuery (R4, issue #415 #3)", () => {
+  it("accepts undefined (not requested) and a normal query", () => {
+    assert.equal(validateRawQuery(undefined), null);
+    assert.equal(validateRawQuery('sum(rate(http_requests_total[5m]))'), null);
+  });
+  it("rejects non-strings, empty/whitespace, and over-long", () => {
+    assert.ok(validateRawQuery(42));
+    assert.ok(validateRawQuery(""));
+    assert.ok(validateRawQuery("   "));
+    assert.ok(validateRawQuery("x".repeat(8193)));
   });
 });
 

--- a/mcp-server/src/tools/validation.ts
+++ b/mcp-server/src/tools/validation.ts
@@ -89,6 +89,22 @@ export function validateLogLabels(labels: unknown): string | null {
  */
 export const validateMetricLabels = validateLogLabels;
 
+/**
+ * Validate a raw PromQL/LogQL passthrough string. The capability gate (is raw
+ * query allowed at all) lives at the handler; this only bounds the shape:
+ * non-empty string, length-capped so a crafted query can't build a
+ * pathological request. The query is sent verbatim to the backend (that is the
+ * point of a passthrough), so there is no syntax check — an invalid query just
+ * yields the backend's own parse error.
+ */
+export function validateRawQuery(raw: unknown): string | null {
+  if (raw === undefined) return null;
+  if (typeof raw !== "string") return "raw_query must be a string.";
+  if (raw.trim().length === 0) return "raw_query must not be empty.";
+  if (raw.length > 8192) return "raw_query too long (max 8192 chars).";
+  return null;
+}
+
 const AGGREGATE_OPS = new Set(["count_over_time", "sum", "topk"]);
 
 /**

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -100,6 +100,10 @@ export interface MetricQuery {
   step?: string;
   groupBy?: string; // label to break the result down by (e.g. "instance", "pod")
   labels?: Record<string, string>; // exact-match label filters AND'd into the series selector
+  /** Raw PromQL, run verbatim over query_range — bypasses the curated metric
+   *  catalog/selector. When set, `metric`/`groupBy`/`labels`/`service` are
+   *  ignored. Gated by the OMCP_RAW_QUERY capability at the tool layer. */
+  rawQuery?: string;
 }
 
 export interface LogQuery {
@@ -114,6 +118,11 @@ export interface LogQuery {
    *  environment, …) become first-class selectors instead of brittle
    *  free-text regex. */
   labels?: Record<string, string>;
+  /** Raw LogQL log-selector query, run verbatim — bypasses the curated
+   *  stream-selector/pipeline construction. When set, `service`/`labels`/
+   *  `level`/`query` are ignored. Gated by the OMCP_RAW_QUERY capability at
+   *  the tool layer. For metric LogQL (count_over_time/…) use `aggregate`. */
+  rawQuery?: string;
 }
 
 /** Server-side log aggregation (Q-LOG2). Pushes count/group/topk down to

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
       - Comparison: comparison.md
   - Observability Intelligence:
       - Anomaly history: anomaly-history.md
+      - Raw query passthrough (raw_query): raw-query.md
       - Distributed traces (query_traces): query-traces.md
       - Auto-postmortems (generate_postmortem): postmortems.md
       - Astronomy-shop benchmark: benchmark-astronomy-shop.md


### PR DESCRIPTION
## R4 — issue #415 #3 (raw query passthrough)

Adds a `raw_query` escape hatch to `query_metrics` (verbatim PromQL) and `query_logs` (verbatim LogQL), for ad-hoc queries the curated catalog/selector can't express (any function, any series, hand-written LogQL). As promised in the issue thread, it is **gated behind an explicit operator capability and OFF by default**.

### Enabling
`OMCP_RAW_QUERY=on` (also `true`/`1`). When off (default), the param is still *advertised* in `tools/list` (so an agent can discover it and explain the requirement), but any call passing it is refused with a clear message.

### Safety (the gate is the whole point)
- **Gate fires before any backend is touched.** `opts.allowRawQuery` defaults to **off** when the 4th handler arg is omitted — a forgetful caller cannot accidentally enable raw. Verified live (default boot refuses) and by unit tests (incl. the default-opts path).
- **Tenant-scoped** (only the caller's tenant's connectors) and honours the per-credential **source allow-list**.
- `query_logs` raw output is still **redacted** by the normal wrapper.
- Raw string is `encodeURIComponent`'d into the backend request (no extra URL-param injection) and length-capped (8192).
- `raw_query` is mutually exclusive with `aggregate` on `query_logs` — and `aggregate` stays available **without** the raw capability for safe server-side counts/top-k.

`service`/`metric` become schema-optional (raw doesn't need them); the non-raw path re-guards their presence so a normal call never silently no-ops.

### Tests + verification
Capability gate (off→deny, on→reaches backend), connector verbatim passthrough (Prometheus `queryRaw` + Loki), mutual-exclusion, `validateRawQuery` bounds, and a live `tools/list` conformance assertion. Verified end-to-end against a booted server (both tools advertise `raw_query`; gate denies when off). Reviewer-agent: **SHIP** — gate adversarially checked, no bypass found. Docs: `docs/raw-query.md`. No release — bundles into v3.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)