### PR TITLE
feat(ax): serve llms.txt on the gateway + docs site

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,29 @@
+# observability-mcp
+
+> Unified observability gateway for AI agents. One MCP server for Prometheus,
+> Loki, and any backend via pluggable connectors — with server-side
+> filtering/aggregation so agents get numbers, not haystacks.
+
+A running gateway serves its live version of this file at /llms.txt
+(generated from the canonical tool registry). Twelve read-only MCP tools
+(readOnlyHint: true on all), an agent usage guide as MCP resource
+(omcp://guide/agent-usage), and triage/postmortem prompts.
+
+## Docs
+
+- For agents (start here): https://thotischner.github.io/observability-mcp/for-agents/
+- Getting started: https://thotischner.github.io/observability-mcp/getting-started/
+- Loki log analytics (labels + aggregate): https://thotischner.github.io/observability-mcp/loki/
+- Raw query passthrough: https://thotischner.github.io/observability-mcp/raw-query/
+- IP enrichment: https://thotischner.github.io/observability-mcp/ip-enrichment/
+- Source: https://github.com/ThoTischner/observability-mcp
+
+## Connect
+
+    npx @thotischner/observability-mcp
+    claude mcp add observability --transport http http://localhost:3000/mcp
+
+## Contribute as an agent
+
+- Report template: https://github.com/ThoTischner/observability-mcp/issues/new?template=agent-report.yml
+- Discussions: https://github.com/ThoTischner/observability-mcp/discussions

--- a/mcp-server/src/conformance/mcp-2025-11-25.test.ts
+++ b/mcp-server/src/conformance/mcp-2025-11-25.test.ts
@@ -497,3 +497,18 @@ test("E2E: builtin prompts triage-incident + write-postmortem are listed and res
   const msgs = (got.response.result as { messages?: Array<{ content?: { text?: string } }> })?.messages ?? [];
   assert.ok((msgs[0]?.content?.text ?? "").includes('"ci-probe"'), "prompt must interpolate the service arg");
 });
+
+test("E2E: /llms.txt is served and reflects the canonical tool registry", opts, async () => {
+  // llms.txt convention: LLM-readable summary at the server root. Generated
+  // from registry-names.ts, so this also guards against registry drift.
+  const base = URL_ENV!.replace(/\/mcp\/?$/, "");
+  const res = await fetch(`${base}/llms.txt`);
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type") ?? "", /text\/plain/);
+  const text = await res.text();
+  assert.match(text, /^# observability-mcp/, "must start with the llms.txt H1");
+  for (const name of ["query_logs", "query_metrics", "enrich_ips", "get_blast_radius"]) {
+    assert.ok(text.includes(`- ${name} (`), `tool ${name} must be listed`);
+  }
+  assert.ok(text.includes("for-agents"), "must link the for-agents guide");
+});

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1582,6 +1582,42 @@ async function main() {
   let ready = false;
   app.get("/healthz", (_req, res) => res.type("text").send("ok"));
 
+  // /llms.txt — the llms.txt convention (llmstxt.org): a plain-text,
+  // LLM-friendly summary of what this server is and how to use it. The
+  // primary audience of this gateway IS an LLM agent, so the gateway
+  // serves its own. Tool list is generated from the canonical registry
+  // (registry-names.ts) so it can't drift from the real surface.
+  const LLMS_TXT = [
+    "# observability-mcp",
+    "",
+    `> Unified observability gateway for AI agents (v${SERVER_VERSION}). One MCP server`,
+    "> for Prometheus, Loki, and any backend via pluggable connectors — with",
+    "> server-side filtering/aggregation so agents get numbers, not haystacks.",
+    "",
+    "MCP endpoint: POST /mcp (Streamable HTTP) · also stdio (--stdio) and WebSocket (/mcp/ws).",
+    "All tools are read-only and advertise MCP ToolAnnotations (readOnlyHint: true).",
+    "MCP resource omcp://guide/agent-usage carries the agent usage guide;",
+    "prompts triage-incident and write-postmortem compose the tools into workflows.",
+    "",
+    "## Tools",
+    "",
+    ...REGISTERED_TOOLS.map((t) => `- ${t.name} (${t.category}): ${t.summary}`),
+    "",
+    "## Connect",
+    "",
+    "    claude mcp add observability --transport http http://localhost:3000/mcp",
+    "",
+    "## Docs",
+    "",
+    "- For agents (start here): https://thotischner.github.io/observability-mcp/for-agents/",
+    "- Documentation site: https://thotischner.github.io/observability-mcp/",
+    "- Report a finding (agent-report template): https://github.com/ThoTischner/observability-mcp/issues/new?template=agent-report.yml",
+    "- Discussions (agent collaboration welcome): https://github.com/ThoTischner/observability-mcp/discussions",
+    "- Source: https://github.com/ThoTischner/observability-mcp",
+    "",
+  ].join("\n");
+  app.get("/llms.txt", (_req, res) => res.type("text/plain; charset=utf-8").send(LLMS_TXT));
+
   // Procurement-time probe: the MCP spec revisions and transports the
   // gateway supports. Static today — kept as a separate endpoint so a
   // discovery tool / RFP probe / catalog scanner can resolve our


### PR DESCRIPTION
## G3 — llms.txt (the audience is an LLM)

- **`GET /llms.txt`** on the gateway — generated at boot from the canonical tool registry (`registry-names.ts`), so the tool list can't drift from the real surface. Includes connect snippet + for-agents/report/Discussions links. Public in all auth modes (same exposure class as `/healthz`, outside `/api` auth — reviewer-verified).
- **`docs/llms.txt`** — static variant at the docs-site root (mkdocs copies non-md files verbatim).
- **Live-verified** (200, text/plain, 12 tools) + **CI-persisted** conformance test (derives base URL from `OMCP_CONFORMANCE_URL`).

Part of the Agent-Love sprint. Reviewer-agent: **SHIP**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)