### PR TITLE
fix(metrics): query_metrics null summary for no-data, not false zeros (#462)

### DIFF
--- a/mcp-server/src/analysis/correlator.ts
+++ b/mcp-server/src/analysis/correlator.ts
@@ -32,7 +32,7 @@ export function correlateSignals(
     const serviceMetrics = metricResults.filter((m) => m.service === anomaly.service);
     for (const metric of serviceMetrics) {
       if (metric.metric === anomaly.metric) continue;
-      if (metric.summary.trend === "rising") {
+      if (metric.summary && metric.summary.trend === "rising") {
         correlations.push(
           `${anomaly.service}: ${anomaly.metric} anomaly coincides with rising ${metric.metric} ` +
           `(current: ${metric.summary.current.toFixed(2)})`

--- a/mcp-server/src/connectors/prometheus.test.ts
+++ b/mcp-server/src/connectors/prometheus.test.ts
@@ -66,13 +66,9 @@ describe("PrometheusConnector", () => {
   });
 
   describe("computeSummary", () => {
-    it("returns zeros for empty array", () => {
+    it("returns null for empty array — no-data, not a false all-zeros reading (#462)", () => {
       const s = proto.computeSummary([]);
-      assert.equal(s.current, 0);
-      assert.equal(s.average, 0);
-      assert.equal(s.min, 0);
-      assert.equal(s.max, 0);
-      assert.equal(s.trend, "stable");
+      assert.equal(s, null);
     });
 
     it("computes correct summary for values", () => {
@@ -218,6 +214,37 @@ describe("PrometheusConnector", () => {
         assert.equal(result.resolvedSeries, raw);
         assert.equal(result.metric, "(raw)");
         assert.equal(result.values[0].value, 42);
+      } finally {
+        globalThis.fetch = orig;
+      }
+    });
+  });
+
+  describe("queryMetrics no-data → null summary, not zero-fill (#462)", () => {
+    const fakeSource = { name: "test", type: "prometheus" as const, url: "http://localhost:9090", enabled: true };
+
+    it("an empty result set yields values:[], summary:null, and a no-data note", async () => {
+      const connector = new PrometheusConnector();
+      await connector.connect({ ...fakeSource });
+      const orig = globalThis.fetch;
+      // raw_query bypasses the candidate-probe / label-resolve path and runs
+      // query_range directly — here it returns an empty result set (the
+      // no-data case: a logs-only service has no such metric series).
+      globalThis.fetch = (async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: { result: [] } }),
+      } as any)) as any;
+      try {
+        const result = await connector.queryMetrics({
+          service: "",
+          metric: "",
+          duration: "1h",
+          rawQuery: "rate(process_cpu_seconds_total{job=\"logs-only-svc\"}[1m]) * 100",
+        });
+        assert.deepEqual(result.values, [], "no data points");
+        assert.equal(result.summary, null, "summary must be null, not {current:0,...}");
+        assert.match(result.note ?? "", /No data/i, "must carry a no-data note");
       } finally {
         globalThis.fetch = orig;
       }

--- a/mcp-server/src/connectors/prometheus.ts
+++ b/mcp-server/src/connectors/prometheus.ts
@@ -302,6 +302,11 @@ export class PrometheusConnector implements ObservabilityConnector {
       resolvedLabel: label,
     };
 
+    if (!result.summary) {
+      result.note = `No data: no '${params.metric}' series matched "${params.service}" in this window. ` +
+        "The service may expose logs only, or the metric name/label didn't match. Absent ≠ zero — summary is null rather than all-zeros.";
+    }
+
     if (params.groupBy && groups.length > 1) {
       result.groupBy = params.groupBy;
       result.groups = groups;
@@ -365,6 +370,9 @@ export class PrometheusConnector implements ObservabilityConnector {
       resolvedSeries: rawQuery,
       resolvedLabel: "",
     };
+    if (!result.summary) {
+      result.note = "No data: the query returned no series in this window. Absent ≠ zero — summary is null rather than all-zeros.";
+    }
     if (groups.length > 1) result.groups = groups;
     return result;
   }
@@ -565,7 +573,10 @@ export class PrometheusConnector implements ObservabilityConnector {
 
   private computeSummary(values: number[]): MetricResult["summary"] {
     if (values.length === 0) {
-      return { current: 0, average: 0, min: 0, max: 0, trend: "stable" };
+      // No data points → no-data, NOT a confident all-zeros reading. Coercing
+      // an empty series to {current:0,trend:"stable"} is indistinguishable
+      // from a service genuinely idling at 0 (issue #462).
+      return null;
     }
     const current = values[values.length - 1];
     const average = values.reduce((a, b) => a + b, 0) / values.length;

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -663,7 +663,7 @@ async function main() {
       "Fetch the raw time-series for ONE metric of ONE service over a look-back window, returned together with pre-computed summary statistics.",
       "When to use: when you need the actual numeric values or the trend of a known metric. For a 'is this service OK?' verdict use `get_service_health`; to find which services are misbehaving use `detect_anomalies`.",
       "Prerequisites: get the exact service name from `list_services` and choose a metric from the list at the end of this description.",
-      "Behavior: read-only, no side effects. Returns an ordered array of {timestamp, value} points plus a summary {current, average, min, max, trend}. With `groupBy` set, returns one labelled series per distinct label value under `groups` instead of a single aggregated series. Units depend on the metric (e.g. CPU as %, latency as ms, rates as per-second). An unknown service/metric or an unreachable backend yields a structured explanatory error, never an exception.",
+      "Behavior: read-only, no side effects. Returns an ordered array of {timestamp, value} points plus a summary {current, average, min, max, trend}. When no series matched (e.g. a logs-only service has no such metric), `values` is empty and `summary` is `null` (not all-zeros) with a `note` — absent data is not a real zero reading. With `groupBy` set, returns one labelled series per distinct label value under `groups` instead of a single aggregated series. Units depend on the metric (e.g. CPU as %, latency as ms, rates as per-second). An unknown service/metric or an unreachable backend yields a structured explanatory error, never an exception.",
       `Available metrics: ${metricsList}`,
     ].join(" "),
     {

--- a/mcp-server/src/tools/get-service-health.ts
+++ b/mcp-server/src/tools/get-service-health.ts
@@ -47,18 +47,18 @@ export async function getServiceHealthHandler(
     if (!connector.queryMetrics) continue;
     try {
       const cpuResult = await connector.queryMetrics({ service: args.service, metric: "cpu", duration: "5m" });
-      if (cpuResult.values.length > 0) { cpu = cpuResult.summary.current; metricsHadData = true; }
+      if (cpuResult.summary) { cpu = cpuResult.summary.current; metricsHadData = true; }
       checkAnomaly(cpuResult.values.map(v => v.value), "cpu", args.service, connector.name, anomalies);
 
       const memResult = await connector.queryMetrics({ service: args.service, metric: "memory", duration: "5m" });
-      if (memResult.values.length > 0) { memory = memResult.summary.current / 1_000_000; metricsHadData = true; } // MB for display
+      if (memResult.summary) { memory = memResult.summary.current / 1_000_000; metricsHadData = true; } // MB for display
 
       const errResult = await connector.queryMetrics({ service: args.service, metric: "error_rate", duration: "5m" });
-      if (errResult.values.length > 0) { errorRate = errResult.summary.current; metricsHadData = true; }
+      if (errResult.summary) { errorRate = errResult.summary.current; metricsHadData = true; }
       checkAnomaly(errResult.values.map(v => v.value), "error_rate", args.service, connector.name, anomalies);
 
       const latResult = await connector.queryMetrics({ service: args.service, metric: "latency_p99", duration: "5m" });
-      if (latResult.values.length > 0) { latencyP99 = latResult.summary.current; metricsHadData = true; }
+      if (latResult.summary) { latencyP99 = latResult.summary.current; metricsHadData = true; }
       checkAnomaly(latResult.values.map(v => v.value), "latency_p99", args.service, connector.name, anomalies);
     } catch (err) {
       console.error("Health check metrics failed for %s:", sanitizeForLog(args.service), err);

--- a/mcp-server/src/tools/handlers.test.ts
+++ b/mcp-server/src/tools/handlers.test.ts
@@ -313,7 +313,9 @@ describe("getServiceHealthHandler — honest no-data / not-found (issue #453)", 
   const emptySeries = (): MetricResult => ({
     source: "prom1", service: "x", metric: "x", unit: "",
     values: [],
-    summary: { current: 0, average: 0, min: 0, max: 0, trend: "stable" as const },
+    // No data → null summary (matches the real connector after #462), so the
+    // health handler treats it as no-coverage, not a real zero reading.
+    summary: null,
   });
   function metricsConnector(known: string[]): ObservabilityConnector {
     return {

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -184,7 +184,8 @@ export interface MetricSummary {
 export interface MetricGroup {
   key: string;
   values: DataPoint[];
-  summary: MetricSummary;
+  /** null when this group has no data points — absent ≠ a real zero reading. */
+  summary: MetricSummary | null;
 }
 
 export interface MetricResult {
@@ -193,12 +194,15 @@ export interface MetricResult {
   metric: string;
   unit: string;
   values: DataPoint[];
-  summary: MetricSummary;
+  /** null when `values` is empty (no series matched this service/metric) — a
+   *  no-data signal, not a confident all-zeros reading (issue #462). */
+  summary: MetricSummary | null;
   resolvedSeries?: string;   // The actual PromQL executed (for debugging when auto-resolved)
   resolvedLabel?: string;    // Which label (job/service/app/...) the service was matched on
   groupBy?: string;          // Label the result was broken down by
   groups?: MetricGroup[];    // Per-group time-series (set when groupBy was requested and >1 group exists)
   hint?: string;             // Suggestion when caller may want a different query shape
+  note?: string;             // Operator-facing explanation, e.g. why summary is null (no-data)
 }
 
 export interface LogEntry {


### PR DESCRIPTION
## T1 — issue #462

Sibling of the #453A health fix, one level down in the raw metric tool. For a logs-only service, `query_metrics{metric:"cpu"}` returned `values:[]` but `summary:{current:0,…,trend:"stable"}` — indistinguishable from a service genuinely idling at 0%. An agent trusting the summary reports "CPU 0%, p99 0s, stable" for a metric the service doesn't expose.

**Fix:** `computeSummary([])` → `null` (was all-zeros). `MetricResult.summary`/`MetricGroup.summary` are now `MetricSummary | null`; `MetricResult` gains a `note`; both assembly sites set a no-data note. Consumers null-guarded (correlator, get-service-health — the metric guards switch `values.length>0`→`if(summary)`, behaviour-equivalent and preserving the #453A coverage/unknown logic). Description documents the shape.

Tests: computeSummary empty→null; queryMetrics no-data → `values:[]`,`summary:null`,note; mocks updated to the null contract. Reviewer-agent: **SHIP** (58 pass). Part of the open-issues loop → v3.3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)