### PR TITLE
fix(connectors): advertise real capabilities in builtin manifests (audit)

### DIFF
--- a/mcp-server/plugins/kubernetes/manifest.json
+++ b/mcp-server/plugins/kubernetes/manifest.json
@@ -6,7 +6,13 @@
   "description": "Watches a Kubernetes cluster (in-cluster or via kubeconfig) and exposes pods, nodes, deployments, replicasets and namespaces as an infrastructure topology graph. Edges: RUNS_ON (pod→node), OWNED_BY (pod→rs→deployment), IN_NAMESPACE.",
   "signalTypes": ["topology"],
   "license": "Apache-2.0",
-  "capabilities": {},
+  "capabilities": {
+    "listServices": true,
+    "listResources": true,
+    "listEdges": true,
+    "getTopologySnapshot": true,
+    "watchTopology": true
+  },
   "compat": {
     "serverVersion": ">=1.7.0"
   }

--- a/mcp-server/plugins/loki/manifest.json
+++ b/mcp-server/plugins/loki/manifest.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "capabilities": {
     "queryLogs": true,
+    "queryLogAggregate": true,
     "listServices": true
   },
   "compat": {

--- a/mcp-server/src/sdk/manifest-schema.ts
+++ b/mcp-server/src/sdk/manifest-schema.ts
@@ -26,8 +26,15 @@ export const manifestSchema = z.object({
     .object({
       queryMetrics: z.boolean().optional(),
       queryLogs: z.boolean().optional(),
+      queryLogAggregate: z.boolean().optional(),
+      queryTraces: z.boolean().optional(),
       listServices: z.boolean().optional(),
       listAvailableMetrics: z.boolean().optional(),
+      // Topology-provider capabilities (e.g. the Kubernetes connector).
+      listResources: z.boolean().optional(),
+      listEdges: z.boolean().optional(),
+      getTopologySnapshot: z.boolean().optional(),
+      watchTopology: z.boolean().optional(),
     })
     .optional(),
   compat: z

--- a/packages/sdk/src/manifest-schema.ts
+++ b/packages/sdk/src/manifest-schema.ts
@@ -26,8 +26,15 @@ export const manifestSchema = z.object({
     .object({
       queryMetrics: z.boolean().optional(),
       queryLogs: z.boolean().optional(),
+      queryLogAggregate: z.boolean().optional(),
+      queryTraces: z.boolean().optional(),
       listServices: z.boolean().optional(),
       listAvailableMetrics: z.boolean().optional(),
+      // Topology-provider capabilities (e.g. the Kubernetes connector).
+      listResources: z.boolean().optional(),
+      listEdges: z.boolean().optional(),
+      getTopologySnapshot: z.boolean().optional(),
+      watchTopology: z.boolean().optional(),
     })
     .optional(),
   compat: z


### PR DESCRIPTION
## H4b — connector manifest capability accuracy (audit gap class: wired-but-dead / stale advertisement)

The Connectors UI renders each connector's `capabilities`, but the builtin manifests under-advertised what they actually implement:
- **loki**: implements `queryLogAggregate` (the `query_logs` aggregate path routes to it) — was advertising only `queryLogs`+`listServices`.
- **kubernetes**: a full topology provider (`listServices`/`listResources`/`listEdges`/`getTopologySnapshot`/`watchTopology`) — was advertising `{}`.

Extends the capabilities enum in the canonical `manifest-schema.ts` (default `z.object` strips unknown keys) + the SDK-vendored mirror (parity gate, byte-identical), adds `queryTraces` forward-looking, and populates both manifests. **Every advertised capability is verified implemented** in the connector. Builtin `plugins/` carry no SRI digest (unlike hub `connectors/`), so no hash bump. 57 schema/connector tests green. Reviewer-agent: **SHIP**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)