### PR TITLE
fix(health): honest no-data/not-found instead of false 100/healthy (issue #453A)

### DIFF
--- a/mcp-server/src/analysis/health.test.ts
+++ b/mcp-server/src/analysis/health.test.ts
@@ -3,6 +3,12 @@ import assert from "node:assert/strict";
 import { calculateHealthScore } from "./health.js";
 import type { HealthThresholds } from "../types.js";
 
+// Full-coverage scores are never null; narrow for the existing assertions.
+function num(r: { score: number | null }): number {
+  assert.notEqual(r.score, null, "expected a numeric score");
+  return r.score as number;
+}
+
 const defaults: HealthThresholds = {
   weights: { errorRate: 0.35, latency: 0.25, cpu: 0.20, logErrors: 0.20 },
   cpu: { good: 50, warn: 80, crit: 95 },
@@ -26,7 +32,7 @@ describe("calculateHealthScore", () => {
       cpu: 20, memory: 100_000_000, errorRate: 0.005, latencyP99: 0.3, logErrorRate: 0,
     }, defaults);
     assert.equal(result.status, "healthy");
-    assert.ok(result.score > 80);
+    assert.ok(num(result) > 80);
   });
 
   it("returns degraded for elevated values", () => {
@@ -34,7 +40,7 @@ describe("calculateHealthScore", () => {
       cpu: 65, memory: 200_000_000, errorRate: 0.05, latencyP99: 0.8, logErrorRate: 3,
     }, defaults);
     assert.equal(result.status, "degraded");
-    assert.ok(result.score > 50 && result.score <= 80, `Expected degraded score 50-80, got ${result.score}`);
+    assert.ok(num(result) > 50 && num(result) <= 80, `Expected degraded score 50-80, got ${result.score}`);
   });
 
   it("returns critical for extreme values", () => {
@@ -42,7 +48,7 @@ describe("calculateHealthScore", () => {
       cpu: 98, memory: 500_000_000, errorRate: 1.0, latencyP99: 5.0, logErrorRate: 50,
     }, defaults);
     assert.equal(result.status, "critical");
-    assert.ok(result.score <= 50);
+    assert.ok(num(result) <= 50);
   });
 
   it("score is between 0 and 100", () => {
@@ -51,7 +57,7 @@ describe("calculateHealthScore", () => {
         const result = calculateHealthScore({
           cpu, memory: 0, errorRate: err, latencyP99: 0, logErrorRate: 0,
         }, defaults);
-        assert.ok(result.score >= 0 && result.score <= 100, `Score ${result.score} out of range for cpu=${cpu} err=${err}`);
+        assert.ok(num(result) >= 0 && num(result) <= 100, `Score ${result.score} out of range`);
       }
     }
   });
@@ -65,7 +71,7 @@ describe("calculateHealthScore", () => {
       cpu: 25, memory: 0, errorRate: 0, latencyP99: 0, logErrorRate: 0,
     }, strict);
     // CPU 25% with strict thresholds should lower the score
-    assert.ok(result.score < 100);
+    assert.ok(num(result) < 100);
   });
 
   it("includes detail breakdown", () => {
@@ -76,4 +82,37 @@ describe("calculateHealthScore", () => {
     assert.ok("errorRate" in result.details);
     assert.ok(result.details.cpu.score < 100);
   });
+
+  it("coverage: no signals at all → score null, status unknown (issue #453)", () => {
+    const r = calculateHealthScore(
+      { cpu: 0, memory: 0, errorRate: 0, latencyP99: 0, logErrorRate: 0 },
+      defaults,
+      { metrics: false, logs: false },
+    );
+    assert.equal(r.score, null);
+    assert.equal(r.status, "unknown");
+    assert.deepEqual(r.details, {});
+  });
+
+  it("coverage: log-only service is judged on logs, not metric zeros (issue #453)", () => {
+    // High log error rate, no metric coverage → must NOT come back healthy.
+    const r = calculateHealthScore(
+      { cpu: 0, memory: 0, errorRate: 0, latencyP99: 0, logErrorRate: 50 },
+      defaults,
+      { metrics: false, logs: true },
+    );
+    assert.notEqual(r.status, "healthy");
+    assert.ok(num(r) < 50, `log-only with 50 errors/min should not be healthy, got ${r.score}`);
+    assert.ok(!("cpu" in r.details), "metric details excluded when metrics absent");
+    assert.ok("logErrors" in r.details);
+  });
+
+  it("coverage: full coverage (default) is unchanged by the coverage param", () => {
+    const inputs = { cpu: 65, memory: 0, errorRate: 0.05, latencyP99: 0.8, logErrorRate: 3 };
+    const implicit = calculateHealthScore(inputs, defaults);
+    const explicit = calculateHealthScore(inputs, defaults, { metrics: true, logs: true });
+    assert.equal(implicit.score, explicit.score);
+    assert.equal(implicit.status, explicit.status);
+  });
+
 });

