### PR TITLE
feat(enrich): offline enrich_ips tool — geo/ASN/hosting (issue #415 Gap B)

### DIFF
--- a/docs/ip-enrichment.md
+++ b/docs/ip-enrichment.md
@@ -1,0 +1,81 @@
+# IP enrichment (`enrich_ips`)
+
+Traffic / abuse / security investigations over access logs need the same
+three things for each client IP: **geo** (country/city), **ASN/org**
+(which network/ISP), and a **hosting/proxy flag** (the signal that
+separates real humans from datacenter IPs, scanners, and VPN exit
+nodes). The `enrich_ips` tool resolves a batch of IPs to those fields
+from a **local, offline dataset** — there is no per-IP call to an
+external geo API, so it works in air-gapped deployments.
+
+## Enabling
+
+Point the server at a local CSV:
+
+```bash
+OMCP_IP_ENRICH_FILE=/data/ip-enrichment.csv
+```
+
+When unset (the default), `enrich_ips` is still advertised but returns a
+clear "not configured" notice — no external lookups ever happen
+implicitly.
+
+## Dataset format
+
+A dependency-free CSV (so no parser library / host `npm install` is
+needed). One row per IPv4 network:
+
+```csv
+network,country,city,asn,org,hosting
+1.2.3.0/24,US,Ashburn,AS14618,Example Cloud,true
+203.0.113.5,DE,Berlin,AS3320,Example ISP,false
+```
+
+- `network` — an IPv4 CIDR, or a bare IPv4 (treated as `/32`). IPv6 rows
+  are skipped (logged at boot); IPv4 covers the access-log case.
+- `country`, `city`, `asn`, `org` — optional; an empty cell is omitted
+  from the result.
+- `hosting` — `true`/`1`/`yes` (case-insensitive) marks a
+  datacenter/hosting/proxy range; anything else is `false`.
+- Blank lines and `#` comments are ignored; a header row whose first
+  cell is `network` is skipped.
+
+Overlapping/nested ranges resolve to the **most specific** (longest
+prefix) match, so a `/24` row wins over a `/8` that also contains the
+IP. The dataset is loaded once at boot and looked up in-memory.
+
+You supply the data offline — e.g. export the ranges of interest from
+whatever geo/ASN source you already license into this CSV and mount it.
+This keeps enrichment air-gapped and avoids bundling any third-party
+database into the image.
+
+## Usage
+
+```jsonc
+{ "ips": ["203.0.113.5", "198.51.100.9", "1.2.3.99"] }
+```
+
+Returns one row per input IP (max 1000 per call); unmatched and invalid
+IPs come back with `found: false` rather than failing the batch:
+
+```jsonc
+{
+  "results": [
+    { "ip": "1.2.3.99", "found": true, "country": "US", "city": "Ashburn",
+      "asn": "AS14618", "org": "Example Cloud", "hosting": true },
+    { "ip": "8.8.8.8", "found": false }
+  ],
+  "summary": { "total": 2, "matched": 1, "unmatched": 1, "invalid": 0 },
+  "datasetSize": 1
+}
+```
+
+A typical agent flow: pull the IPs of interest with `query_logs`
+(use `labels` / `aggregate` to filter or top-k first), then pass them to
+`enrich_ips` to answer "where from / which are bots".
+
+## Air-gapped guarantee
+
+`enrich_ips` never makes an outbound request — all data comes from the
+local file. This is the deliberate trade vs. a live geo-API enrichment
+on every log line, which would break the air-gapped deployment model.

--- a/mcp-server/src/conformance/mcp-2025-11-25.test.ts
+++ b/mcp-server/src/conformance/mcp-2025-11-25.test.ts
@@ -179,6 +179,17 @@ test("MCP 2025-11-25: query_metrics + query_logs advertise raw_query (issue #415
   }
 });
 
