### PR TITLE
fix(query_logs): report  not  in error responses (#452)

### DIFF
--- a/mcp-server/src/tools/query-logs-error-shape.test.ts
+++ b/mcp-server/src/tools/query-logs-error-shape.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { ConnectorRegistry } from "../connectors/registry.js";
+import { queryLogsHandler } from "./query-logs.js";
+import type { ObservabilityConnector } from "../connectors/interface.js";
+
+// Inject a mock connector into the registry's internal maps.
+function regWith(mock: ObservabilityConnector): ConnectorRegistry {
+  const reg = new ConnectorRegistry();
+  (reg as any).connectors.set(mock.name, mock);
+  (reg as any).sourceConfigs.set(mock.name, { name: mock.name, type: mock.type, url: "http://mock", enabled: true });
+  return reg;
+}
+
+describe("queryLogsHandler error response shape (issue #452)", () => {
+  it("a failing query reports `window` (the look-back), not `duration` (read as wall-clock)", async () => {
+    // Mirrors the raw_query fail-fast case: the connector throws, the handler
+    // returns a structured error. The look-back window must be labelled
+    // `window`, never `duration` — an agent reading duration:"5m" on a <1s
+    // failure thinks it hung (the very symptom the fail-fast fix removed).
+    const mock = {
+      connect: async () => {}, disconnect: async () => {},
+      healthCheck: async () => ({ status: "up" as const, latencyMs: 1 }),
+      getDefaultMetrics: () => [], getMetrics: () => [],
+      listServices: async () => [],
+      name: "loki1", type: "loki", signalType: "logs" as const,
+      queryLogs: async () => { throw new Error("query_logs raw_query returned a 'matrix' result, but query_logs handles log lines (streams) only."); },
+    } as unknown as ObservabilityConnector;
+
+    const result = await queryLogsHandler(
+      regWith(mock),
+      { raw_query: "sum(count_over_time({service_name=\"x\"} | json [1h]))", duration: "1h" },
+      undefined,
+      { allowRawQuery: true },
+    );
+    const data = JSON.parse(result.content[0].text);
+    assert.ok(data.error, "must be an error response");
+    assert.equal(data.window, "1h", "look-back must be reported as `window`");
+    assert.equal("duration" in data, false, "must NOT carry a `duration` field (misread as elapsed time)");
+  });
+});

--- a/mcp-server/src/tools/query-logs.ts
+++ b/mcp-server/src/tools/query-logs.ts
@@ -138,7 +138,8 @@ export async function queryLogsHandler(
     }
     if (aggResults.length === 0) {
       return {
-        content: [{ type: "text" as const, text: JSON.stringify({ error: aggErrors.length ? `Aggregate failed: ${aggErrors.join("; ")}` : "No data returned", service: args.service, duration }) }],
+        // `window` = the requested look-back, not elapsed time (issue #452).
+        content: [{ type: "text" as const, text: JSON.stringify({ error: aggErrors.length ? `Aggregate failed: ${aggErrors.join("; ")}` : "No data returned", service: args.service, window: duration }) }],
         isError: aggErrors.length > 0,
       };
     }
@@ -179,7 +180,9 @@ export async function queryLogsHandler(
           text: JSON.stringify({
             error: errors.length > 0 ? `Query failed: ${errors.join("; ")}` : "No logs returned",
             service: args.service,
-            duration,
+            // The requested look-back window, NOT elapsed wall-clock time. Named
+            // `window` so a fast failure isn't misread as a 5-minute hang (#452).
+            window: duration,
           }),
         },
       ],


### PR DESCRIPTION
## T2 — issue #452 reopened, leftover #1

The S2 fail-fast fix surfaced a stale field: the `query_logs` error / no-data responses returned `duration` (the requested look-back window), which an agent reads as **elapsed wall-clock** — so a <1s fast failure looks like a 5-minute hang (the symptom S2 removed). Renamed to `window` in both error/no-data responses; input param + connector-call args stay `duration`; success path untouched.

Test: throwing connector → response carries `window`, never `duration`. Reviewer-agent: **SHIP** (8 pass). Part of the open-issues loop → v3.3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)