--- a/mcp-server/src/analysis/health.ts
+++ b/mcp-server/src/analysis/health.ts
@@ -9,41 +9,73 @@ export interface HealthInputs {
 }
 
 export interface HealthResult {
-  score: number;
-  status: HealthStatus;
+  /** 0-100, or null when no signal had data (status "unknown"). */
+  score: number | null;
+  status: HealthStatus | "unknown";
   details: Record<string, { score: number; value: number; threshold: string }>;
 }
 
-export function calculateHealthScore(inputs: HealthInputs, thresholds: HealthThresholds): HealthResult {
+/** Which signal families actually returned data. Missing/false families are
+ *  excluded from the weighted score and the remaining weights are
+ *  renormalised — so a log-only service is judged on its logs, not on metric
+ *  zeros coerced to "healthy" (issue #453). Omit for the back-compat
+ *  all-signals-present behaviour. */
+export interface SignalCoverage {
+  metrics?: boolean;
+  logs?: boolean;
+}
+
+export function calculateHealthScore(
+  inputs: HealthInputs,
+  thresholds: HealthThresholds,
+  coverage?: SignalCoverage,
+): HealthResult {
   const w = thresholds.weights;
   const t = thresholds;
+  const hasMetrics = coverage?.metrics !== false; // default: present (back-compat)
+  const hasLogs = coverage?.logs !== false;
 
   const cpuScore = scoreFromThreshold(inputs.cpu, t.cpu.good, t.cpu.warn, t.cpu.crit);
   const errorRateScore = scoreFromThreshold(inputs.errorRate, t.errorRate.good, t.errorRate.warn, t.errorRate.crit);
   const latencyScore = scoreFromThreshold(inputs.latencyP99, t.latencyP99.good, t.latencyP99.warn, t.latencyP99.crit);
   const logErrorScore = scoreFromThreshold(inputs.logErrorRate, t.logErrors.good, t.logErrors.warn, t.logErrors.crit);
 
-  const weightedScore =
-    cpuScore * w.cpu +
-    errorRateScore * w.errorRate +
-    latencyScore * w.latency +
-    logErrorScore * w.logErrors;
+  // Only count the families that actually reported data; renormalise by the
+  // sum of their weights so a missing family is neither a free "100" nor a
+  // free "0". With full coverage the active weights sum to ~1 and this equals
+  // the previous behaviour.
+  let weighted = 0;
+  let activeWeight = 0;
+  if (hasMetrics) {
+    weighted += cpuScore * w.cpu + errorRateScore * w.errorRate + latencyScore * w.latency;
+    activeWeight += w.cpu + w.errorRate + w.latency;
+  }
+  if (hasLogs) {
+    weighted += logErrorScore * w.logErrors;
+    activeWeight += w.logErrors;
+  }
 
-  const score = Math.round(Math.max(0, Math.min(100, weightedScore)));
+  const details: HealthResult["details"] = {};
+  if (hasMetrics) {
+    details.cpu = { score: Math.round(cpuScore), value: inputs.cpu, threshold: `warn >${t.cpu.warn}%, crit >${t.cpu.crit}%` };
+    details.errorRate = { score: Math.round(errorRateScore), value: inputs.errorRate, threshold: `warn >${t.errorRate.warn}/s, crit >${t.errorRate.crit}/s` };
+    details.latencyP99 = { score: Math.round(latencyScore), value: inputs.latencyP99, threshold: `warn >${t.latencyP99.warn}s, crit >${t.latencyP99.crit}s` };
+  }
+  if (hasLogs) {
+    details.logErrors = { score: Math.round(logErrorScore), value: inputs.logErrorRate, threshold: `warn >${t.logErrors.warn}/min, crit >${t.logErrors.crit}/min` };
+  }
+
+  // No family reported data → honestly unknown, not a confident 100/healthy.
+  if (activeWeight === 0) {
+    return { score: null, status: "unknown", details };
+  }
+
+  const score = Math.round(Math.max(0, Math.min(100, weighted / activeWeight)));
   const status: HealthStatus =
     score > t.statusBoundaries.healthy ? "healthy" :
     score > t.statusBoundaries.degraded ? "degraded" : "critical";
 
-  return {
-    score,
-    status,
-    details: {
-      cpu: { score: Math.round(cpuScore), value: inputs.cpu, threshold: `warn >${t.cpu.warn}%, crit >${t.cpu.crit}%` },
-      errorRate: { score: Math.round(errorRateScore), value: inputs.errorRate, threshold: `warn >${t.errorRate.warn}/s, crit >${t.errorRate.crit}/s` },
-      latencyP99: { score: Math.round(latencyScore), value: inputs.latencyP99, threshold: `warn >${t.latencyP99.warn}s, crit >${t.latencyP99.crit}s` },
-      logErrors: { score: Math.round(logErrorScore), value: inputs.logErrorRate, threshold: `warn >${t.logErrors.warn}/min, crit >${t.logErrors.crit}/min` },
-    },
-  };
+  return { score, status, details };
 }
 
 function scoreFromThreshold(value: number, good: number, warn: number, crit: number): number {

--- a/mcp-server/src/analysis/library.test.ts
+++ b/mcp-server/src/analysis/library.test.ts
@@ -44,7 +44,7 @@ describe("embeddable analysis library", () => {
         statusBoundaries: { healthy: 80, degraded: 50 },
       }
     );
-    assert.ok(r.score >= 0 && r.score <= 100);
+    assert.ok(r.score !== null && r.score >= 0 && r.score <= 100);
     assert.ok(["healthy", "degraded", "critical"].includes(r.status as string));
   });
 });

