### PR TITLE
fix(docs+wiring): correct stale docs/descriptions found by the v3.2 audit

### DIFF
--- a/docs/anomaly-history.md
+++ b/docs/anomaly-history.md
@@ -74,12 +74,12 @@ works without code changes.
 
 ## Operational notes
 
-- **Detector hook ships in F15b.** The `AnomalyHistory` writer is
-  alive in v2.x and reachable via `get_anomaly_history`; the
-  detector-side `record()` hook that fills it from the live
-  `detect_anomalies` path lands in the follow-up. Externally-written
-  `omcp_anomaly_score` metrics (e.g. from a sibling tool that
-  produces them) are already queryable.
+- **Detector hook is wired.** The `AnomalyHistory` writer is fed from
+  the live `detect_anomalies` path — every scan records its scores via
+  the `record()` hook (`detect-anomalies.ts`, wired in `index.ts`), and
+  they are queryable through `get_anomaly_history`. Externally-written
+  `omcp_anomaly_score` metrics (e.g. from a sibling tool that produces
+  them) are queryable too.
 - **Retention** is the TSDB's job. The gateway never deletes —
   configure the receiver's retention to match your post-mortem
   window (e.g. 30 days).

--- a/docs/postmortems.md
+++ b/docs/postmortems.md
@@ -98,11 +98,22 @@ into the Product(s) you want to expose. See
 
 ## Persistence
 
