### PR TITLE
feat(redaction): anonymous-friendly per-call redaction bypass (issue #415 Gap A)

### DIFF
--- a/docs/redaction.md
+++ b/docs/redaction.md
@@ -48,6 +48,8 @@ rather than confabulating around scrubbed text.
 
 ## Opt-out
 
+### Global
+
 Set `OMCP_REDACTION=off` at server startup to disable redaction
 process-wide. Sensible only when:
 
@@ -55,11 +57,27 @@ process-wide. Sensible only when:
 - The agent runs entirely on-prem with the same trust boundary as the
   raw logs.
 
-There is no per-request bypass today. A future iteration will introduce
-a `redaction:bypass` RBAC permission (admin role by default) + an
-opt-in credential allow-list (`OMCP_KEY_BYPASS_REDACTION`) so an
-interactive admin session can
-flip redaction off for one tool call without restarting the server.
+### Per-call bypass (preferred)
+
+A tool call can request `bypass_redaction: true` to skip redaction for
+that single `query_logs` response. The server honours it **only** when
+the calling identity is allowed to bypass — so the per-call arg alone
+never weakens redaction. Two ways to grant that:
+
+| Deployment | How to allow the per-call bypass |
+|---|---|
+| **Credentialed** (`OMCP_API_KEYS` set) | Add the credential's name to `OMCP_KEY_BYPASS_REDACTION` (comma-separated allow-list). |
+| **Anonymous** (no credentials) | Set `OMCP_BYPASS_REDACTION_ANON=true`. There is no named credential to allow-list, so this opts the anonymous/stdio identity in. |
+
+This is the right lever for the common single-user, self-hosted case:
+an agent investigating its *own* logs needs raw IPs (to geolocate,
+dedupe, or separate humans from bots) without the blunt
+`OMCP_REDACTION=off` sledgehammer. Redaction stays the default for
+every call that does **not** set `bypass_redaction: true`, and every
+bypass (engaged or denied) is recorded on the management-plane audit
+chain.
+
+Both levers default OFF — redaction is on out of the box.
 
 ## False-positive notes
 

--- a/mcp-server/src/context.test.ts
+++ b/mcp-server/src/context.test.ts
@@ -42,6 +42,13 @@ test("defaultContext — no allowedTools (anonymous sees every tool, back-compat
   assert.equal(allowsTool(ctx.allowedTools, "any_tool"), true);
 });
 
