### PR TITLE
chore(release): v3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,57 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.2.1] — 2026-06-10
+
+Hardening patch — a post-3.2.0 reachability / end-to-end audit (4 gap
+classes: MCP reachability, wired-but-dead, stale docs, real-E2E-vs-unit)
+turned up one real bug and a set of doc/coverage gaps. Every finding was
+adversarially verified before fixing.
+
+### Fixed
+
+- **`get_anomaly_history` returns data again.** The handler built a
+  complete PromQL selector (`omcp_anomaly_score{service=…,method=…}`)
+  but passed it as the `metric` arg; the curated path wrapped it into
+  invalid double-brace PromQL (`…{…}{ job=… }`) → Prometheus 400 → the
+  catch swallowed it and the tool **always** reported "no history". It
+  could never return data via a Prometheus source. Now routed verbatim
+  via `rawQuery`. Regression-tested.
+
+### Changed
+
+- **Builtin connector manifests now advertise their real capabilities**
+  (the Connectors UI renders these): Loki adds `queryLogAggregate`;
+  Kubernetes adds its topology-provider capabilities
+  (`listServices`/`listResources`/`listEdges`/`getTopologySnapshot`/
+  `watchTopology`). The manifest `capabilities` schema (and the
+  published SDK mirror) gained the corresponding optional keys.
+- **`list_services` now surfaces per-service `labels`** (e.g. the Loki
+  connector's `discoveredVia`) — the value was computed then dropped in
+  the dedup merge, so `docs/loki.md`'s documented field never appeared.
+- Documentation/description corrections found by the audit: `list_sources`
+  no longer promises a `url` field it never returned; `query_traces`
+  comments/description no longer imply a bundled Tempo/Jaeger plugin
+  (Tempo installs from the hub; no Jaeger connector exists);
+  `postmortems.md` documents the shipped persistence endpoints;
+  `anomaly-history.md` reflects that the detector→history hook is wired.
+
+### Testing (CI-persisted, post-#415)
+
+- **Real `tools/call` behavioural E2E over the live MCP transport**
+  (runs in `integration.yml`) — asserts curated params *take effect over
+  the wire* (raw_query gate, `query_logs` aggregate shape, `enrich_ips`,
+  per-tool dispatch for all 12), closing the class of gap that let the
+  3.1.0 `labels`/`aggregate` ship unreachable.
+- **Playwright coverage** for previously-uncovered tabs
+  (postmortems/audit/entitlement) and the Add-Source test-connection +
+  URL-validation flow (`ui-smoke`).
+
+### Notes
+
+- The SDK (`@thotischner/observability-mcp-sdk`) bumps to 3.2.1 — its
+  published `manifestSchema` gained the new optional capability keys.
+
 ## [3.2.0] — 2026-06-09
 
 Agent-usability release — closes the remaining points from the

--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,11 +4,11 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 2.2.0
+version: 2.2.1
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
-appVersion: "3.2.0"
+appVersion: "3.2.1"
 
 home: https://github.com/ThoTischner/observability-mcp
 sources:
@@ -51,20 +51,14 @@ annotations:
     url: https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc
   artifacthub.io/images: |
     - name: observability-mcp
-      image: ghcr.io/thotischner/observability-mcp:3.2.0
+      image: ghcr.io/thotischner/observability-mcp:3.2.1
       platforms:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
+    - kind: fixed
+      description: "get_anomaly_history returned data again — it built a complete PromQL selector but passed it as `metric`, producing invalid PromQL (silent empty); now routed via rawQuery"
     - kind: changed
-      description: "appVersion → 3.2.0 (agent-usability release, issue #415); chart points at the 3.2.0 image"
-    - kind: added
-      description: "query_metrics labels equality filter (PromQL series scoping)"
-    - kind: added
-      description: "raw_query passthrough for query_metrics/query_logs — capability-gated, default off (OMCP_RAW_QUERY)"
-    - kind: added
-      description: "enrich_ips tool — offline geo/ASN/hosting lookup from a local dataset (OMCP_IP_ENRICH_FILE), air-gapped"
-    - kind: added
-      description: "anonymous-friendly per-call redaction bypass (OMCP_BYPASS_REDACTION_ANON)"
+      description: "appVersion → 3.2.1; chart points at the 3.2.1 image"
     - kind: changed
-      description: "get_topology returns an explicit no-connector note instead of a bare empty graph"
+      description: "builtin connector manifests advertise their real capabilities (loki queryLogAggregate; kubernetes topology providers)"

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thotischner/observability-mcp",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp-sdk",
-  "version": "3.1.0",
+  "version": "3.2.1",
   "description": "Plugin SDK for observability-mcp — types + Zod schemas + lifecycle-hook helpers for authoring connectors and post-tool hooks.",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## v3.2.1 — hardening patch (post-#415 reachability/E2E audit)

A multi-agent audit over 4 gap classes (MCP reachability, wired-but-dead, stale docs, real-E2E-vs-unit) found **38 confirmed** issues; this release ships the fixes.

### Fixed
- **`get_anomaly_history`** returned data again — it built a complete PromQL selector but passed it as `metric`, producing invalid double-brace PromQL → 400 → silent "no history". The tool could never return data via Prometheus. Now routed via `rawQuery` (#436).

### Changed
- Builtin connector manifests advertise their **real capabilities** (Loki `queryLogAggregate`; Kubernetes topology providers) — schema + published SDK mirror updated (#440).
- `list_services` surfaces per-service `labels` (`discoveredVia`); stale doc/description corrections (`list_sources` url, `query_traces` Tempo/Jaeger honesty, postmortems persistence, anomaly-history hook) (#438).

### Testing (now persisted in CI)
- Real `tools/call` behavioural E2E **over the live MCP transport** (#437) — closes the class of gap that let 3.1.0 ship `labels`/`aggregate` unreachable.
- Playwright coverage for uncovered tabs + Add-Source test-connection/validation (#439, #441).

### Versions
mcp-server 3.2.0→**3.2.1**, Helm chart 2.2.0→**2.2.1** (appVersion 3.2.1, image `:3.2.1`), SDK 3.1.0→**3.2.1** (its published `manifestSchema` changed). Reviewer-agent: **SHIP** (version consistency, CHANGELOG accuracy, SDK-bump rationale, sensitive-data all checked).

Squash-merging this `chore(release): v3.2.1` commit auto-tags `v3.2.1` → docker/npm/helm publish. An `sdk-v3.2.1` tag follows for the SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)