### PR TITLE
feat(ax): populate initialize.instructions + golden rule (issue #455)

### DIFF
--- a/mcp-server/src/conformance/mcp-2025-11-25.test.ts
+++ b/mcp-server/src/conformance/mcp-2025-11-25.test.ts
@@ -512,3 +512,15 @@ test("E2E: /llms.txt is served and reflects the canonical tool registry", opts, 
   }
   assert.ok(text.includes("for-agents"), "must link the for-agents guide");
 });
+
+test("E2E: initialize advertises non-empty instructions pointing at the usage guide (issue #455)", opts, async () => {
+  const { response } = await jsonRpc("initialize", {
+    protocolVersion: PROTOCOL_VERSION,
+    capabilities: {},
+    clientInfo: { name: "harness", version: "0" },
+  }, { id: 30 });
+  const r = response.result as { instructions?: string };
+  assert.ok(r.instructions && r.instructions.length > 0, "initialize.instructions must be populated");
+  assert.match(r.instructions!, /omcp:\/\/guide\/agent-usage/, "must point at the usage-guide resource");
+  assert.match(r.instructions!, /aggregate/i, "must carry the filter+aggregate golden rule");
+});

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -423,10 +423,25 @@ async function main() {
    * same wrapped handler the McpServer would dispatch over MCP.
    */
   function createMcpServer(ctx: RequestContext): { mcpServer: McpServer; toolHandlers: Map<string, (args: unknown, extra: unknown) => Promise<unknown>> } {
-    const mcpServer = new McpServer({
-      name: "observability-mcp",
-      version: SERVER_VERSION,
-    });
+    const mcpServer = new McpServer(
+      {
+        name: "observability-mcp",
+        version: SERVER_VERSION,
+      },
+      {
+        // `instructions` is the one channel the MCP spec auto-injects into the
+        // agent's context on connect (issue #455). Keep it tight: point at the
+        // full guide resource + the single rule that prevents the most common
+        // mistake (dumping raw rows), + the empty-state contract.
+        instructions:
+          "Read MCP resource `omcp://guide/agent-usage` before heavy use. " +
+          "Golden rule: filter + aggregate server-side — use `query_logs`/`query_metrics` " +
+          "`labels` and `query_logs` `aggregate` to ask for numbers, not haystacks (raw log " +
+          "dumps blow past context limits). All tools are read-only. When a result is empty " +
+          "or refused, the message names the operator flag that unlocks it (e.g. OMCP_RAW_QUERY) " +
+          "— relay it verbatim. Prompts `triage-incident` and `write-postmortem` compose the tools.",
+      },
+    );
     const toolHandlers = new Map<string, (args: unknown, extra: unknown) => Promise<unknown>>();
 
   // --- Register tools with Zod schemas ---
@@ -704,6 +719,7 @@ async function main() {
     [
       "Fetch recent log entries for ONE service over a look-back window, with a pre-computed summary (error/warning counts and the most frequent error patterns).",
       "When to use: to inspect what a service actually logged, or to investigate an error spike surfaced by `detect_anomalies` / `get_service_health`. For numeric metrics use `query_metrics` instead.",
+      "Golden rule: filter + aggregate server-side — pass `labels` to scope and `aggregate` (count_over_time/sum/topk) to get numbers, not raw rows. A high-volume window returned raw will blow past your context limit.",
       "Prerequisites: get the exact service name from `list_services` (the service must expose a logs signal).",
       "Behavior: read-only, no side effects. Returns the matching log entries (newest first, capped by `limit`) plus a summary with total/error/warn counts and top recurring error patterns. No matches yields an empty result with a zeroed summary; an unreachable backend yields a structured explanatory error, never an exception.",
     ].join(" "),


### PR DESCRIPTION
## S4 — issue #455 (highest-leverage AX fix)

`initialize.instructions` is the **one channel the MCP spec auto-injects** into an agent's context on connect — and it was empty. The carefully-written 3.3.0 guide lived only in `resources`/`llms.txt`, which agents don't auto-consume, so it only reached an agent if a human said "read the resource".

**Fix:** construct `McpServer` with an `instructions` string — pointer to `omcp://guide/agent-usage` + the filter+aggregate golden rule + the empty-states-name-the-flag contract. Plus the golden rule seeded into the `query_logs` description as a fallback for clients that don't surface `instructions`.

Live-verified (instructions present, mentions guide + aggregate) + conformance assertion. Reviewer-agent: **SHIP**. Part of the open-issues loop → folds into v3.3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)