+test("MCP 2025-11-25: enrich_ips tool is advertised (issue #415 Gap B)", opts, async () => {
+  const session = await newSession();
+  const { response } = await jsonRpc("tools/list", {}, { id: 2, session });
+  const r = response.result as {
+    tools?: Array<{ name?: string; inputSchema?: { properties?: Record<string, unknown> } }>;
+  };
+  const tool = r.tools?.find((t) => t.name === "enrich_ips");
+  assert.ok(tool, "enrich_ips tool must be advertised");
+  assert.ok("ips" in (tool.inputSchema?.properties ?? {}), "enrich_ips must advertise an `ips` param");
+});
+
 test("MCP 2025-11-25: tools/call dispatches and returns CallToolResult", opts, async () => {
   const session = await newSession();
   const { response } = await jsonRpc(

--- a/mcp-server/src/enrich/ip-dataset.test.ts
+++ b/mcp-server/src/enrich/ip-dataset.test.ts
@@ -1,0 +1,93 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { ipv4ToInt, parseCidr, IpEnrichmentDataset } from "./ip-dataset.js";
+
+describe("ipv4ToInt", () => {
+  it("parses valid IPv4", () => {
+    assert.equal(ipv4ToInt("0.0.0.0"), 0);
+    assert.equal(ipv4ToInt("255.255.255.255"), 4294967295);
+    assert.equal(ipv4ToInt("1.2.3.4"), 0x01020304);
+  });
+  it("rejects malformed / out-of-range / non-IPv4", () => {
+    assert.equal(ipv4ToInt("1.2.3"), null);
+    assert.equal(ipv4ToInt("1.2.3.256"), null);
+    assert.equal(ipv4ToInt("1.2.3.4.5"), null);
+    assert.equal(ipv4ToInt("a.b.c.d"), null);
+    assert.equal(ipv4ToInt("::1"), null);
+    assert.equal(ipv4ToInt(""), null);
+  });
+});
+
+describe("parseCidr", () => {
+  it("parses a /24 to its inclusive range", () => {
+    const r = parseCidr("1.2.3.0/24");
+    assert.deepEqual(r, { start: 0x01020300, end: 0x010203ff, prefix: 24 });
+  });
+  it("treats a bare IP as /32", () => {
+    const r = parseCidr("203.0.113.5");
+    assert.equal(r?.prefix, 32);
+    assert.equal(r?.start, r?.end);
+  });
+  it("normalises a non-aligned base to the network address", () => {
+    // 1.2.3.42/24 → network 1.2.3.0
+    const r = parseCidr("1.2.3.42/24");
+    assert.equal(r?.start, 0x01020300);
+  });
+  it("handles /0 (whole space)", () => {
+    const r = parseCidr("0.0.0.0/0");
+    assert.deepEqual(r, { start: 0, end: 4294967295, prefix: 0 });
+  });
+  it("rejects bad prefixes / addresses", () => {
+    assert.equal(parseCidr("1.2.3.0/33"), null);
+    assert.equal(parseCidr("1.2.3.0/-1"), null);
+    assert.equal(parseCidr("nope/24"), null);
+  });
+});
+
+describe("IpEnrichmentDataset.fromCsv + lookup", () => {
+  const csv = [
+    "network,country,city,asn,org,hosting", // header skipped
+    "# a comment line",
+    "",
+    "10.0.0.0/8,US,,AS100,Example Cloud,true",
+    "10.1.2.0/24,US,Ashburn,AS100,Example Cloud Edge,true",
+    "203.0.113.5,DE,Berlin,AS3320,Example ISP,false",
+    "2001:db8::/32,XX,,,,", // IPv6 → skipped
+    "garbage-row",
+  ].join("\n");
+
+  it("parses rows, skips header/comments/blank, counts skipped", () => {
+    const ds = IpEnrichmentDataset.fromCsv(csv);
+    assert.equal(ds.size, 3); // 3 valid IPv4 rows
+    assert.equal(ds.skipped, 2); // IPv6 + garbage
+  });
+
+  it("returns the most specific (longest-prefix) match", () => {
+    const ds = IpEnrichmentDataset.fromCsv(csv);
+    // 10.1.2.5 is inside both /8 and /24 → the /24 (more specific) wins.
+    const hit = ds.lookup("10.1.2.5");
+    assert.equal(hit?.city, "Ashburn");
+    assert.equal(hit?.org, "Example Cloud Edge");
+    assert.equal(hit?.hosting, true);
+  });
+
+  it("falls back to the broader range when no specific one matches", () => {
+    const ds = IpEnrichmentDataset.fromCsv(csv);
+    const hit = ds.lookup("10.5.5.5"); // only in /8
+    assert.equal(hit?.asn, "AS100");
+    assert.equal(hit?.city, undefined); // empty cell omitted
+  });
+
+  it("matches a /32 exactly and parses hosting=false", () => {
+    const ds = IpEnrichmentDataset.fromCsv(csv);
+    const hit = ds.lookup("203.0.113.5");
+    assert.equal(hit?.country, "DE");
+    assert.equal(hit?.hosting, false);
+  });
+
+  it("returns null for an unmatched or invalid IP", () => {
+    const ds = IpEnrichmentDataset.fromCsv(csv);
+    assert.equal(ds.lookup("8.8.8.8"), null);
+    assert.equal(ds.lookup("not-an-ip"), null);
+  });
+});

--- a/mcp-server/src/enrich/ip-dataset.ts
+++ b/mcp-server/src/enrich/ip-dataset.ts
@@ -1,0 +1,120 @@
+// Offline IPv4 enrichment dataset (issue #415 Gap B).
+//
+// Air-gapped by construction: enrichment comes from a LOCAL dataset the
+// operator supplies (OMCP_IP_ENRICH_FILE), never a per-line phone-home to an
+// external geo/ASN API. The format is a dependency-free CSV so no parser
+// library (and no npm install on the host) is needed:
+//
+//   network,country,city,asn,org,hosting
+//   1.2.3.0/24,US,Ashburn,AS14618,Example Cloud,true
+//   203.0.113.5,DE,Berlin,AS3320,Example ISP,false
+//
+// - `network` is an IPv4 CIDR (or a bare IPv4, treated as /32). IPv6 rows are
+//   skipped (logged by the caller) — IPv4 covers the access-log case the
+//   report was about; IPv6 can follow.
+// - Remaining columns are optional; an empty cell is omitted from the result.
+// - `hosting` is the "is this a datacenter / hosting / proxy range" flag — the
+//   signal that separates real humans from bots/scanners/VPN-exit-nodes. Parsed
+//   truthily from true/1/yes (case-insensitive); anything else is false.
+// - Lines that are blank or start with `#` are ignored. A header row whose
+//   first cell is literally `network` is skipped.
+
+export interface IpEnrichment {
+  country?: string;
+  city?: string;
+  asn?: string;
+  org?: string;
+  hosting?: boolean;
+}
+
+interface Range {
+  start: number; // inclusive, unsigned 32-bit
+  end: number; // inclusive
+  prefix: number; // CIDR prefix length — larger = more specific
+  data: IpEnrichment;
+}
+
+/** Parse an IPv4 string to an unsigned 32-bit integer, or null if invalid. */
+export function ipv4ToInt(ip: string): number | null {
+  const parts = ip.trim().split(".");
+  if (parts.length !== 4) return null;
+  let n = 0;
+  for (const p of parts) {
+    if (!/^\d{1,3}$/.test(p)) return null;
+    const o = Number(p);
+    if (o > 255) return null;
+    n = n * 256 + o;
+  }
+  return n >>> 0;
+}
+
+/** Parse an IPv4 CIDR (or bare IPv4 = /32) to an inclusive integer range. */
+export function parseCidr(cidr: string): { start: number; end: number; prefix: number } | null {
+  const [addr, prefixStr] = cidr.trim().split("/");
+  const base = ipv4ToInt(addr);
+  if (base === null) return null;
+  const prefix = prefixStr === undefined ? 32 : Number(prefixStr);
+  if (!Number.isInteger(prefix) || prefix < 0 || prefix > 32) return null;
+  // Mask: top `prefix` bits. prefix 0 → whole space; 32 → single host.
+  const hostBits = 32 - prefix;
+  const mask = prefix === 0 ? 0 : (0xffffffff << hostBits) >>> 0;
+  const start = (base & mask) >>> 0;
+  const end = (start + (hostBits === 32 ? 0xffffffff : (1 << hostBits) - 1)) >>> 0;
+  return { start, end, prefix };
+}
+
+export class IpEnrichmentDataset {
+  private ranges: Range[] = [];
+  /** Rows that couldn't be parsed (bad CIDR, IPv6, malformed) — surfaced for diagnostics. */
+  readonly skipped: number;
+  readonly size: number;
+
+  private constructor(ranges: Range[], skipped: number) {
+    // Sort by start asc; lookup picks the most specific (largest prefix)
+    // containing range so nested/overlapping rows resolve deterministically.
+    this.ranges = ranges.sort((a, b) => a.start - b.start || a.end - b.end);
+    this.skipped = skipped;
+    this.size = ranges.length;
+  }
+
+  static fromCsv(text: string): IpEnrichmentDataset {
+    const ranges: Range[] = [];
+    let skipped = 0;
+    for (const rawLine of text.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (!line || line.startsWith("#")) continue;
+      const cells = line.split(",").map((c) => c.trim());
+      if (cells[0].toLowerCase() === "network") continue; // header
+      const r = parseCidr(cells[0]);
+      if (!r) {
+        skipped++;
+        continue;
+      }
+      const data: IpEnrichment = {};
+      if (cells[1]) data.country = cells[1];
+      if (cells[2]) data.city = cells[2];
+      if (cells[3]) data.asn = cells[3];
+      if (cells[4]) data.org = cells[4];
+      if (cells[5] !== undefined && cells[5] !== "") {
+        data.hosting = ["true", "1", "yes"].includes(cells[5].toLowerCase());
+      }
+      ranges.push({ start: r.start, end: r.end, prefix: r.prefix, data });
+    }
+    return new IpEnrichmentDataset(ranges, skipped);
+  }
+
+  /** Look up an IPv4 string. Returns the most specific matching row, or null. */
+  lookup(ip: string): IpEnrichment | null {
+    const n = ipv4ToInt(ip);
+    if (n === null) return null;
+    let best: Range | null = null;
+    // Linear scan is fine for the dataset sizes this is meant for (curated
+    // ranges of interest, not a full global table). Pick the most specific
+    // (largest prefix) range that contains the IP.
+    for (const r of this.ranges) {
+      if (r.start > n) break; // sorted by start asc — all remaining ranges start after n
+      if (n <= r.end && (best === null || r.prefix > best.prefix)) best = r;
+    }
+    return best ? { ...best.data } : null;
+  }
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -118,6 +118,8 @@ import { listSourcesHandler } from "./tools/list-sources.js";
 import { listServicesHandler } from "./tools/list-services.js";
 import { queryMetricsHandler } from "./tools/query-metrics.js";
 import { queryLogsHandler } from "./tools/query-logs.js";
+import { enrichIpsHandler } from "./tools/enrich-ips.js";
+import { IpEnrichmentDataset } from "./enrich/ip-dataset.js";
 import { queryTracesHandler } from "./tools/query-traces.js";
 import { getAnomalyHistoryHandler } from "./tools/get-anomaly-history.js";
 import { generatePostmortemHandler } from "./tools/generate-postmortem.js";
@@ -359,6 +361,27 @@ async function main() {
   const BYPASS_REDACTION_ANON = ["on", "true", "1"].includes(
     String(process.env.OMCP_BYPASS_REDACTION_ANON ?? "false").toLowerCase()
   );
+  // Offline IP-enrichment dataset (issue #415 Gap B) — loaded once at boot from
+  // a local CSV (OMCP_IP_ENRICH_FILE). No external geo/ASN API is ever called,
+  // so it stays air-gapped. Unset / unreadable → enrich_ips returns a clear
+  // "not configured" notice rather than failing.
+  let ipEnrichment: IpEnrichmentDataset | null = null;
+  const ipEnrichFile = process.env.OMCP_IP_ENRICH_FILE;
+  if (ipEnrichFile) {
+    try {
+      ipEnrichment = IpEnrichmentDataset.fromCsv(readFileSync(ipEnrichFile, "utf8"));
+      console.log(
+        `[enrich] IP enrichment dataset loaded from ${ipEnrichFile}: ${ipEnrichment.size} ranges` +
+          (ipEnrichment.skipped ? ` (${ipEnrichment.skipped} rows skipped)` : ""),
+      );
+    } catch (err) {
+      console.error(
+        `[enrich] failed to load OMCP_IP_ENRICH_FILE (${ipEnrichFile}): ${
+          err instanceof Error ? err.message : String(err)
+        } — enrich_ips will report 'not configured'`,
+      );
+    }
+  }
   function redactToolText<T extends { content: Array<{ text: string }> }>(
     result: T,
     opts: { bypass?: boolean } = {},
@@ -881,6 +904,27 @@ async function main() {
     async (args) => {
       await enforceEntitledAccess(ctx, { tool: "get_blast_radius" });
       return withToolMetrics("get_blast_radius", () => getBlastRadiusHandler(registry, args, ctx));
+    }
+  );
+
+  registerTool(
+    "enrich_ips",
+    [
+      "Resolve a batch of IPv4 addresses to geo (country/city), ASN/org, and a hosting/proxy flag.",
+      "When to use: answering 'where are these visitors from?' or 'which of these IPs are bots / datacenter / VPN exit nodes?' over access logs, without an out-of-band geo-API call per IP.",
+      "Behavior: read-only. Looks each IP up in a LOCAL offline dataset the operator configured (OMCP_IP_ENRICH_FILE) — there is no external network call, so it is safe in air-gapped deployments. Returns one row per input IP with found=true/false plus any known fields. If no dataset is configured it returns a clear notice explaining how to enable it.",
+      "Related: pull the IPs from `query_logs` (use `labels`/`aggregate` to find the IPs of interest first).",
+    ].join(" "),
+    {
+      ips: z
+        .array(z.string())
+        .describe(
+          "Required. IPv4 address strings to enrich (e.g. ['203.0.113.5','198.51.100.9']). Max 1000 per call; invalid entries are returned with found=false rather than failing the batch.",
+        ),
+    },
+    async (args) => {
+      await enforceEntitledAccess(ctx, { tool: "enrich_ips" });
+      return withToolMetrics("enrich_ips", async () => enrichIpsHandler(ipEnrichment, args, ctx));
     }
   );
 

--- a/mcp-server/src/tools/enrich-ips.test.ts
+++ b/mcp-server/src/tools/enrich-ips.test.ts
@@ -1,0 +1,50 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { IpEnrichmentDataset } from "../enrich/ip-dataset.js";
+import { enrichIpsHandler } from "./enrich-ips.js";
+
+function parse(result: { content: Array<{ text: string }> }) {
+  return JSON.parse(result.content[0].text);
+}
+
+const ds = IpEnrichmentDataset.fromCsv(
+  ["1.2.3.0/24,US,Ashburn,AS14618,Example Cloud,true", "203.0.113.5,DE,Berlin,AS3320,Example ISP,false"].join("\n"),
+);
+
+describe("enrichIpsHandler (R6, issue #415 Gap B)", () => {
+  it("returns a clear 'not configured' notice when no dataset is loaded", () => {
+    const out = parse(enrichIpsHandler(null, { ips: ["1.2.3.4"] }));
+    assert.match(out.error, /not configured/i);
+    assert.match(out.error, /OMCP_IP_ENRICH_FILE/);
+  });
+
+  it("rejects empty / missing ips", () => {
+    assert.match(parse(enrichIpsHandler(ds, { ips: [] })).error, /non-empty array/i);
+    assert.match(parse(enrichIpsHandler(ds, {})).error, /non-empty array/i);
+  });
+
+  it("rejects an over-large batch", () => {
+    const many = Array.from({ length: 1001 }, (_, i) => `1.2.3.${i % 255}`);
+    assert.match(parse(enrichIpsHandler(ds, { ips: many })).error, /Too many IPs/i);
+  });
+
+  it("enriches known IPs and reports found=false for misses + invalid", () => {
+    const out = parse(enrichIpsHandler(ds, { ips: ["1.2.3.99", "8.8.8.8", "not-an-ip"] }));
+    assert.equal(out.results.length, 3);
+
+    const matched = out.results.find((r: any) => r.ip === "1.2.3.99");
+    assert.equal(matched.found, true);
+    assert.equal(matched.city, "Ashburn");
+    assert.equal(matched.hosting, true);
+
+    const miss = out.results.find((r: any) => r.ip === "8.8.8.8");
+    assert.equal(miss.found, false);
+    assert.equal(miss.city, undefined);
+
+    const invalid = out.results.find((r: any) => r.ip === "not-an-ip");
+    assert.equal(invalid.found, false);
+
+    assert.deepEqual(out.summary, { total: 3, matched: 1, unmatched: 1, invalid: 1 });
+    assert.equal(out.datasetSize, 2);
+  });
+});

--- a/mcp-server/src/tools/enrich-ips.ts
+++ b/mcp-server/src/tools/enrich-ips.ts
@@ -1,0 +1,89 @@
+import { IpEnrichmentDataset, ipv4ToInt } from "../enrich/ip-dataset.js";
+import { defaultContext, type RequestContext } from "../context.js";
+import { errorResponse } from "./validation.js";
+
+// enrich_ips (issue #415 Gap B): resolve a batch of IPs to geo / ASN / org /
+// hosting-flag from the operator's LOCAL offline dataset. No external lookups,
+// so it is safe in air-gapped deployments. Disabled (returns a clear message)
+// when no dataset is configured.
+
+export const enrichIpsDefinition = {
+  name: "enrich_ips" as const,
+  description:
+    "Resolve a batch of IPv4 addresses to geo (country/city), ASN/org, and a hosting/proxy flag from a local offline dataset. Use this to answer 'where are these visitors from / which are bots or datacenter IPs' without an out-of-band geo API call. Requires the operator to have configured an offline dataset (OMCP_IP_ENRICH_FILE); returns a clear notice otherwise.",
+};
+
+const MAX_IPS = 1000;
+
+export interface EnrichIpsArgs {
+  ips?: string[];
+}
+
+export interface IpEnrichmentResult {
+  ip: string;
+  found: boolean;
+  country?: string;
+  city?: string;
+  asn?: string;
+  org?: string;
+  hosting?: boolean;
+}
+
+export function enrichIpsHandler(
+  dataset: IpEnrichmentDataset | null,
+  args: EnrichIpsArgs,
+  // The RequestContext seam — enrich_ips doesn't scope by tenant today (the
+  // dataset is a single process-wide table), but every tool handler threads
+  // ctx so access-control / audit can attach without a signature change later.
+  _ctx: RequestContext = defaultContext(),
+) {
+  if (!dataset) {
+    return errorResponse(
+      "IP enrichment is not configured. Set OMCP_IP_ENRICH_FILE to a local CSV " +
+        "(network,country,city,asn,org,hosting) to enable offline geo/ASN/hosting " +
+        "lookups — there is no external API call, so it stays air-gapped.",
+    );
+  }
+  const ips = args.ips;
+  if (!Array.isArray(ips) || ips.length === 0) {
+    return errorResponse("`ips` must be a non-empty array of IPv4 address strings.");
+  }
+  if (ips.length > MAX_IPS) {
+    return errorResponse(`Too many IPs (${ips.length}); max ${MAX_IPS} per call.`);
+  }
+
+  const results: IpEnrichmentResult[] = [];
+  let invalid = 0;
+  let matched = 0;
+  for (const ip of ips) {
+    if (typeof ip !== "string" || ipv4ToInt(ip) === null) {
+      invalid++;
+      results.push({ ip: String(ip), found: false });
+      continue;
+    }
+    const hit = dataset.lookup(ip);
+    if (hit) {
+      matched++;
+      results.push({ ip, found: true, ...hit });
+    } else {
+      results.push({ ip, found: false });
+    }
+  }
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            results,
+            summary: { total: ips.length, matched, unmatched: ips.length - matched - invalid, invalid },
+            datasetSize: dataset.size,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}

--- a/mcp-server/src/tools/registry-names.ts
+++ b/mcp-server/src/tools/registry-names.ts
@@ -25,6 +25,7 @@ export const REGISTERED_TOOL_NAMES = [
   "generate_postmortem",
   "get_topology",
   "get_blast_radius",
+  "enrich_ips",
 ] as const;
 
 export type RegisteredToolName = typeof REGISTERED_TOOL_NAMES[number];
@@ -55,6 +56,7 @@ export const REGISTERED_TOOLS: readonly ToolRegistryEntry[] = [
   { name: "generate_postmortem",category: "diagnose",  summary: "One-shot markdown post-mortem stitching anomaly history + traces + blast-radius + logs for a service." },
   { name: "get_topology",       category: "topology",  summary: "Return the infrastructure topology graph (resources + edges)." },
   { name: "get_blast_radius",   category: "topology",  summary: "Given a resource, return the impact set if its host(s) fail." },
+  { name: "enrich_ips",         category: "query",     summary: "Resolve IPv4 addresses to geo/ASN/org/hosting-flag from a local offline dataset." },
 ] as const;
 
 /** Validate a candidate Product tools[] array. Returns the unknown

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
   - Observability Intelligence:
       - Anomaly history: anomaly-history.md
       - Raw query passthrough (raw_query): raw-query.md
+      - IP enrichment (enrich_ips): ip-enrichment.md
       - Distributed traces (query_traces): query-traces.md
       - Auto-postmortems (generate_postmortem): postmortems.md
       - Astronomy-shop benchmark: benchmark-astronomy-shop.md


### PR DESCRIPTION
## R6 — issue #415 Gap B

New MCP tool **`enrich_ips`**: resolves a batch of IPv4 addresses to **geo** (country/city), **ASN/org**, and a **hosting/proxy flag** — the three things every traffic/abuse/security investigation needs per IP (the hosting flag is what separates real humans from datacenter IPs / scanners / VPN exit nodes). The tester raised this from "nice-to-have" to high-value after a full day of campaign analytics.

### Air-gapped by construction
Enrichment comes from a **local** dataset the operator supplies (`OMCP_IP_ENRICH_FILE`, a dependency-free CSV `network,country,city,asn,org,hosting`), loaded once at boot. **There is no per-IP external geo-API call** — the deliberate trade vs. a live phone-home that would break the air-gapped model (exactly why the original "geo enrichment on every line" idea was declined). Unset/unreadable → the tool returns a clear "not configured" notice (no crash).

### Details
- IPv4 CIDR **longest-prefix** lookup (unsigned-32-bit safe), in-memory; bare IP = `/32`; IPv6/comment/header/malformed rows skipped + counted.
- Batch cap 1000; invalid IPs return `found:false` rather than failing the batch.
- Wired into the inline `registerTool` schema **and** the `registry-names` parity list; handler threads `RequestContext` (seam). Tool always advertised.
- Always opt-in: returns "not configured" until a dataset is set.

### Tests + verification
`ip-dataset` (ipv4ToInt/parseCidr edge cases incl. `/0`,`/32`, nested longest-prefix, header/comment/IPv6 skip), `enrich-ips` handler (not-configured, bounds, matched/unmatched/invalid summary), conformance advertise. Live-verified end-to-end (`{found:true,country:US,city:Ashburn,asn:AS14618,hosting:true}`, summary `{matched:1,unmatched:1}`). Reviewer-agent: **SHIP** — air-gapped property (no fetch/http/dns anywhere) + CIDR math adversarially verified. Docs: `docs/ip-enrichment.md`. No release — bundles into v3.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)