### PR TITLE
chore(release): v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,58 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.2.0] — 2026-06-09
+
+Agent-usability release — closes the remaining points from the
+real-world feedback in issue #415 (the log-side #1/#2 shipped in 3.1.x).
+Every addition is opt-in or additive; migrating from 3.1 is
+non-breaking. See [`docs/migrations/3.1-to-3.2.md`](docs/migrations/3.1-to-3.2.md).
+
+### Added
+
+- **`query_metrics` `labels` filter** (issue #415 #4) — an optional
+  exact-match label map AND'd into the metric's PromQL series selector,
+  the metrics-side equivalent of the `query_logs` `labels` param. Scope
+  a curated metric to a subset of series (e.g. `error_rate` for one
+  `route`/`status`) instead of the all-series aggregate; combine with
+  `groupBy` to filter-then-break-down. Label names re-validated and
+  values escaped for PromQL (backslash/quote/`\n\r\t`).
+- **`raw_query` passthrough** (issue #415 #3) — an escape hatch for
+  verbatim PromQL (`query_metrics`) and LogQL (`query_logs`) when the
+  curated catalog can't express a query. **Capability-gated, OFF by
+  default**: enable with `OMCP_RAW_QUERY=on`. Still tenant-scoped,
+  source-allow-listed, and (for logs) redacted; mutually exclusive with
+  `aggregate`. The param is advertised even when disabled so an agent
+  can discover and explain the requirement. See
+  [raw-query.md](docs/raw-query.md).
+- **`enrich_ips` tool** (issue #415 Gap B) — resolves a batch of IPv4
+  addresses to geo (country/city), ASN/org, and a hosting/proxy flag
+  from a **local offline dataset** (`OMCP_IP_ENRICH_FILE`, a CSV). No
+  per-IP external API call, so it preserves the air-gapped guarantee;
+  returns a clear "not configured" notice until a dataset is set. See
+  [ip-enrichment.md](docs/ip-enrichment.md).
+- **Anonymous-friendly redaction bypass** (issue #415 Gap A) —
+  `OMCP_BYPASS_REDACTION_ANON=true` opts the anonymous/stdio identity
+  into the per-call `bypass_redaction` arg. In an anonymous deployment
+  there is no named credential to add to `OMCP_KEY_BYPASS_REDACTION`, so
+  this is the only way a single-user self-hosted agent can see raw
+  values on its own logs without the blunt global `OMCP_REDACTION=off`.
+  Default OFF; redaction stays on for every call that doesn't ask, and
+  bypasses are audited. See [redaction.md](docs/redaction.md#opt-out).
+
+### Changed
+
+- **`get_topology`** now returns an explicit `note` when no
+  topology-capable connector is configured, instead of a bare empty
+  graph — signal vs. silence for agents on a Prometheus/Loki-only stack
+  (issue #415). Existing fields are unchanged.
+
+### Notes
+
+- The SDK (`@thotischner/observability-mcp-sdk`) is unchanged in 3.2.0
+  and stays at 3.1.0 — these are all gateway tool-surface changes; the
+  plugin contract / manifest `schemaVersion` did not move.
+
 ## [3.1.1] — 2026-06-09
 
 Patch release — fixes a ship gap in 3.1.0 reported from real-world use

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,15 +20,29 @@ per-capability detail and
 - ✅ Security hardening: session revocation, per-account lockout, password policy, Content-Security-Policy
 - ✅ Agent log analytics (issue #415): `query_logs` structured label filters + server-side aggregation (count/sum/topk)
 
-### v3.2 — candidates
+## v3.2 — shipped 2026-06-09
 
-The remaining 3.0 deferred items, still open after 3.1 (vote via
-Discussions):
+The **agent-usability** release — closes the remaining points from the
+real-world feedback in issue #415. All additive / opt-in. See
+[CHANGELOG.md](CHANGELOG.md) and
+[`docs/migrations/3.1-to-3.2.md`](docs/migrations/3.1-to-3.2.md).
+
+- ✅ `query_metrics` `labels` equality filter (issue #415 #4) — PromQL series scoping, metrics-side of the `query_logs` `labels` param
+- ✅ `raw_query` passthrough for `query_metrics`/`query_logs` (issue #415 #3) — capability-gated, default off (`OMCP_RAW_QUERY`)
+- ✅ `enrich_ips` tool (issue #415 Gap B) — offline geo/ASN/hosting lookup from a local dataset, air-gapped
+- ✅ Anonymous-friendly per-call redaction bypass (issue #415 Gap A) — `OMCP_BYPASS_REDACTION_ANON`
+- ✅ `get_topology` explicit no-connector note (issue #415, signal vs. silence)
+- ✅ `query_logs` `labels`/`aggregate` made reachable over MCP (3.1.1 hotfix — 3.1.0 ship gap)
+
+### v3.3 — candidates
+
+Still open (vote via Discussions):
 
 - A custom postmortem template engine (persistence + the Postmortems UI tab already ship)
 - SCIM filter/search on the collection endpoints + a UI Provisioning sub-tab
 - Strict-mode MkDocs build (resolve the cross-repo link warnings)
-- Raw PromQL/LogQL passthrough for agent analytics (issue #415 item #3) — gated behind a `raw_query` capability (label-selectors + aggregation already shipped in 3.1)
+- IPv6 support + bundled-dataset tooling for `enrich_ips`
+- Per-credential / RBAC gating for `raw_query` (today it's a global capability flag)
 
 ## v3.0 — shipped 2026-06-06
 

--- a/docs/migrations/3.1-to-3.2.md
+++ b/docs/migrations/3.1-to-3.2.md
@@ -1,0 +1,55 @@
+# Migrating from 3.1 to 3.2
+
+3.2 is the **agent-usability** release that closes the remaining points
+from issue #415 (the `query_logs` `labels`/`aggregate` log-side shipped
+in 3.1.0, and was made reachable over MCP in the 3.1.1 hotfix). The
+migration is **non-breaking** — every new capability is additive or
+opt-in, and the default `docker compose --profile demo up` runs
+identically on 3.1 and 3.2.
+
+## tl;dr
+
+| You are running… | Required action |
+|---|---|
+| The OSS demo / defaults | None — behaviour is unchanged. |
+| Any custom env / Helm values from 3.1 | None. The new flags below are all off / inert by default. |
+| An agent that calls `query_metrics` / `query_logs` | Nothing required; two new optional params (`labels` on `query_metrics`, `raw_query` on both) are available when you want them. |
+
+## New, additive (no flag needed)
+
+| Tool | What's new | Docs |
+|---|---|---|
+| `query_metrics` | optional `labels` exact-match filter, AND'd into the PromQL series selector (metrics-side of the `query_logs` `labels` param) | [prometheus.md](../prometheus.md) |
+| `get_topology` | explicit `note` when no topology connector is configured (was a bare empty graph) | — |
+
+## New, opt-in
+
+| Env / Value | What it does | Docs |
+|---|---|---|
+| `OMCP_RAW_QUERY=on` | Enables the `raw_query` escape hatch (verbatim PromQL on `query_metrics`, LogQL on `query_logs`). **OFF by default** — it widens the read surface beyond the curated catalog, so it's an explicit operator opt-in. Still tenant-scoped, source-allow-listed, and (logs) redacted. | [raw-query.md](../raw-query.md) |
+| `OMCP_IP_ENRICH_FILE=<path>` | Enables the `enrich_ips` tool, backed by a **local offline** CSV (`network,country,city,asn,org,hosting`). No external API call — air-gapped. Unset → `enrich_ips` returns a "not configured" notice. | [ip-enrichment.md](../ip-enrichment.md) |
+| `OMCP_BYPASS_REDACTION_ANON=true` | Lets the **anonymous/stdio** identity use the per-call `bypass_redaction` arg (no named credential exists to add to `OMCP_KEY_BYPASS_REDACTION` in an anonymous deployment). Default OFF; redaction stays on for any call that doesn't set the arg. | [redaction.md](../redaction.md#opt-out) |
+
+## New MCP tool
+
+- **`enrich_ips`** — `{ ips: string[] }` → per-IP geo / ASN / org /
+  hosting-flag from the local dataset. Always advertised; inert until
+  `OMCP_IP_ENRICH_FILE` is set. The tool count goes from 11 to 12.
+
+## Security defaults
+
+Nothing changed by default. The two security-relevant additions
+(`raw_query`, anonymous redaction bypass) are **both off unless the
+operator turns them on**, and both keep their guards when on (capability
+gate, two-key bypass requirement, audit trail).
+
+## Nothing removed
+
+No env var, Helm value, endpoint, MCP tool, or CLI command was removed
+or renamed in 3.2. The 3.1 surface is a strict subset of 3.2.
+
+## SDK
+
+The plugin SDK is unchanged and stays at `3.1.0`. The 3.2 work is all in
+the gateway's tool surface; the plugin contract / manifest
+`schemaVersion` did not move.

--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,11 +4,11 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 2.1.1
+version: 2.2.0
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
-appVersion: "3.1.1"
+appVersion: "3.2.0"
 
 home: https://github.com/ThoTischner/observability-mcp
 sources:
@@ -51,10 +51,20 @@ annotations:
     url: https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc
   artifacthub.io/images: |
     - name: observability-mcp
-      image: ghcr.io/thotischner/observability-mcp:3.1.1
+      image: ghcr.io/thotischner/observability-mcp:3.2.0
       platforms:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "query_logs labels/aggregate params are now advertised over MCP and reach the handler (3.1.0 ship gap, issue #415); chart points at the 3.1.1 image"
+    - kind: changed
+      description: "appVersion → 3.2.0 (agent-usability release, issue #415); chart points at the 3.2.0 image"
+    - kind: added
+      description: "query_metrics labels equality filter (PromQL series scoping)"
+    - kind: added
+      description: "raw_query passthrough for query_metrics/query_logs — capability-gated, default off (OMCP_RAW_QUERY)"
+    - kind: added
+      description: "enrich_ips tool — offline geo/ASN/hosting lookup from a local dataset (OMCP_IP_ENRICH_FILE), air-gapped"
+    - kind: added
+      description: "anonymous-friendly per-call redaction bypass (OMCP_BYPASS_REDACTION_ANON)"
+    - kind: changed
+      description: "get_topology returns an explicit no-connector note instead of a bare empty graph"

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thotischner/observability-mcp",
-      "version": "3.1.1",
+      "version": "3.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
   "license": "Apache-2.0",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
       - 1.x → 2.0: migrations/1.x-to-2.0.md
       - 2.x → 3.0: migrations/2.x-to-3.0.md
       - 3.0 → 3.1: migrations/3.0-to-3.1.md
+      - 3.1 → 3.2: migrations/3.1-to-3.2.md
 
 extra:
   social:


### PR DESCRIPTION
## v3.2.0 — agent-usability release (issue #415)

Closes the remaining points from the real-world tester feedback on issue #415 (the `query_logs` `labels`/`aggregate` log-side shipped in 3.1.0 and was made reachable over MCP in the 3.1.1 hotfix). Bundles the five feature PRs already merged + reviewed:

| Slice | PR | Issue point |
|---|---|---|
| `query_metrics` `labels` filter | #431 | #4 (metrics) |
| `raw_query` passthrough (gated, default off) | #432 | #3 |
| `enrich_ips` offline IP enrichment | #434 | Gap B |
| anonymous-friendly redaction bypass | #433 | Gap A |
| `get_topology` no-connector note | #430 | signal-vs-silence |

### Release mechanics
- `mcp-server` 3.1.1 → **3.2.0**; Helm chart 2.1.1 → **2.2.0** (appVersion 3.2.0, image `:3.2.0`).
- SDK unchanged at 3.1.0 (gateway-only tool-surface changes; manifest `schemaVersion` did not move).
- CHANGELOG `[3.2.0]`, `docs/migrations/3.1-to-3.2.md`, ROADMAP (v3.2 shipped + v3.3 candidates), mkdocs nav.

### Verification
Live tools/list against a booted server: **12 tools** (was 11); `query_metrics` advertises `labels`+`raw_query`, `query_logs` advertises `labels`+`aggregate`+`raw_query`, `enrich_ips` present. Full unit suite **303 passing**, typecheck clean. Reviewer-agent: **SHIP** (version consistency, env-flag names, and the air-gapped/default-off properties cross-checked against the code).

Squash-merging this `chore(release): v3.2.0` commit triggers the tag-on-release workflow → `v3.2.0` tag → docker / npm / helm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)