--- a/mcp-server/src/tools/get-service-health.ts
+++ b/mcp-server/src/tools/get-service-health.ts
@@ -36,26 +36,29 @@ export async function getServiceHealthHandler(
   const metricsConnectors = tenantConnectors.filter((c) => c.signalType === "metrics");
   const logConnectors = tenantConnectors.filter((c) => c.signalType === "logs");
 
-  // Gather metrics
+  // Gather metrics. Track whether any series actually returned data —
+  // absent metrics must NOT be coerced to 0 and read as a confident
+  // "healthy" (issue #453).
   let cpu = 0, memory = 0, errorRate = 0, latencyP99 = 0;
+  let metricsHadData = false;
   const anomalies: AnomalyReport[] = [];
 
   for (const connector of metricsConnectors) {
     if (!connector.queryMetrics) continue;
     try {
       const cpuResult = await connector.queryMetrics({ service: args.service, metric: "cpu", duration: "5m" });
-      cpu = cpuResult.summary.current;
+      if (cpuResult.values.length > 0) { cpu = cpuResult.summary.current; metricsHadData = true; }
       checkAnomaly(cpuResult.values.map(v => v.value), "cpu", args.service, connector.name, anomalies);
 
       const memResult = await connector.queryMetrics({ service: args.service, metric: "memory", duration: "5m" });
-      memory = memResult.summary.current / 1_000_000; // Convert to MB for display
+      if (memResult.values.length > 0) { memory = memResult.summary.current / 1_000_000; metricsHadData = true; } // MB for display
 
       const errResult = await connector.queryMetrics({ service: args.service, metric: "error_rate", duration: "5m" });
-      errorRate = errResult.summary.current;
+      if (errResult.values.length > 0) { errorRate = errResult.summary.current; metricsHadData = true; }
       checkAnomaly(errResult.values.map(v => v.value), "error_rate", args.service, connector.name, anomalies);
 
       const latResult = await connector.queryMetrics({ service: args.service, metric: "latency_p99", duration: "5m" });
-      latencyP99 = latResult.summary.current;
+      if (latResult.values.length > 0) { latencyP99 = latResult.summary.current; metricsHadData = true; }
       checkAnomaly(latResult.values.map(v => v.value), "latency_p99", args.service, connector.name, anomalies);
     } catch (err) {
       console.error("Health check metrics failed for %s:", sanitizeForLog(args.service), err);
@@ -65,12 +68,14 @@ export async function getServiceHealthHandler(
   // Gather logs
   let logErrorRate = 0;
   let topErrors: string[] = [];
+  let logsHadData = false;
   const correlations: string[] = [];
 
   for (const connector of logConnectors) {
     if (!connector.queryLogs) continue;
     try {
       const logs = await connector.queryLogs({ service: args.service, duration: "5m", limit: 200 });
+      if (logs.summary.total > 0) logsHadData = true; // real log coverage in the window
       logErrorRate = logs.summary.errorCount; // errors in 5m window
       topErrors = logs.summary.topPatterns;
 
@@ -88,7 +93,33 @@ export async function getServiceHealthHandler(
     }
   }
 
-  // Calculate health score
+  // Honest signal coverage: judge the service only on the families that
+  // actually returned data, so a log-only (or absent) service is never
+  // coerced to a confident "healthy" from metric zeros (issue #453).
+  const coverage = { metrics: metricsHadData, logs: logsHadData };
+
+  // No data at all → either the service doesn't exist (typo / decommissioned)
+  // or it isn't monitored. Say so explicitly, like the other tools' empty
+  // states — don't return 100/healthy.
+  if (!metricsHadData && !logsHadData) {
+    const known = await knownServiceNames(tenantConnectors, args.service);
+    const note = known
+      ? `No metric or log data for "${args.service}" in the last 5 minutes — the service exists but has no monitored signals (or was quiet). Health is unknown, not healthy.`
+      : `Service "${args.service}" was not found in any connected source. Check the exact name via list_services. (Not reporting a health score for a service that does not exist.)`;
+    const result: ServiceHealth = {
+      service: args.service,
+      status: "unknown",
+      score: null,
+      signals: { metrics: null, logs: null },
+      anomalies,
+      correlations,
+      coverage,
+      note,
+    };
+    return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+  }
+
+  // Calculate health score over the covered signals only.
   const { DEFAULT_HEALTH_THRESHOLDS } = await import("../config/loader.js");
   const health = calculateHealthScore({
     cpu,
@@ -96,23 +127,49 @@ export async function getServiceHealthHandler(
     errorRate,
     latencyP99,
     logErrorRate,
-  }, _thresholds || DEFAULT_HEALTH_THRESHOLDS);
+  }, _thresholds || DEFAULT_HEALTH_THRESHOLDS, coverage);
 
   const result: ServiceHealth = {
     service: args.service,
     status: health.status,
     score: health.score,
     signals: {
-      metrics: { cpu, memory, errorRate, latencyP99 },
-      logs: { errorRate: logErrorRate, topErrors },
+      metrics: metricsHadData ? { cpu, memory, errorRate, latencyP99 } : null,
+      logs: logsHadData ? { errorRate: logErrorRate, topErrors } : null,
     },
     anomalies,
     correlations,
+    coverage,
+    note: !metricsHadData
+      ? "No metrics signal for this service — score reflects logs only."
+      : !logsHadData
+        ? "No logs signal for this service — score reflects metrics only."
+        : undefined,
   };
 
   return {
     content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
   };
+}
+
+/** Best-effort: does any connector in the tenant know this service name?
+ *  Used only on the no-data path to distinguish "exists but unmonitored/quiet"
+ *  from "doesn't exist (typo/decommissioned)". A connector that throws is
+ *  treated as "can't confirm" and skipped. */
+async function knownServiceNames(
+  connectors: { listServices?: () => Promise<Array<{ name: string }>> }[],
+  service: string,
+): Promise<boolean> {
+  for (const c of connectors) {
+    if (!c.listServices) continue;
+    try {
+      const svcs = await c.listServices();
+      if (svcs.some((s) => s.name === service)) return true;
+    } catch {
+      /* can't confirm via this connector — keep checking */
+    }
+  }
+  return false;
 }
 
 function checkAnomaly(

--- a/mcp-server/src/tools/handlers.test.ts
+++ b/mcp-server/src/tools/handlers.test.ts
@@ -275,3 +275,60 @@ describe("getServiceHealthHandler — one-sided latency (regression)", () => {
     assert.equal(latAnom, undefined, `latency dropping must not be an anomaly, got: ${JSON.stringify(latAnom)}`);
   });
 });
+
+describe("getServiceHealthHandler — honest no-data / not-found (issue #453)", () => {
+  const emptySeries = (): MetricResult => ({
+    source: "prom1", service: "x", metric: "x", unit: "",
+    values: [],
+    summary: { current: 0, average: 0, min: 0, max: 0, trend: "stable" as const },
+  });
+  function metricsConnector(known: string[]): ObservabilityConnector {
+    return {
+      connect: async () => {}, disconnect: async () => {},
+      healthCheck: async () => ({ status: "up" as const, latencyMs: 1 }),
+      getDefaultMetrics: () => [], getMetrics: () => [],
+      listServices: async () => known.map((name) => ({ name, source: "prom1", signalType: "metrics" as const })),
+      name: "prom1", type: "prometheus", signalType: "metrics" as const,
+      queryMetrics: async () => emptySeries(), // no data for any metric
+    } as unknown as ObservabilityConnector;
+  }
+  function regWith(...mocks: ObservabilityConnector[]): ConnectorRegistry {
+    const reg = new ConnectorRegistry();
+    for (const m of mocks) {
+      (reg as any).connectors.set(m.name, m);
+      (reg as any).sourceConfigs.set(m.name, { name: m.name, type: m.type, url: "http://m", enabled: true });
+    }
+    return reg;
+  }
+
+  it("nonexistent service → status unknown, score null, not-found note (not 100/healthy)", async () => {
+    const reg = regWith(metricsConnector(["payment-service"])); // does NOT know the queried name
+    const data = JSON.parse((await getServiceHealthHandler(reg, { service: "nope-xyz" })).content[0].text);
+    assert.equal(data.status, "unknown");
+    assert.equal(data.score, null);
+    assert.equal(data.signals.metrics, null);
+    assert.match(data.note, /not found/i);
+  });
+
+  it("log-only service with errors → judged on logs, never 100/healthy from metric zeros", async () => {
+    const logs = {
+      connect: async () => {}, disconnect: async () => {},
+      healthCheck: async () => ({ status: "up" as const, latencyMs: 1 }),
+      getDefaultMetrics: () => [], getMetrics: () => [],
+      listServices: async () => [{ name: "logapp", source: "loki1", signalType: "logs" as const }],
+      name: "loki1", type: "loki", signalType: "logs" as const,
+      queryLogs: async () => ({
+        source: "loki1", service: "logapp", entries: [],
+        summary: { total: 60, errorCount: 40, warnCount: 0, topPatterns: ["boom"] },
+      }),
+    } as unknown as ObservabilityConnector;
+    const reg = regWith(metricsConnector([]), logs);
+    const data = JSON.parse((await getServiceHealthHandler(reg, { service: "logapp" })).content[0].text);
+    assert.notEqual(data.status, "healthy");
+    assert.notEqual(data.status, "unknown");
+    assert.equal(data.signals.metrics, null, "metrics signal must be null when no metric data");
+    assert.ok(data.signals.logs, "logs signal must be present");
+    assert.deepEqual(data.coverage, { metrics: false, logs: true });
+    assert.ok(data.score !== null && data.score < 50, `40 errors/5min log-only must not be healthy, got ${data.score}`);
+  });
+});

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -354,20 +354,28 @@ export interface AnomalyReport {
 
 export interface ServiceHealth {
   service: string;
-  status: HealthStatus;
-  score: number; // 0-100
+  /** "unknown" when the service has no data in any signal (or doesn't exist). */
+  status: HealthStatus | "unknown";
+  /** 0-100, or null when status is "unknown" (no signal had data). */
+  score: number | null;
   signals: {
+    /** null when the service exposes no metrics signal / no metric data. */
     metrics: {
       cpu: number;
       memory: number;
       errorRate: number;
       latencyP99: number;
-    };
+    } | null;
+    /** null when the service exposes no logs signal / no log data. */
     logs: {
       errorRate: number;
       topErrors: string[];
-    };
+    } | null;
   };
   anomalies: AnomalyReport[];
   correlations: string[];
+  /** Which signal families actually had data (drives the score weighting). */
+  coverage?: { metrics: boolean; logs: boolean };
+  /** Operator-facing explanation when status is "unknown" or coverage is partial. */
+  note?: string;
 }


### PR DESCRIPTION
## S5 — issue #453 part A

`get_service_health` coerced absent metrics → 0 → `score:100/"healthy"` — for a **log-only** service with no metric coverage, and even for a **nonexistent** service (a typo'd name read as good news). The one place the gateway gave false confidence instead of the honest "no data" it gives everywhere else.

**Fix:**
- `calculateHealthScore` gains optional `coverage:{metrics,logs}` — families with no data are excluded from the weighted score and remaining weights renormalised; no families → `{score:null, status:"unknown"}`. Default path unchanged (weights sum to 1.0).
- Handler tracks whether metrics/logs actually returned data: no-data + unknown to `list_services` → `unknown`/`null`/**not-found note**; no-data + exists → unknown (quiet/unmonitored); else scores over covered signals; `signals.metrics/logs` null when absent; adds `coverage` + `note`.

Tests: health coverage cases + handler cases (nonexistent→not-found, log-only-with-errors→not healthy). UI reads fields defensively (reviewer-confirmed). Reviewer-agent: **SHIP**. Part of the open-issues loop → v3.3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)