### PR TITLE
chore(release): v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,53 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.3.0] — 2026-06-10
+
+Agent-experience release — the gateway's primary audience is an LLM
+agent, so this release makes the MCP surface self-describing and the
+collaboration loop a paved road. Purely additive; no migration needed.
+
+### Added
+
+- **MCP ToolAnnotations on all 12 tools** — every builtin tool now
+  advertises `{title, readOnlyHint: true, destructiveHint: false,
+  idempotentHint: true, openWorldHint: false}` over `tools/list`.
+  Clients (e.g. Claude) use these hints for auto-approve decisions;
+  the whole surface is read-only and now says so machine-readably.
+- **Builtin MCP resources + prompts** (first registrations through the
+  Q12 hook-wrapped seams, so plugin resource/prompt hooks now fire):
+  - resource **`omcp://guide/agent-usage`** (text/markdown) — the
+    agent-validated #415 workflow: filter→aggregate→enrich recipe,
+    signal-vs-silence behaviours, operator flags, report link.
+  - prompt **`triage-incident`** (service) — composes
+    `get_service_health` → `detect_anomalies` → `get_blast_radius` →
+    aggregated `query_logs`.
+  - prompt **`write-postmortem`** (service, duration?) —
+    `generate_postmortem` + verification + blameless-rewrite steps.
+- **`GET /llms.txt`** — the llms.txt convention, generated at boot from
+  the canonical tool registry (can't drift from the real surface), plus
+  a static variant at the docs-site root. Public in all auth modes.
+- **Official MCP Registry presence** — `server.json` + an OIDC publish
+  workflow (`mcp-registry-publish.yml`, runs on every release tag);
+  listed as `io.github.ThoTischner/observability-mcp`.
+- **Agent collaboration scaffolding** — `docs/for-agents.md` (connect,
+  proven triage recipe, how to report), the `agent-report` issue form
+  encoding the #415 report format, and seeded GitHub Discussions
+  (release announcements + the #415 case study).
+
+### Changed
+
+- README hero: benchmark headline (0/10 → 10/10) + 30-second connect
+  snippet now sit above the badge wall; secondary badges folded.
+
+### Notes
+
+- The SDK (`@thotischner/observability-mcp-sdk`) is unchanged (3.2.1) —
+  the plugin contract did not move.
+- All of the above is verified live over the MCP transport and pinned
+  by conformance tests in CI (tools/list annotations, resources/read,
+  prompts/get, /llms.txt).
+
 ## [3.2.1] — 2026-06-10
 
 Hardening patch — a post-3.2.0 reachability / end-to-end audit (4 gap

--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,11 +4,11 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 2.2.1
+version: 2.3.0
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
-appVersion: "3.2.1"
+appVersion: "3.3.0"
 
 home: https://github.com/ThoTischner/observability-mcp
 sources:
@@ -51,14 +51,18 @@ annotations:
     url: https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc
   artifacthub.io/images: |
     - name: observability-mcp
-      image: ghcr.io/thotischner/observability-mcp:3.2.1
+      image: ghcr.io/thotischner/observability-mcp:3.3.0
       platforms:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "get_anomaly_history returned data again — it built a complete PromQL selector but passed it as `metric`, producing invalid PromQL (silent empty); now routed via rawQuery"
     - kind: changed
-      description: "appVersion → 3.2.1; chart points at the 3.2.1 image"
-    - kind: changed
-      description: "builtin connector manifests advertise their real capabilities (loki queryLogAggregate; kubernetes topology providers)"
+      description: "appVersion → 3.3.0 (agent-experience release); chart points at the 3.3.0 image"
+    - kind: added
+      description: "MCP ToolAnnotations on all 12 tools (readOnlyHint etc. for client auto-approve)"
+    - kind: added
+      description: "builtin MCP resources + prompts: agent usage guide (omcp://guide/agent-usage), triage-incident, write-postmortem"
+    - kind: added
+      description: "llms.txt served at /llms.txt, generated from the canonical tool registry"
+    - kind: added
+      description: "listed on the official MCP Registry (io.github.ThoTischner/observability-mcp)"

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thotischner/observability-mcp",
-      "version": "3.2.1",
+      "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## v3.3.0 — agent-experience release

Bundles the Agent-Love sprint (all merged + reviewer-SHIP + live-verified + conformance-pinned):

| Slice | PR |
|---|---|
| MCP ToolAnnotations on all 12 tools | #443 |
| Builtin resources + prompts (usage guide, triage, postmortem) | #448 |
| `GET /llms.txt` (registry-generated) + docs variant | #449 |
| Official MCP Registry presence (server.json + OIDC workflow) | #450 |
| for-agents guide + agent-report issue form | #444 |
| README hero (headline + connect above badges) | #447 |

**Versions:** mcp-server 3.2.1→**3.3.0**, Helm chart 2.2.1→**2.3.0** (appVersion 3.3.0). SDK unchanged (3.2.1; no `packages/sdk` change since the 3.2.1 tag — reviewer-verified).

Squash-merging auto-tags `v3.3.0` → docker/npm/helm publish **+ the new registry publish** (waits for npm, then updates the listing to 3.3.0). Reviewer-agent: **SHIP**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)