### PR TITLE
chore(release): v3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,74 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.3.1] — 2026-06-10
+
+Agent-feedback patch — three structured agent reports against 3.3.0
+(#452/#453/#455, Loki + Grafana Cloud) turned up two real `query_logs`
+bugs, a "false-healthy" gap in the health tooling, and the missing
+auto-injected usage channel. Every finding was adversarially verified
+and fixed over the real MCP transport. Additive and non-breaking.
+
+### Fixed
+
+- **`query_logs` `aggregate: count_over_time` no longer leaks the label
+  set (#452).** With an empty `by`, a bucketed `count_over_time` over a
+  `| json` stream kept every extracted label (rid/ip/status/…) as its
+  own series, so "requests over time" came back as a high-cardinality
+  mess instead of one bucketed total. It is now always `sum`-wrapped —
+  no `by` collapses to a single series; explicit `by` is unchanged.
+- **`query_logs` `raw_query` with a vector/matrix aggregation fails fast
+  with a clear message instead of crashing (#452).** A metric
+  `raw_query` (e.g. `sum(count_over_time(...))`) returns Loki resultType
+  vector/matrix, not streams; the streams parser dereferenced undefined
+  fields and crashed on `.level`, and the 5-minute default window meant
+  it ran to timeout. The handler now checks `resultType` and returns an
+  actionable error ("use `aggregate` for counts/top-k, or query_metrics
+  raw_query for vector/matrix results").
+- **`get_service_health` reports honest "no data" / "not found" instead
+  of a confident `100/healthy` (#453).** Absent metrics were coerced to
+  `0` and scored as healthy — even for a log-only service with no metric
+  coverage, and even for a service that does not exist (a typo read as
+  good news). Health is now computed only over the signal families that
+  actually returned data (`coverage:{metrics,logs}`); a service with no
+  data in any signal is `status:"unknown"`, `score:null`, and an unknown
+  name yields an explicit "not found" note like the other tools'
+  empty-states. `signals.metrics`/`signals.logs` are `null` when absent.
+- **`detect_anomalies` fleet scan no longer silently drops log-only
+  services (#453).** Service discovery enumerated only metrics
+  connectors, so a log-only service was skipped and the "all healthy"
+  all-clear was misleadingly partial. Discovery now unions metrics + log
+  connectors (log-only services are scanned via their log error-rate),
+  and the result carries `coverage.scanned:[{service,signals[]}]` plus a
+  summary that states the coverage, so an all-clear is verifiable.
+
+### Added
+
+- **`initialize.instructions` is now populated (#455).** The one channel
+  the MCP spec auto-injects into an agent's context on connect was empty,
+  so the 3.3.0 usage guide only reached agents a human pointed at it. It
+  now carries a tight kernel: read `omcp://guide/agent-usage`, the
+  filter+aggregate golden rule, all-tools-read-only, the
+  empty-states-name-the-flag contract, and a pointer to the agent-report
+  template. The golden rule is also seeded into the `query_logs`
+  description as a fallback for clients that don't surface instructions.
+- **Collaboration pointers aligned (#455 follow-up).** The
+  `omcp://guide/agent-usage` resource's Report-findings section gains the
+  Discussions link (with an operator-behalf caveat) so the guide and
+  `/llms.txt` agree — the Discussions link stays out of the per-connect
+  `instructions` kernel by design.
+
+### Notes
+
+- **Behaviour change for custom health weights that don't sum to 1.0:**
+  `calculateHealthScore` now renormalises by the active signal weights.
+  With the default weights (which sum to 1.0) the score is unchanged;
+  custom thresholds whose weights don't sum to 1.0 will shift slightly
+  (the renormalised value is more correct — the old path could exceed
+  100 before clamping).
+- The SDK (`@thotischner/observability-mcp-sdk`) is unchanged — these are
+  all gateway tool-surface fixes; the plugin contract did not move.
+
 ## [3.3.0] — 2026-06-10
 
 Agent-experience release — the gateway's primary audience is an LLM

--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,11 +4,11 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 2.3.0
+version: 2.3.1
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
-appVersion: "3.3.0"
+appVersion: "3.3.1"
 
 home: https://github.com/ThoTischner/observability-mcp
 sources:
@@ -51,18 +51,20 @@ annotations:
     url: https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc
   artifacthub.io/images: |
     - name: observability-mcp
-      image: ghcr.io/thotischner/observability-mcp:3.3.0
+      image: ghcr.io/thotischner/observability-mcp:3.3.1
       platforms:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
     - kind: changed
-      description: "appVersion → 3.3.0 (agent-experience release); chart points at the 3.3.0 image"
+      description: "appVersion → 3.3.1 (agent-feedback patch); chart points at the 3.3.1 image"
+    - kind: fixed
+      description: "query_logs count_over_time without `by` no longer leaks the label set — collapses to one bucketed series (#452)"
+    - kind: fixed
+      description: "query_logs raw_query with a vector/matrix aggregation fails fast with a clear message instead of crashing/timing out (#452)"
+    - kind: fixed
+      description: "get_service_health reports honest no-data/unknown (and not-found for typo'd names) instead of a false 100/healthy (#453)"
+    - kind: fixed
+      description: "detect_anomalies fleet scan covers log-only services and reports per-service coverage so an all-clear isn't silently partial (#453)"
     - kind: added
-      description: "MCP ToolAnnotations on all 12 tools (readOnlyHint etc. for client auto-approve)"
-    - kind: added
-      description: "builtin MCP resources + prompts: agent usage guide (omcp://guide/agent-usage), triage-incident, write-postmortem"
-    - kind: added
-      description: "llms.txt served at /llms.txt, generated from the canonical tool registry"
-    - kind: added
-      description: "listed on the official MCP Registry (io.github.ThoTischner/observability-mcp)"
+      description: "initialize.instructions populated (golden rule + guide pointer) so the usage guide auto-reaches connecting agents (#455)"

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thotischner/observability-mcp",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Agent-feedback patch — bundles **six** fixes from three structured agent reports against 3.3.0 (#452 / #453 / #455), each merged + reviewer-verified + adversarially checked over the real MCP transport.

| Fix | Issue |
|-----|-------|
| `query_logs` `count_over_time` without `by` → one bucketed series (no label-set leak) | #452 |
| `query_logs` `raw_query` vector/matrix → fail-fast with clear message (no `.level` crash/timeout) | #452 |
| `get_service_health` honest no-data / `unknown` / not-found instead of false `100/healthy` | #453 |
| `detect_anomalies` fleet scan covers log-only services + reports `coverage` | #453 |
| `initialize.instructions` populated (usage-guide kernel + golden rule) | #455 |
| guide ↔ llms.txt collaboration pointers aligned | #455 follow-up |

Versions: mcp-server 3.3.0→3.3.1, helm chart 2.3.0→2.3.1 (appVersion 3.3.1). SDK unchanged. Full suite green (834 real tests; CHANGELOG + reviewer-agent verified). `enrich_ips` bundled-dataset tooling stays the separate v3.3 candidate (tester tracks it separately).

Merging auto-tags v3.3.1 → docker/npm/helm + MCP-registry publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)