-P6 of the production-readiness sprint will add
-`POST /api/postmortems` storage so a generated report survives
-the agent session. Until then the markdown is returned only to the
-caller — paste it into your ticket / wiki / Slack at the call
-site.
+Generated reports can be persisted on the management plane (the
+`generate_postmortem` MCP tool itself is stateless and still returns the
+markdown to the caller). The endpoints:
+
+| Method | Path | Behaviour |
+|---|---|---|
+| `POST` | `/api/postmortems` | `{service, duration}` — regenerates (forces `format=json`), stores, and returns the saved entry. |
+| `GET` | `/api/postmortems` | List stored reports, tenant-scoped, newest first. |
+| `GET` | `/api/postmortems/:id` | Fetch one stored report. |
+| `DELETE` | `/api/postmortems/:id` | Delete one (admin-gated). |
+
+Storage is an append-only JSONL file at `OMCP_POSTMORTEMS_FILE`
+(default `/tmp/postmortems.jsonl`); entries are tenant-scoped. The
+Postmortems UI tab lists and opens stored reports. If you only need the
+report at the call site, ignore the API and use the markdown the tool
+returns.
 
 ## Failure modes the tool handles
 

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -500,7 +500,7 @@ async function main() {
     [
       "List the configured observability backends (Prometheus, Loki, and any connector) and whether each is currently reachable.",
       "When to use: call this first to learn which source names exist and are healthy before passing `source` to other tools, or to debug why a query returns no data.",
-      "Behavior: read-only, no side effects. Returns one entry per source with its name, type, configured URL, signal types (metrics/logs), and a live up/down status. Never throws for an unreachable backend — the backend is reported as down instead.",
+      "Behavior: read-only, no side effects. Returns one entry per source with its name, type, signal types (metrics/logs), and a live up/down status (the backend URL is intentionally not exposed — it may carry embedded credentials). Never throws for an unreachable backend — the backend is reported as down instead.",
       "Related: use `list_services` to see what is monitored within these sources.",
     ].join(" "),
     {},
@@ -767,8 +767,8 @@ async function main() {
       "Query distributed traces for a service over a given timeframe.",
       "Returns ranked trace summaries (duration, span count, error status) with a p50/p95 aggregate across the returned set.",
       "When to use: investigate tail-latency outliers, walk call chains across services for a specific time window, or pull traces related to an anomaly that the metric/log tools surfaced first.",
-      "Prerequisites: get the exact service name from `list_services`. A Tempo / Jaeger / OTLP connector must be configured.",
-      "Behavior: read-only. `filter` accepts the backend's native query language (TraceQL on Tempo, tag query on Jaeger). When `errorsOnly=true`, only traces with at least one error span are returned. Default limit is 50.",
+      "Prerequisites: get the exact service name from `list_services`. A traces connector (e.g. Tempo, installable from the connector hub) must be configured — none is bundled by default, so without one this returns a clean 'No trace backends configured' result.",
+      "Behavior: read-only. `filter` accepts the backend's native query language (e.g. TraceQL on Tempo). When `errorsOnly=true`, only traces with at least one error span are returned. Default limit is 50.",
     ].join(" "),
     {
       service: z.string().describe("Service name (e.g. 'payment-service')."),
@@ -1377,11 +1377,11 @@ async function main() {
   // get_anomaly_history queries them back via any Prometheus source
   // pointed at the same TSDB.
   //
-  // The detector-side hook that actually records per-anomaly scores
-  // is plumbed in F15b (it requires passing this instance into the
-  // detectAnomaliesHandler — minor surgery deferred). The
-  // infrastructure ships now so externally-written omcp_anomaly_score
-  // metrics are already queryable end-to-end.
+  // The detector-side hook that records per-anomaly scores is wired:
+  // this instance is passed into detectAnomaliesHandler at the
+  // detect_anomalies tool registration below, so every scan records its
+  // scores. Externally-written omcp_anomaly_score metrics are queryable
+  // end-to-end too.
   const anomalyHistory = new AnomalyHistory(anomalyHistoryFromEnv());
   anomalyHistory.start();
   if (anomalyHistory.isEnabled()) {

--- a/mcp-server/src/tools/handlers.test.ts
+++ b/mcp-server/src/tools/handlers.test.ts
@@ -101,6 +101,22 @@ describe("listServicesHandler", () => {
     assert.deepEqual(apiGw.signalTypes.sort(), ["logs", "metrics"]);
   });
 
+  it("carries per-service labels (e.g. discoveredVia) through the merge (audit: docs/loki.md)", async () => {
+    const reg = createRegistryWithMocks([
+      createMockConnector({
+        name: "loki1", type: "loki", signalType: "logs",
+        listServices: async () => [
+          { name: "payment-service", source: "loki1", signalType: "logs", labels: { discoveredVia: "service_name" } },
+        ],
+      }),
+    ]);
+    const result = await listServicesHandler(reg, {});
+    const data = JSON.parse(result.content[0].text);
+    const svc = data.services.find((s: any) => s.name === "payment-service");
+    assert.ok(svc, "service must be present");
+    assert.equal(svc.labels?.discoveredVia, "service_name", "discoveredVia must surface in the tool output");
+  });
+
   it("filters services case-insensitively", async () => {
     const reg = createRegistryWithMocks([
       createMockConnector({

--- a/mcp-server/src/tools/list-services.ts
+++ b/mcp-server/src/tools/list-services.ts
@@ -35,19 +35,27 @@ export async function listServicesHandler(
     }
   }
 
-  // Deduplicate by name, merge signal types
-  const merged = new Map<string, { name: string; sources: string[]; signalTypes: string[] }>();
+  // Deduplicate by name, merge signal types. Carry per-service `labels`
+  // (e.g. the Loki connector's `discoveredVia`, documented in docs/loki.md)
+  // through the merge so discovery metadata actually surfaces in the tool
+  // output; first source to set a given label key wins.
+  const merged = new Map<
+    string,
+    { name: string; sources: string[]; signalTypes: string[]; labels?: Record<string, string> }
+  >();
   for (const svc of allServices) {
     const existing = merged.get(svc.name);
     if (existing) {
       if (!existing.sources.includes(svc.source)) existing.sources.push(svc.source);
       if (!existing.signalTypes.includes(svc.signalType))
         existing.signalTypes.push(svc.signalType);
+      if (svc.labels) existing.labels = { ...svc.labels, ...(existing.labels ?? {}) };
     } else {
       merged.set(svc.name, {
         name: svc.name,
         sources: [svc.source],
         signalTypes: [svc.signalType],
+        labels: svc.labels ? { ...svc.labels } : undefined,
       });
     }
   }

--- a/mcp-server/src/tools/query-traces.ts
+++ b/mcp-server/src/tools/query-traces.ts
@@ -6,10 +6,12 @@
 // summaries, and recomputes a global p50/p95 over the merged set
 // (rather than blindly averaging per-source summaries).
 //
-// Backend support today: a Tempo connector + a Jaeger shim ship as
-// filesystem plugins. Any connector that implements queryTraces
-// participates automatically — no changes needed in the tool layer
-// when a new backend lands.
+// Backend support: no traces backend is bundled by default. The Tempo
+// connector ships in the connector hub (install it to enable traces);
+// there is no Jaeger connector today. Any connector that implements the
+// optional queryTraces capability participates automatically — so on a
+// stack without one the tool returns a clean "No trace backends
+// configured" result rather than failing.
 
 import type { ConnectorRegistry } from "../connectors/registry.js";
 import { defaultContext, type RequestContext } from "../context.js";
@@ -22,7 +24,7 @@ export const queryTracesDefinition = {
     "Query distributed traces for a service over a given timeframe.",
     "Returns ranked trace summaries with duration, error status, and span count, plus a p50/p95 duration aggregate across the returned set.",
     "When to use: investigating tail-latency outliers, walking call chains across services for a known time window, or pulling related traces for an anomaly the metric/log tools surfaced first.",
-    "Behavior: read-only; results may be capped via `limit` (default 50). `filter` accepts the backend's native query language (TraceQL on Tempo, tag query on Jaeger). When `errorsOnly=true`, only traces with at least one error span are returned.",
+    "Behavior: read-only; results may be capped via `limit` (default 50). `filter` accepts the backend's native query language (e.g. TraceQL on Tempo). When `errorsOnly=true`, only traces with at least one error span are returned.",
     "Related: `query_metrics` for the per-service latency series; `get_blast_radius` for the topology a trace traverses.",
   ].join(" "),
   inputSchema: {


### PR DESCRIPTION
## H4 — stale-docs / description batch (audit gap class 3)

Five fixes, each now matching the code (the audit flagged docs/descriptions that described features inaccurately — the same class as the redaction.md/topology stale spots found during #415):

1. **list_services** carries per-service `labels` (e.g. the Loki connector's `discoveredVia`) through the dedup merge — it was computed then silently dropped, so `docs/loki.md`'s claim was false. + unit test.
2. **list_sources** tool description drops the "configured URL" promise (the handler never returned `url`; URLs may carry embedded creds).
3. **query_traces** header comment + tool description + registration no longer claim a bundled Tempo/Jaeger filesystem plugin — none ships (Tempo installs from the hub; no Jaeger connector exists). Honest "No trace backends configured" framing.
4. **postmortems.md** "Persistence" section rewritten to document the shipped `GET/POST/DELETE /api/postmortems` endpoints + `OMCP_POSTMORTEMS_FILE` (was described as not-yet-shipped).
5. **anomaly-history.md** + an `index.ts` comment: the `detect_anomalies`→`record()` history hook **is** wired (was described as deferred/F15b-pending).

Reviewer-agent: **SHIP** — every claim re-verified against code; no new overpromise introduced. Part of the post-#415 E2E-hardening sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)