### PR TITLE
fix(detect-anomalies): scan log-only services + report coverage (issue #453B)

### DIFF
--- a/mcp-server/src/tools/detect-anomalies.ts
+++ b/mcp-server/src/tools/detect-anomalies.ts
@@ -74,16 +74,34 @@ export async function detectAnomaliesHandler(
   const metricsConnectors = tenantConnectors.filter((c) => c.signalType === "metrics");
   const logConnectors = tenantConnectors.filter((c) => c.signalType === "logs");
 
-  let serviceNames: string[] = [];
+  // Discover services from BOTH metrics and log connectors, tracking which
+  // signal each service exposes. Previously the fleet scan only enumerated
+  // metrics connectors, so a log-only service was silently dropped from the
+  // scan — and the "all healthy" all-clear never said so (issue #453B). Now
+  // log-only services are scanned (via their log error-rate, as the
+  // description promises) and the per-service coverage is reported.
+  const coverage = new Map<string, { metrics: boolean; logs: boolean }>();
+  const mark = (name: string, key: "metrics" | "logs") => {
+    const e = coverage.get(name) ?? { metrics: false, logs: false };
+    e[key] = true;
+    coverage.set(name, e);
+  };
+  for (const connector of metricsConnectors) {
+    try { for (const s of await connector.listServices()) mark(s.name, "metrics"); } catch { /* connector down — skip */ }
+  }
+  for (const connector of logConnectors) {
+    try { for (const s of await connector.listServices()) mark(s.name, "logs"); } catch { /* connector down — skip */ }
+  }
+
+  let serviceNames: string[];
   if (args.service) {
     serviceNames = [args.service];
-  } else {
-    for (const connector of metricsConnectors) {
-      const services = await connector.listServices();
-      for (const s of services) {
-        if (!serviceNames.includes(s.name)) serviceNames.push(s.name);
-      }
+    if (!coverage.has(args.service)) {
+      // Unknown to listServices — still attempt both signal paths.
+      coverage.set(args.service, { metrics: metricsConnectors.length > 0, logs: logConnectors.length > 0 });
     }
+  } else {
+    serviceNames = [...coverage.keys()];
   }
 
   const allAnomalies: AnomalyReport[] = [];
@@ -226,15 +244,27 @@ export async function detectAnomaliesHandler(
         )
       : { ranked: [], summary: "" };
 
+  // Per-service coverage so an "all healthy" all-clear is verifiable rather
+  // than silently partial: the caller sees exactly which services were
+  // scanned and on which signals (issue #453B).
+  const scanned = serviceNames.map((name) => {
+    const cov = coverage.get(name) ?? { metrics: false, logs: false };
+    const signals = [cov.metrics ? "metrics" : null, cov.logs ? "logs" : null].filter(Boolean) as string[];
+    return { service: name, signals };
+  });
+  const metricsCount = scanned.filter((s) => s.signals.includes("metrics")).length;
+  const logsCount = scanned.filter((s) => s.signals.includes("logs")).length;
+
   const result = {
     scannedServices: serviceNames.length,
+    coverage: { scanned },
     anomalies: allAnomalies,
     correlations: allCorrelations,
     rootCause,
     summary:
       allAnomalies.length === 0
-        ? "All services healthy — no anomalies detected."
-        : `${allAnomalies.length} anomal${allAnomalies.length === 1 ? "y" : "ies"} detected across ${[...new Set(allAnomalies.map((a) => a.service))].length} service(s).`,
+        ? `No anomalies across ${serviceNames.length} scanned service(s) (${metricsCount} with metrics, ${logsCount} with logs).`
+        : `${allAnomalies.length} anomal${allAnomalies.length === 1 ? "y" : "ies"} detected across ${[...new Set(allAnomalies.map((a) => a.service))].length} of ${serviceNames.length} scanned service(s).`,
   };
 
   return {

--- a/mcp-server/src/tools/handlers.test.ts
+++ b/mcp-server/src/tools/handlers.test.ts
@@ -168,6 +168,39 @@ describe("listServicesHandler", () => {
   });
 });
 
+describe("detectAnomaliesHandler — fleet coverage (issue #453B)", () => {
+  it("fleet scan includes log-only services and reports per-service coverage", async () => {
+    const reg = createRegistryWithMocks([
+      createMockConnector({
+        name: "prom1", type: "prometheus", signalType: "metrics",
+        listServices: async () => [{ name: "metric-svc", source: "prom1", signalType: "metrics" }],
+        queryMetrics: async () => ({
+          source: "prom1", service: "metric-svc", metric: "x", unit: "",
+          values: Array.from({ length: 30 }, (_, i) => ({ timestamp: new Date(Date.now() - (30 - i) * 9000).toISOString(), value: 20 })),
+          summary: { current: 20, average: 20, min: 20, max: 20, trend: "stable" as const },
+        }),
+      }),
+      createMockConnector({
+        name: "loki1", type: "loki", signalType: "logs",
+        listServices: async () => [{ name: "log-only-svc", source: "loki1", signalType: "logs" }],
+        queryLogs: async () => ({
+          source: "loki1", service: "log-only-svc", entries: [],
+          summary: { total: 10, errorCount: 0, warnCount: 0, topPatterns: [] },
+        }),
+      }),
+    ]);
+    const data = JSON.parse((await detectAnomaliesHandler(reg, {})).content[0].text);
+    // Both services scanned — the log-only one is NOT silently dropped.
+    assert.equal(data.scannedServices, 2);
+    const names = data.coverage.scanned.map((s: any) => s.service).sort();
+    assert.deepEqual(names, ["log-only-svc", "metric-svc"]);
+    const logOnly = data.coverage.scanned.find((s: any) => s.service === "log-only-svc");
+    assert.deepEqual(logOnly.signals, ["logs"], "log-only service must be scanned via its logs signal");
+    // All-clear is no longer silently partial — it states the coverage.
+    assert.match(data.summary, /2 scanned service\(s\)/);
+  });
+});
+
 describe("detectAnomaliesHandler — A5 memory/OOM coverage", () => {
   const flatMemory = () => ({
     source: "prom1", service: "payment-service", metric: "memory", unit: "bytes",


### PR DESCRIPTION
## S6 — issue #453 part B

The fleet scan discovered services **only from metrics connectors**, so a log-only service was silently dropped (scanned 2 of 3, never said which) — even though the tool advertises log-error-spike detection, and the only log-bearing service was the one excluded.

**Fix:**
- Discover services from **both** metrics + log connectors (per-connector try/catch so a down connector doesn't abort discovery). Log-only services now get scanned via the existing log error-rate path.
- Result gains `coverage.scanned: [{service, signals[]}]` and the summary states coverage — *"No anomalies across N scanned service(s) (X with metrics, Y with logs)"* — so an all-clear is **verifiable, not silently partial**. Existing fields kept (additive).

Test: metrics-only + log-only connector → both scanned, log-only reports `signals:["logs"]`. Reviewer-agent: **SHIP** (no double-counting, additive shape). Closes the open-issues loop → folds into v3.3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)