### PR TITLE
fix(anomaly-history): route omcp_anomaly_score via rawQuery (was wired-but-dead)

### DIFF
--- a/mcp-server/src/tools/get-anomaly-history.test.ts
+++ b/mcp-server/src/tools/get-anomaly-history.test.ts
@@ -1,0 +1,75 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { ConnectorRegistry } from "../connectors/registry.js";
+import type { MetricQuery, MetricResult } from "../types.js";
+import { getAnomalyHistoryHandler } from "./get-anomaly-history.js";
+
+// Regression guard for the wired-but-dead bug found in the v3.2 audit:
+// get_anomaly_history hand-builds a complete PromQL selector
+// (`omcp_anomaly_score{service="x",method="mad"}`) and must pass it via
+// `rawQuery` (verbatim passthrough), NOT via `metric`. The curated `metric`
+// path wraps the value in `{ {{selector}} }`, which for an already-complete
+// selector yields invalid double-brace PromQL → Prometheus 400 → the handler
+// swallowed it and always returned "no history". This test pins that the
+// connector receives a verbatim rawQuery and never the manglable metric path.
+
+function fakeRegistry(capture: (q: MetricQuery) => void, result: MetricResult | null): ConnectorRegistry {
+  const conn = {
+    name: "prom",
+    type: "prometheus",
+    signalType: "metrics" as const,
+    async queryMetrics(q: MetricQuery): Promise<MetricResult> {
+      capture(q);
+      if (!result) throw new Error("no data");
+      return result;
+    },
+  };
+  return { getByTenant: () => [conn] } as unknown as ConnectorRegistry;
+}
+
+function parse(r: { content: Array<{ text: string }> }) {
+  return JSON.parse(r.content[0].text);
+}
+
+describe("get_anomaly_history — rawQuery wiring (audit regression)", () => {
+  it("routes the omcp_anomaly_score selector via rawQuery, not metric", async () => {
+    let captured: MetricQuery | undefined;
+    const reg = fakeRegistry(
+      (q) => (captured = q),
+      {
+        source: "prom",
+        service: "payment",
+        metric: "omcp_anomaly_score",
+        unit: "",
+        values: [{ timestamp: "2026-06-09T00:00:00.000Z", value: 0.7 }],
+        summary: { current: 0.7, average: 0.7, min: 0.7, max: 0.7, trend: "stable" },
+      } as MetricResult,
+    );
+
+    const out = parse(await getAnomalyHistoryHandler(reg, { service: "payment", method: "mad", duration: "1h" }));
+
+    assert.ok(captured, "connector.queryMetrics must be called");
+    // The fix: rawQuery carries the verbatim selector.
+    assert.equal(captured!.rawQuery, 'omcp_anomaly_score{service="payment",method="mad"}');
+    // And it must NOT be smuggled through the curated `metric` path (which would
+    // double-brace it). metric may be a bare name placeholder, but never the selector.
+    assert.doesNotMatch(String(captured!.metric ?? ""), /\{/, "metric must not carry the brace selector");
+    // Sanity: the verbatim query has exactly one brace block (no double-brace).
+    assert.equal((captured!.rawQuery!.match(/\{/g) || []).length, 1);
+
+    assert.equal(out.isError, undefined);
+    assert.equal(out.values.length, 1);
+  });
+
+  it("omits the method filter when not given", async () => {
+    let captured: MetricQuery | undefined;
+    const reg = fakeRegistry((q) => (captured = q), {
+      source: "prom", service: "api", metric: "omcp_anomaly_score", unit: "",
+      values: [{ timestamp: "2026-06-09T00:00:00.000Z", value: 1 }],
+      summary: { current: 1, average: 1, min: 1, max: 1, trend: "stable" },
+    } as MetricResult);
+
+    await getAnomalyHistoryHandler(reg, { service: "api" });
+    assert.equal(captured!.rawQuery, 'omcp_anomaly_score{service="api"}');
+  });
+});

--- a/mcp-server/src/tools/get-anomaly-history.ts
+++ b/mcp-server/src/tools/get-anomaly-history.ts
@@ -77,12 +77,19 @@ export async function getAnomalyHistoryHandler(
   const metric = `omcp_anomaly_score{${labelFilters.join(",")}}`;
 
   // Fan out across every metrics connector; first non-empty answer wins.
+  // CRITICAL: pass the hand-built selector via `rawQuery`, NOT `metric`.
+  // The connector's curated path wraps a bare `metric` in `{ {{selector}} }`,
+  // which for our already-complete selector produces invalid double-brace
+  // PromQL (`omcp_anomaly_score{service="x"}{ job="x" }`) → 400 → the catch
+  // below swallowed it and the tool always reported "no history". rawQuery is
+  // sent verbatim to /api/v1/query_range (the R4 passthrough).
   for (const c of candidates) {
     if (!c.queryMetrics) continue;
     try {
       const r = await c.queryMetrics({
         service: args.service,
-        metric,
+        metric: "omcp_anomaly_score",
+        rawQuery: metric,
         duration,
       });
       if (r && Array.isArray(r.values) && r.values.length > 0) {


### PR DESCRIPTION
## H1 — real bug found by the v3.2 reachability audit

`get_anomaly_history` was **wired-but-dead**: it hand-builds the selector `omcp_anomaly_score{service="x",method="mad"}` and passed it as the `metric` arg. The Prometheus connector's curated path wraps a bare metric in `{ {{selector}} }`, so an already-complete selector became **invalid double-brace PromQL** (`omcp_anomaly_score{service="x"}{ job="x" }`) → Prometheus 400 → the handler's catch swallowed it → the tool **always** returned "no history". It could never return data via a Prometheus source.

### Fix
Pass the selector via `rawQuery` (the R4 verbatim passthrough → `/api/v1/query_range` unwrapped). `metric` becomes a bare placeholder (ignored on the raw path). Bonus: a hypothetical non-rawQuery metrics connector now emits valid single-brace PromQL instead of regressing.

### Test
New `get-anomaly-history.test.ts` pins the regression: the connector receives `rawQuery` = the verbatim selector, `metric` carries no brace, exactly one brace block. Reviewer-agent: **SHIP** (fix correctness + fan-out safety + non-flaky verified). Part of the post-#415 E2E-hardening sweep; ships in the next patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)