### PR TITLE
fix(loki): fail fast when query_logs raw_query returns vector/matrix (issue #452)

### DIFF
--- a/mcp-server/src/connectors/loki.test.ts
+++ b/mcp-server/src/connectors/loki.test.ts
@@ -116,6 +116,32 @@ describe("Q-LOG1: queryLogs LogQL assembly", () => {
     });
     assert.equal(q, '{job="raw"}');
   });
+
+  it("#452: rawQuery returning a vector/matrix fails fast with a clear message (no .level crash)", async () => {
+    const conn = new LokiConnector();
+    await conn.connect({ name: "loki", type: "loki", url: "http://loki:3100", enabled: true } as any);
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async (url: any) => {
+      const u = String(url);
+      if (u.includes("/label/") && u.includes("/values")) return jsonRes({ data: ["app"] });
+      // A metric raw_query (sum(count_over_time(...))) returns resultType matrix,
+      // not streams — must not be fed to the streams parser.
+      if (u.includes("/query_range")) {
+        return jsonRes({ data: { resultType: "matrix", result: [{ metric: { url: "/" }, values: [[1000, "5"]] }] } });
+      }
+      return jsonRes({ data: [] });
+    }) as any;
+    try {
+      await conn.queryLogs({ rawQuery: "sum(count_over_time({app=\"x\"} | json [6h]))", duration: "6h" } as any);
+      assert.fail("expected a thrown error for a non-streams raw_query result");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      assert.match(msg, /'matrix' result/);
+      assert.match(msg, /aggregate.*param|query_metrics raw_query/);
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
 });
 
 describe("Q-LOG2: parseDurationSeconds / defaultBucketSeconds", () => {

--- a/mcp-server/src/connectors/loki.ts
+++ b/mcp-server/src/connectors/loki.ts
@@ -246,6 +246,19 @@ export class LokiConnector implements ObservabilityConnector {
 
     const data = await this.apiGet<LokiQueryResponse>(url);
 
+    // A log query yields resultType "streams". A metric query (e.g. a
+    // raw_query wrapping sum()/count() → vector/matrix) does NOT — and the
+    // streams parser below would dereference undefined `.stream`/`.values`
+    // and crash on `.level` (issue #452). Fail fast with a clear, actionable
+    // message instead of running to timeout on a wrong-shaped result.
+    const resultType = data?.data?.resultType;
+    if (resultType && resultType !== "streams") {
+      throw new Error(
+        `query_logs raw_query returned a '${resultType}' result, but query_logs handles log lines (streams) only. ` +
+          "For counts/sums/top-k use the `aggregate` param on query_logs; for arbitrary vector/matrix LogQL use query_metrics raw_query.",
+      );
+    }
+
     const entries: LogEntry[] = [];
     for (const stream of data?.data?.result || []) {
       const labels = stream.stream;


### PR DESCRIPTION
## S2 — issue #452 bug 2

A metric `raw_query` on `query_logs` (e.g. `sum(count_over_time(...))`) returns Loki `resultType` vector/matrix, not streams. The streams parser then dereferenced undefined `.stream`/`.values` and crashed on `.level` — and the 5m default `duration` meant it ran to timeout instead of erroring.

**Fix:** check `resultType` right after the fetch; if it's not `streams`, throw a clear, actionable error (surfaced by the handler as a structured `Query failed: …` result): *"query_logs handles log lines (streams) only; use `aggregate` for counts/top-k, or query_metrics raw_query for vector/matrix"*. Normal log queries (resultType `streams`, or absent) are unaffected. Reviewer-verified incl. the handler catch path. Connector test asserts a matrix response → thrown + guidance text.

Part of the #452 fix-as-found loop → v3.3.1. 🤖 Generated with [Claude Code](https://claude.com/claude-code)