### PR TITLE
chore(release): v3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.3.2] — 2026-06-11
+
+Agent-feedback patch — two more reports against 3.3.1 (#462 and the
+reopened #452) extending the "absent ≠ zero" honesty principle into the
+raw metric tool and tidying a stale field the fail-fast fix surfaced.
+Additive and non-breaking.
+
+### Fixed
+
+- **`query_metrics` reports no-data honestly instead of false zeros
+  (#462).** For a service with no matching series (e.g. a logs-only
+  service queried for `cpu`), the tool returned `values:[]` but
+  `summary:{current:0,…,trend:"stable"}` — indistinguishable from a
+  service genuinely idling at 0. `summary` is now `null` (with an
+  explanatory `note`) when no series matched, mirroring the #453A health
+  fix one level down. `MetricResult.summary` and `MetricGroup.summary`
+  are now nullable; consumers (correlation, health scoring) treat a null
+  summary as no-data.
+- **`query_logs` error responses report `window`, not `duration`
+  (#452).** The fail-fast fix (3.3.1) surfaced a stale field: the
+  error / no-data response echoed the requested look-back as `duration`,
+  which an agent reads as elapsed wall-clock — so a sub-second failure
+  looked like a 5-minute hang. The field is now named `window`; the
+  success path and the input parameter are unchanged.
+
+### Notes
+
+- The label-filtered `count_over_time` 400 reported under #452 could not
+  be reproduced: the emitted LogQL
+  (`sum (count_over_time({sel} | json | label="v" [step]))`) is
+  well-formed and structurally identical to the working `sum`/`topk`
+  path. A regression guard asserting that LogQL shape was added; the
+  intermittent 400 is treated as backend-side/transient.
+- `MetricResult.summary`/`MetricGroup.summary` becoming nullable is
+  additive (a new `null` case for the no-data state); existing readers
+  that always had data are unaffected. SDK unchanged.
+
 ## [3.3.1] — 2026-06-10
 
 Agent-feedback patch — three structured agent reports against 3.3.0

--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,11 +4,11 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 2.3.1
+version: 2.3.2
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
-appVersion: "3.3.1"
+appVersion: "3.3.2"
 
 home: https://github.com/ThoTischner/observability-mcp
 sources:
@@ -51,20 +51,16 @@ annotations:
     url: https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc
   artifacthub.io/images: |
     - name: observability-mcp
-      image: ghcr.io/thotischner/observability-mcp:3.3.1
+      image: ghcr.io/thotischner/observability-mcp:3.3.2
       platforms:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
     - kind: changed
-      description: "appVersion → 3.3.1 (agent-feedback patch); chart points at the 3.3.1 image"
+      description: "appVersion → 3.3.2 (agent-feedback patch); chart points at the 3.3.2 image"
     - kind: fixed
-      description: "query_logs count_over_time without `by` no longer leaks the label set — collapses to one bucketed series (#452)"
+      description: "query_metrics reports no-data honestly (summary:null + note) instead of false all-zeros for a service with no matching series (#462)"
     - kind: fixed
-      description: "query_logs raw_query with a vector/matrix aggregation fails fast with a clear message instead of crashing/timing out (#452)"
-    - kind: fixed
-      description: "get_service_health reports honest no-data/unknown (and not-found for typo'd names) instead of a false 100/healthy (#453)"
-    - kind: fixed
-      description: "detect_anomalies fleet scan covers log-only services and reports per-service coverage so an all-clear isn't silently partial (#453)"
+      description: "query_logs error/no-data responses report `window` (the look-back) not `duration`, so a fast failure isn't misread as a 5-minute hang (#452)"
     - kind: added
-      description: "initialize.instructions populated (golden rule + guide pointer) so the usage guide auto-reaches connecting agents (#455)"
+      description: "regression guard: label-filtered count_over_time emits well-formed sum-wrapped LogQL (#452)"

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thotischner/observability-mcp",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Agent-feedback patch — bundles **three** fixes from two reports against 3.3.1 (#462 and the reopened #452), each merged + reviewer-verified.

| Fix | Issue |
|-----|-------|
| `query_metrics` no-data → `summary:null` + note, not false all-zeros | #462 |
| `query_logs` error responses report `window` (look-back), not `duration` (misread as wall-clock) | #452 |
| Regression guard: label-filtered `count_over_time` emits valid sum-wrapped LogQL (400 classified backend/transient) | #452 |

Versions: mcp-server 3.3.1→3.3.2, helm chart 2.3.1→2.3.2 (appVersion 3.3.2). `MetricResult.summary`/`MetricGroup.summary` now nullable (additive no-data state). SDK unchanged. Full suite green (the only non-pass is the known `/scripts/hash-password.mjs` docker-mount artifact — green in CI / full-repo mount).

Merging auto-tags v3.3.2 → docker/npm/helm + MCP-registry publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)