### PR TITLE
fix(loki): count_over_time without by collapses to one series (issue #452)

### DIFF
--- a/mcp-server/src/connectors/loki.test.ts
+++ b/mcp-server/src/connectors/loki.test.ts
@@ -140,11 +140,14 @@ describe("Q-LOG2: buildAggregateLogQL", () => {
     assert.equal(r.step, "900s");
     assert.equal(r.logql, `sum by (url) (count_over_time(${PIPE} [900s]))`);
   });
-  it("count_over_time without by → bare count_over_time, default step", () => {
+  it("count_over_time without by → sum-wrapped (single series), default step (#452)", () => {
+    // Regression for issue #452: a bare count_over_time over a `| json` stream
+    // keeps every extracted label as its own series. With no `by` we must
+    // collapse to one bucketed total via sum(...).
     const r = buildAggregateLogQL(PIPE, { op: "count_over_time" }, "1h");
     assert.equal(r.mode, "range");
     assert.equal(r.step, "60s");
-    assert.equal(r.logql, `count_over_time(${PIPE} [60s])`);
+    assert.equal(r.logql, `sum (count_over_time(${PIPE} [60s]))`);
   });
   it("sum → instant total per group over the whole window", () => {
     const r = buildAggregateLogQL(PIPE, { op: "sum", by: ["status"] }, "1h");

--- a/mcp-server/src/connectors/loki.ts
+++ b/mcp-server/src/connectors/loki.ts
@@ -99,7 +99,12 @@ export function buildAggregateLogQL(
   if (agg.op === "count_over_time") {
     const stepSec = (agg.step && parseDurationSeconds(agg.step)) || defaultBucketSeconds(durSec);
     const inner = `count_over_time(${streamPipeline} [${stepSec}s])`;
-    const logql = byClause ? `sum${byClause} (${inner})` : inner;
+    // Always wrap in sum() — even with no `by`. A bare count_over_time over a
+    // `| json`-piped stream keeps every extracted label (rid/ip/status/…) as
+    // its own series, so the "requests over time" headline case returns a
+    // high-cardinality mess instead of one bucketed total (issue #452). With
+    // no `by` we collapse to a single series; `sum by(...)` for explicit by.
+    const logql = `sum${byClause} (${inner})`;
     return { logql, mode: "range", step: `${stepSec}s` };
   }
 


### PR DESCRIPTION
## S1 — issue #452 bug 1

`query_logs` `aggregate: count_over_time` with an empty `by` emitted a bare `count_over_time({sel} | json [step])`, which keeps every `| json`-extracted label (rid/ip/status…) as its own series — the "requests over time" headline case was unusable (12 high-cardinality series instead of ~6 hourly buckets). `sum`/`topk` were fine because they always wrap in `sum by(...)`.

**Fix:** always `sum`-wrap `count_over_time` — no `by` → `sum (count_over_time(...))` (single series), explicit `by` → `sum by(...) (...)` (unchanged). Reviewer-verified: valid LogQL, no regression to by/sum/topk, the matrix consumer parses the single-series result cleanly. Updated the no-by unit test (it had encoded the buggy shape).

Part of the #452 fix-as-found loop → v3.3.1. 🤖 Generated with [Claude Code](https://claude.com/claude-code)