+test("defaultContext — allowBypassRedaction is off by default, opt-in via opts (R5, issue #415 Gap A)", () => {
+  assert.equal(defaultContext().allowBypassRedaction, undefined);
+  assert.equal(defaultContext({}).allowBypassRedaction, undefined);
+  assert.equal(defaultContext({ allowBypassRedaction: false }).allowBypassRedaction, undefined);
+  assert.equal(defaultContext({ allowBypassRedaction: true }).allowBypassRedaction, true);
+});
+
 import { sessionContext } from "./context.js";
 
 test("sessionContext — undefined session → defaultContext shape (anonymous, default tenant)", () => {

--- a/mcp-server/src/context.ts
+++ b/mcp-server/src/context.ts
@@ -41,12 +41,20 @@ export interface RequestContext {
   correlationId: string;
 }
 
-/** Default all-access anonymous context — preserves current behaviour. */
-export function defaultContext(): RequestContext {
+/** Default all-access anonymous context — preserves current behaviour.
+ *  `opts.allowBypassRedaction` lets an operator opt the anonymous identity
+ *  into per-call redaction bypass (OMCP_BYPASS_REDACTION_ANON) — in an
+ *  anonymous deployment there is no named credential to add to
+ *  OMCP_KEY_BYPASS_REDACTION, so this is the only way a single-user
+ *  self-hosted agent can see raw IPs on its own logs without the blunt
+ *  global OMCP_REDACTION=off. Defaults off; all existing call sites that
+ *  omit opts are unchanged. */
+export function defaultContext(opts: { allowBypassRedaction?: boolean } = {}): RequestContext {
   return {
     principalId: "anonymous",
     auth: "anonymous",
     tenant: DEFAULT_TENANT,
+    allowBypassRedaction: opts.allowBypassRedaction || undefined,
     correlationId: randomUUID(),
   };
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -350,6 +350,15 @@ async function main() {
   const RAW_QUERY_ENABLED = ["on", "true", "1"].includes(
     String(process.env.OMCP_RAW_QUERY ?? "off").toLowerCase()
   );
+  // Opt the anonymous/default identity into per-call redaction bypass. In an
+  // anonymous deployment (no OMCP_API_KEYS) there is no named credential to
+  // add to OMCP_KEY_BYPASS_REDACTION, so a per-call bypass_redaction can never
+  // succeed — the only lever was the blunt global OMCP_REDACTION=off. This
+  // flag lets a single-user self-hosted agent see raw values on its own logs
+  // via the per-call arg, while redaction stays the default. Default OFF.
+  const BYPASS_REDACTION_ANON = ["on", "true", "1"].includes(
+    String(process.env.OMCP_BYPASS_REDACTION_ANON ?? "false").toLowerCase()
+  );
   function redactToolText<T extends { content: Array<{ text: string }> }>(
     result: T,
     opts: { bypass?: boolean } = {},
@@ -646,7 +655,7 @@ async function main() {
         .boolean()
         .optional()
         .describe(
-          "Optional. When true, request that PII/secret redaction be skipped for this single call. The server only honours this when the calling credential was explicitly authorised via OMCP_KEY_BYPASS_REDACTION; otherwise the request still gets redacted output. Default: false.",
+          "Optional. When true, request that PII/secret redaction be skipped for this single call. The server only honours this when the calling identity is authorised to bypass — a credential listed in OMCP_KEY_BYPASS_REDACTION, or the anonymous identity when the operator set OMCP_BYPASS_REDACTION_ANON=true; otherwise the request still gets redacted output. Default: false.",
         ),
       raw_query: z
         .string()
@@ -3319,8 +3328,10 @@ async function main() {
   });
 
   // Stdio transport: one server over stdin/stdout, no HTTP listener.
+  // Stdio is inherently a local single-user channel, so the anonymous
+  // redaction-bypass opt-in applies here too.
   if (STDIO) {
-    const { mcpServer: server } = createMcpServer(defaultContext());
+    const { mcpServer: server } = createMcpServer(defaultContext({ allowBypassRedaction: BYPASS_REDACTION_ANON }));
     await server.connect(new StdioServerTransport());
     console.error(
       `observability-mcp running on stdio transport · connectors: ${registry
@@ -3425,7 +3436,7 @@ async function main() {
     req: import("express").Request,
     res: import("express").Response
   ): Promise<RequestContext | null> {
-    if (!credentialsConfigured()) return defaultContext();
+    if (!credentialsConfigured()) return defaultContext({ allowBypassRedaction: BYPASS_REDACTION_ANON });
     const cred = resolveToken(
       extractToken(req.headers as Record<string, unknown>),
       loadCredentials()


### PR DESCRIPTION
## R5 — issue #415 Gap A

A tester on the default (anonymous) deployment found that `bypass_redaction: true` can **never** succeed: the bypass requires the calling credential to be in `OMCP_KEY_BYPASS_REDACTION`, and with no `OMCP_API_KEYS` there's no named credential to add. The only lever left was the blunt global `OMCP_REDACTION=off`. A self-hosted single-user agent investigating its *own* logs (geolocate IPs, dedupe, separate humans from bots) needs raw values without disabling redaction wholesale.

### Change
`OMCP_BYPASS_REDACTION_ANON=true` opts the anonymous/default (and stdio) identity into the per-call bypass.

### Safety
- **Two-key requirement preserved**: redaction is skipped only when the identity is allowed **AND** the call sets `bypass_redaction:true`. A normal anonymous call (no arg) stays redacted.
- **Default OFF**; `defaultContext()` with no args still yields `allowBypassRedaction: undefined`.
- **Scoped to anonymous**: credentialed deployments are unaffected — `OMCP_KEY_BYPASS_REDACTION` still governs per-credential (`principalContext` untouched).
- Every bypass (engaged/denied) stays on the management-plane audit chain.

### Verification
Live: with the flag on, an anonymous `query_logs` + `bypass_redaction:true` emits `redaction_bypass_engaged` (vs `_denied` when off). Unit test pins the default-safe + opt-in behaviour. Also rewrote the stale `docs/redaction.md` "no per-request bypass today" section (per-call bypass already shipped) and aligned the param description. Reviewer-agent: **SHIP** (default-safe + two-key verified). No release — bundles into v3.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)