### PR TITLE
feat(enrich_ips): IPv6 support + offline GeoLite2 dataset converter

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -67,6 +67,8 @@ jobs:
           node --test hub/build-catalog.test.mjs
       - name: Audit-verifier CLI (end-to-end)
         run: node --test scripts/verify-audit.test.mjs
+      - name: IP-enrich CSV converter CLI (end-to-end)
+        run: node --test scripts/build-ip-enrich-csv.test.mjs
       - name: Connectors (tests + manifest/catalog integrity in sync)
         run: |
           node --test connectors/*/*.test.mjs connectors/*/contract/*.test.mjs

--- a/docs/ip-enrichment.md
+++ b/docs/ip-enrichment.md
@@ -23,16 +23,18 @@ implicitly.
 ## Dataset format
 
 A dependency-free CSV (so no parser library / host `npm install` is
-needed). One row per IPv4 network:
+needed). One row per network (IPv4 or IPv6):
 
 ```csv
 network,country,city,asn,org,hosting
 1.2.3.0/24,US,Ashburn,AS14618,Example Cloud,true
 203.0.113.5,DE,Berlin,AS3320,Example ISP,false
+2001:db8::/32,US,,AS14618,Example Cloud,true
 ```
 
-- `network` — an IPv4 CIDR, or a bare IPv4 (treated as `/32`). IPv6 rows
-  are skipped (logged at boot); IPv4 covers the access-log case.
+- `network` — an IPv4 or IPv6 CIDR, or a bare address (treated as `/32`
+  resp. `/128`). Both families are supported; lookups dispatch by address
+  family. IPv4-mapped IPv6 (`::ffff:1.2.3.4`) parses on the IPv6 side.
 - `country`, `city`, `asn`, `org` — optional; an empty cell is omitted
   from the result.
 - `hosting` — `true`/`1`/`yes` (case-insensitive) marks a
@@ -48,6 +50,31 @@ You supply the data offline — e.g. export the ranges of interest from
 whatever geo/ASN source you already license into this CSV and mount it.
 This keeps enrichment air-gapped and avoids bundling any third-party
 database into the image.
+
+### Building the CSV from a MaxMind GeoLite2 export
+
+`scripts/build-ip-enrich-csv.mjs` reshapes a licensed **MaxMind GeoLite2**
+export into this CSV. It runs with plain `node` (no npm install), handles
+IPv4 and IPv6, and joins City blocks → country/city via the Locations
+file and (optionally) ASN blocks → asn/org. The geo/ASN **data never
+leaves your machine** — the script only reformats a file you already
+license; nothing is bundled and there is no network call.
+
+```bash
+node scripts/build-ip-enrich-csv.mjs \
+  --city-blocks GeoLite2-City-Blocks-IPv4.csv \
+  --city-blocks GeoLite2-City-Blocks-IPv6.csv \
+  --locations   GeoLite2-City-Locations-en.csv \
+  --asn-blocks  GeoLite2-ASN-Blocks-IPv4.csv \
+  --asn-blocks  GeoLite2-ASN-Blocks-IPv6.csv \
+  --out enrich.csv
+# then: OMCP_IP_ENRICH_FILE=enrich.csv
+```
+
+`--locations` and `--asn-blocks` are optional (with only city blocks you
+get `network,country,city`). The `hosting` flag is left blank — GeoLite2
+City/ASN don't carry it (it lives in the paid Anonymous-IP DB); set it
+yourself if you have that data.
 
 ## Usage
 

--- a/mcp-server/src/enrich/ip-dataset.test.ts
+++ b/mcp-server/src/enrich/ip-dataset.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { ipv4ToInt, parseCidr, IpEnrichmentDataset } from "./ip-dataset.js";
+import { ipv4ToInt, parseCidr, ipv6ToBigInt, parseCidr6, IpEnrichmentDataset } from "./ip-dataset.js";
 
 describe("ipv4ToInt", () => {
   it("parses valid IPv4", () => {
@@ -52,14 +52,14 @@ describe("IpEnrichmentDataset.fromCsv + lookup", () => {
     "10.0.0.0/8,US,,AS100,Example Cloud,true",
     "10.1.2.0/24,US,Ashburn,AS100,Example Cloud Edge,true",
     "203.0.113.5,DE,Berlin,AS3320,Example ISP,false",
-    "2001:db8::/32,XX,,,,", // IPv6 → skipped
+    "2001:db8::/32,XX,,,,", // IPv6 — now parsed, not skipped
     "garbage-row",
   ].join("\n");
 
-  it("parses rows, skips header/comments/blank, counts skipped", () => {
+  it("parses rows (v4 + v6), skips header/comments/blank, counts skipped", () => {
     const ds = IpEnrichmentDataset.fromCsv(csv);
-    assert.equal(ds.size, 3); // 3 valid IPv4 rows
-    assert.equal(ds.skipped, 2); // IPv6 + garbage
+    assert.equal(ds.size, 4); // 3 IPv4 + 1 IPv6 row
+    assert.equal(ds.skipped, 1); // only the garbage row
   });
 
   it("returns the most specific (longest-prefix) match", () => {
@@ -89,5 +89,85 @@ describe("IpEnrichmentDataset.fromCsv + lookup", () => {
     const ds = IpEnrichmentDataset.fromCsv(csv);
     assert.equal(ds.lookup("8.8.8.8"), null);
     assert.equal(ds.lookup("not-an-ip"), null);
+  });
+});
+
+describe("ipv6ToBigInt", () => {
+  it("parses a full address", () => {
+    assert.equal(ipv6ToBigInt("2001:0db8:0000:0000:0000:0000:0000:0001"), 0x20010db8000000000000000000000001n);
+  });
+  it("expands :: zero-compression", () => {
+    assert.equal(ipv6ToBigInt("2001:db8::1"), 0x20010db8000000000000000000000001n);
+    assert.equal(ipv6ToBigInt("::1"), 1n);
+    assert.equal(ipv6ToBigInt("::"), 0n);
+    assert.equal(ipv6ToBigInt("ff02::"), 0xff020000000000000000000000000000n);
+  });
+  it("parses an IPv4-mapped tail", () => {
+    // ::ffff:1.2.3.4 → the v4 lives in the low 32 bits with ffff above it
+    assert.equal(ipv6ToBigInt("::ffff:1.2.3.4"), 0x00000000000000000000ffff01020304n);
+  });
+  it("rejects malformed input", () => {
+    assert.equal(ipv6ToBigInt("2001:db8::1::2"), null); // two ::
+    assert.equal(ipv6ToBigInt("gggg::1"), null);
+    assert.equal(ipv6ToBigInt("1.2.3.4"), null); // v4 is not v6
+    assert.equal(ipv6ToBigInt("12345::"), null); // hextet too long
+    assert.equal(ipv6ToBigInt(""), null);
+  });
+});
+
+describe("parseCidr6", () => {
+  it("parses a /32 to its inclusive range", () => {
+    const r = parseCidr6("2001:db8::/32");
+    assert.equal(r?.prefix, 32);
+    assert.equal(r?.start, 0x20010db8000000000000000000000000n);
+    assert.equal(r?.end, 0x20010db8ffffffffffffffffffffffffn);
+  });
+  it("treats a bare address as /128", () => {
+    const r = parseCidr6("2001:db8::1");
+    assert.equal(r?.prefix, 128);
+    assert.equal(r?.start, r?.end);
+  });
+  it("handles /0 (whole space)", () => {
+    const r = parseCidr6("::/0");
+    assert.equal(r?.start, 0n);
+    assert.equal(r?.end, (1n << 128n) - 1n);
+  });
+  it("rejects bad prefixes / addresses", () => {
+    assert.equal(parseCidr6("2001:db8::/129"), null);
+    assert.equal(parseCidr6("nope::/32"), null);
+  });
+});
+
+describe("IpEnrichmentDataset IPv6 lookup", () => {
+  const csv = [
+    "network,country,city,asn,org,hosting",
+    "2001:db8::/32,US,,AS100,Example Cloud,true",
+    "2001:db8:1::/48,US,Ashburn,AS100,Example Cloud Edge,true",
+    "2606:4700::/32,US,,AS13335,Example CDN,true",
+    "10.0.0.0/8,DE,Berlin,AS3320,Example ISP,false", // v4 row alongside
+  ].join("\n");
+
+  it("returns the most specific v6 match", () => {
+    const ds = IpEnrichmentDataset.fromCsv(csv);
+    const hit = ds.lookup("2001:db8:1::abcd"); // inside both /32 and /48
+    assert.equal(hit?.city, "Ashburn");
+    assert.equal(hit?.org, "Example Cloud Edge");
+  });
+  it("falls back to the broader v6 range", () => {
+    const ds = IpEnrichmentDataset.fromCsv(csv);
+    const hit = ds.lookup("2001:db8:9::1"); // only in /32
+    assert.equal(hit?.asn, "AS100");
+    assert.equal(hit?.city, undefined);
+  });
+  it("keeps v4 and v6 lookups independent", () => {
+    const ds = IpEnrichmentDataset.fromCsv(csv);
+    assert.equal(ds.lookup("10.1.2.3")?.country, "DE"); // v4 path
+    assert.equal(ds.lookup("2606:4700::1")?.org, "Example CDN"); // v6 path
+    assert.equal(ds.lookup("2607:f8b0::1"), null); // unmatched v6
+  });
+  it("normalises an IPv4-mapped query against a v4 row? no — :: form hits v6 table only", () => {
+    const ds = IpEnrichmentDataset.fromCsv(csv);
+    // A ':'-bearing query goes to the v6 table; it won't match the 10.0.0.0/8 v4 row.
+    assert.equal(ds.lookup("::ffff:10.1.2.3"), null);
   });
 });

--- a/mcp-server/src/enrich/ip-dataset.ts
+++ b/mcp-server/src/enrich/ip-dataset.ts
@@ -9,9 +9,9 @@
 //   1.2.3.0/24,US,Ashburn,AS14618,Example Cloud,true
 //   203.0.113.5,DE,Berlin,AS3320,Example ISP,false
 //
-// - `network` is an IPv4 CIDR (or a bare IPv4, treated as /32). IPv6 rows are
-//   skipped (logged by the caller) — IPv4 covers the access-log case the
-//   report was about; IPv6 can follow.
+// - `network` is an IPv4 or IPv6 CIDR (or a bare address, treated as /32 or
+//   /128). Both families are supported; IPv4 uses fast 32-bit integer ranges,
+//   IPv6 uses 128-bit BigInt ranges. IPv4-mapped IPv6 (`::ffff:1.2.3.4`) parses.
 // - Remaining columns are optional; an empty cell is omitted from the result.
 // - `hosting` is the "is this a datacenter / hosting / proxy range" flag — the
 //   signal that separates real humans from bots/scanners/VPN-exit-nodes. Parsed
@@ -31,6 +31,13 @@ interface Range {
   start: number; // inclusive, unsigned 32-bit
   end: number; // inclusive
   prefix: number; // CIDR prefix length — larger = more specific
+  data: IpEnrichment;
+}
+
+interface Range6 {
+  start: bigint; // inclusive, 128-bit
+  end: bigint; // inclusive
+  prefix: number; // CIDR prefix length (0–128) — larger = more specific
   data: IpEnrichment;
 }
 
@@ -63,33 +70,94 @@ export function parseCidr(cidr: string): { start: number; end: number; prefix: n
   return { start, end, prefix };
 }
 
+/** Parse an IPv6 string to a 128-bit BigInt, or null if invalid. Handles
+ *  `::` zero-compression and a trailing IPv4-mapped tail (`::ffff:1.2.3.4`). */
+export function ipv6ToBigInt(ip: string): bigint | null {
+  let s = ip.trim();
+  if (s === "" || s.includes(":::")) return null;
+  // A trailing embedded IPv4 (e.g. ::ffff:1.2.3.4) → two hextets.
+  const lastColon = s.lastIndexOf(":");
+  if (s.slice(lastColon + 1).includes(".")) {
+    const v4 = ipv4ToInt(s.slice(lastColon + 1));
+    if (v4 === null) return null;
+    const hi = (v4 >>> 16) & 0xffff;
+    const lo = v4 & 0xffff;
+    s = s.slice(0, lastColon + 1) + hi.toString(16) + ":" + lo.toString(16);
+  }
+
+  const halves = s.split("::");
+  if (halves.length > 2) return null; // at most one "::"
+  const parseGroups = (part: string): number[] | null => {
+    if (part === "") return [];
+    const groups = part.split(":");
+    const out: number[] = [];
+    for (const g of groups) {
+      if (!/^[0-9a-fA-F]{1,4}$/.test(g)) return null;
+      out.push(parseInt(g, 16));
+    }
+    return out;
+  };
+
+  let hextets: number[];
+  if (halves.length === 2) {
+    const left = parseGroups(halves[0]);
+    const right = parseGroups(halves[1]);
+    if (left === null || right === null) return null;
+    const fill = 8 - left.length - right.length;
+    if (fill < 1) return null; // "::" must stand for at least one zero group
+    hextets = [...left, ...Array(fill).fill(0), ...right];
+  } else {
+    const all = parseGroups(s);
+    if (all === null) return null;
+    hextets = all;
+  }
+  if (hextets.length !== 8) return null;
+
+  let n = 0n;
+  for (const h of hextets) n = (n << 16n) | BigInt(h);
+  return n;
+}
+
+/** Parse an IPv6 CIDR (or bare IPv6 = /128) to an inclusive BigInt range. */
+export function parseCidr6(cidr: string): { start: bigint; end: bigint; prefix: number } | null {
+  const [addr, prefixStr] = cidr.trim().split("/");
+  const base = ipv6ToBigInt(addr);
+  if (base === null) return null;
+  const prefix = prefixStr === undefined ? 128 : Number(prefixStr);
+  if (!Number.isInteger(prefix) || prefix < 0 || prefix > 128) return null;
+  const hostBits = BigInt(128 - prefix);
+  const full = (1n << 128n) - 1n;
+  const mask = prefix === 0 ? 0n : (full << hostBits) & full;
+  const start = base & mask;
+  const end = start | ((1n << hostBits) - 1n);
+  return { start, end, prefix };
+}
+
 export class IpEnrichmentDataset {
   private ranges: Range[] = [];
-  /** Rows that couldn't be parsed (bad CIDR, IPv6, malformed) — surfaced for diagnostics. */
+  private ranges6: Range6[] = [];
+  /** Rows that couldn't be parsed (bad CIDR, malformed) — surfaced for diagnostics. */
   readonly skipped: number;
   readonly size: number;
 
-  private constructor(ranges: Range[], skipped: number) {
+  private constructor(ranges: Range[], ranges6: Range6[], skipped: number) {
     // Sort by start asc; lookup picks the most specific (largest prefix)
     // containing range so nested/overlapping rows resolve deterministically.
     this.ranges = ranges.sort((a, b) => a.start - b.start || a.end - b.end);
+    this.ranges6 = ranges6.sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : a.end < b.end ? -1 : a.end > b.end ? 1 : 0));
     this.skipped = skipped;
-    this.size = ranges.length;
+    this.size = ranges.length + ranges6.length;
   }
 
   static fromCsv(text: string): IpEnrichmentDataset {
     const ranges: Range[] = [];
+    const ranges6: Range6[] = [];
     let skipped = 0;
     for (const rawLine of text.split(/\r?\n/)) {
       const line = rawLine.trim();
       if (!line || line.startsWith("#")) continue;
       const cells = line.split(",").map((c) => c.trim());
       if (cells[0].toLowerCase() === "network") continue; // header
-      const r = parseCidr(cells[0]);
-      if (!r) {
-        skipped++;
-        continue;
-      }
       const data: IpEnrichment = {};
       if (cells[1]) data.country = cells[1];
       if (cells[2]) data.city = cells[2];
@@ -98,13 +166,26 @@ export class IpEnrichmentDataset {
       if (cells[5] !== undefined && cells[5] !== "") {
         data.hosting = ["true", "1", "yes"].includes(cells[5].toLowerCase());
       }
-      ranges.push({ start: r.start, end: r.end, prefix: r.prefix, data });
+      // Route by family: a ':' in the network cell means IPv6.
+      if (cells[0].includes(":")) {
+        const r6 = parseCidr6(cells[0]);
+        if (!r6) { skipped++; continue; }
+        ranges6.push({ start: r6.start, end: r6.end, prefix: r6.prefix, data });
+      } else {
+        const r = parseCidr(cells[0]);
+        if (!r) { skipped++; continue; }
+        ranges.push({ start: r.start, end: r.end, prefix: r.prefix, data });
+      }
     }
-    return new IpEnrichmentDataset(ranges, skipped);
+    return new IpEnrichmentDataset(ranges, ranges6, skipped);
   }
 
-  /** Look up an IPv4 string. Returns the most specific matching row, or null. */
+  /** Look up an IPv4 or IPv6 string. Returns the most specific matching row, or null. */
   lookup(ip: string): IpEnrichment | null {
+    return ip.includes(":") ? this.lookup6(ip) : this.lookup4(ip);
+  }
+
+  private lookup4(ip: string): IpEnrichment | null {
     const n = ipv4ToInt(ip);
     if (n === null) return null;
     let best: Range | null = null;
@@ -113,6 +194,17 @@ export class IpEnrichmentDataset {
     // (largest prefix) range that contains the IP.
     for (const r of this.ranges) {
       if (r.start > n) break; // sorted by start asc — all remaining ranges start after n
+      if (n <= r.end && (best === null || r.prefix > best.prefix)) best = r;
+    }
+    return best ? { ...best.data } : null;
+  }
+
+  private lookup6(ip: string): IpEnrichment | null {
+    const n = ipv6ToBigInt(ip);
+    if (n === null) return null;
+    let best: Range6 | null = null;
+    for (const r of this.ranges6) {
+      if (r.start > n) break; // sorted by start asc
       if (n <= r.end && (best === null || r.prefix > best.prefix)) best = r;
     }
     return best ? { ...best.data } : null;

--- a/mcp-server/src/tools/enrich-ips.test.ts
+++ b/mcp-server/src/tools/enrich-ips.test.ts
@@ -47,4 +47,18 @@ describe("enrichIpsHandler (R6, issue #415 Gap B)", () => {
     assert.deepEqual(out.summary, { total: 3, matched: 1, unmatched: 1, invalid: 1 });
     assert.equal(out.datasetSize, 2);
   });
+
+  it("accepts IPv6 inputs and enriches them (not counted invalid)", () => {
+    const ds6 = IpEnrichmentDataset.fromCsv(
+      ["2001:db8::/32,US,,AS14618,Example Cloud,true", "1.2.3.0/24,DE,Berlin,AS3320,Example ISP,false"].join("\n"),
+    );
+    const out = parse(enrichIpsHandler(ds6, { ips: ["2001:db8::1", "2606:4700::1", "1.2.3.9"] }));
+    const v6hit = out.results.find((r: any) => r.ip === "2001:db8::1");
+    assert.equal(v6hit.found, true);
+    assert.equal(v6hit.org, "Example Cloud");
+    const v6miss = out.results.find((r: any) => r.ip === "2606:4700::1");
+    assert.equal(v6miss.found, false);
+    // A valid-but-unmatched IPv6 is "unmatched", NOT "invalid".
+    assert.deepEqual(out.summary, { total: 3, matched: 2, unmatched: 1, invalid: 0 });
+  });
 });

--- a/mcp-server/src/tools/enrich-ips.ts
+++ b/mcp-server/src/tools/enrich-ips.ts
@@ -1,4 +1,4 @@
-import { IpEnrichmentDataset, ipv4ToInt } from "../enrich/ip-dataset.js";
+import { IpEnrichmentDataset, ipv4ToInt, ipv6ToBigInt } from "../enrich/ip-dataset.js";
 import { defaultContext, type RequestContext } from "../context.js";
 import { errorResponse } from "./validation.js";
 
@@ -10,10 +10,15 @@ import { errorResponse } from "./validation.js";
 export const enrichIpsDefinition = {
   name: "enrich_ips" as const,
   description:
-    "Resolve a batch of IPv4 addresses to geo (country/city), ASN/org, and a hosting/proxy flag from a local offline dataset. Use this to answer 'where are these visitors from / which are bots or datacenter IPs' without an out-of-band geo API call. Requires the operator to have configured an offline dataset (OMCP_IP_ENRICH_FILE); returns a clear notice otherwise.",
+    "Resolve a batch of IPv4 or IPv6 addresses to geo (country/city), ASN/org, and a hosting/proxy flag from a local offline dataset. Use this to answer 'where are these visitors from / which are bots or datacenter IPs' without an out-of-band geo API call. Requires the operator to have configured an offline dataset (OMCP_IP_ENRICH_FILE); returns a clear notice otherwise.",
 };
 
 const MAX_IPS = 1000;
+
+/** A string is a valid IP if it parses as either IPv4 or IPv6. */
+function isValidIp(ip: string): boolean {
+  return ipv4ToInt(ip) !== null || ipv6ToBigInt(ip) !== null;
+}
 
 export interface EnrichIpsArgs {
   ips?: string[];
@@ -46,7 +51,7 @@ export function enrichIpsHandler(
   }
   const ips = args.ips;
   if (!Array.isArray(ips) || ips.length === 0) {
-    return errorResponse("`ips` must be a non-empty array of IPv4 address strings.");
+    return errorResponse("`ips` must be a non-empty array of IPv4 or IPv6 address strings.");
   }
   if (ips.length > MAX_IPS) {
     return errorResponse(`Too many IPs (${ips.length}); max ${MAX_IPS} per call.`);
@@ -56,7 +61,7 @@ export function enrichIpsHandler(
   let invalid = 0;
   let matched = 0;
   for (const ip of ips) {
-    if (typeof ip !== "string" || ipv4ToInt(ip) === null) {
+    if (typeof ip !== "string" || !isValidIp(ip)) {
       invalid++;
       results.push({ ip: String(ip), found: false });
       continue;

--- a/scripts/build-ip-enrich-csv.mjs
+++ b/scripts/build-ip-enrich-csv.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+// build-ip-enrich-csv.mjs — turn a licensed MaxMind GeoLite2 export into the
+// enrich_ips CSV (network,country,city,asn,org,hosting) that OMCP_IP_ENRICH_FILE
+// expects. The geo/ASN DATA stays on the operator's machine — this only
+// reshapes a file you already license; nothing is bundled into the image and
+// there is no network call, so the air-gapped guarantee is preserved.
+//
+// Dependency-free (own RFC-4180 CSV parser — MaxMind org names contain commas),
+// so it runs with plain `node` and needs no npm install. Handles IPv4 and IPv6.
+//
+// Usage:
+//   node scripts/build-ip-enrich-csv.mjs \
+//     --city-blocks GeoLite2-City-Blocks-IPv4.csv \
+//     --city-blocks GeoLite2-City-Blocks-IPv6.csv \
+//     --locations   GeoLite2-City-Locations-en.csv \
+//     --asn-blocks  GeoLite2-ASN-Blocks-IPv4.csv \
+//     --asn-blocks  GeoLite2-ASN-Blocks-IPv6.csv \
+//     --out enrich.csv
+//
+// --city-blocks / --asn-blocks may be repeated (v4 + v6). --locations and the
+// ASN files are optional: with only city blocks you get network,country,city;
+// add ASN to fill asn/org. The `hosting` flag is left blank — GeoLite2 City/ASN
+// don't carry it (it lives in the paid Anonymous-IP DB); set it yourself if you
+// have that data. ASN is matched by each block's network address against the
+// ASN range table (ASN ranges are coarser, so this is exact in practice).
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+// ---- argv ----
+function parseArgs(argv) {
+  const out = { cityBlocks: [], asnBlocks: [], locations: null, out: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--city-blocks") out.cityBlocks.push(argv[++i]);
+    else if (a === "--asn-blocks") out.asnBlocks.push(argv[++i]);
+    else if (a === "--locations") out.locations = argv[++i];
+    else if (a === "--out") out.out = argv[++i];
+    else if (a === "--help" || a === "-h") out.help = true;
+    else throw new Error(`unknown arg: ${a}`);
+  }
+  return out;
+}
+
+// ---- RFC-4180 CSV: handles "quoted, fields" with embedded commas/quotes ----
+function parseCsvLine(line) {
+  const cells = [];
+  let cur = "";
+  let inQ = false;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (inQ) {
+      if (c === '"') {
+        if (line[i + 1] === '"') { cur += '"'; i++; }
+        else inQ = false;
+      } else cur += c;
+    } else if (c === '"') inQ = true;
+    else if (c === ",") { cells.push(cur); cur = ""; }
+    else cur += c;
+  }
+  cells.push(cur);
+  return cells;
+}
+
+function* csvRows(text) {
+  // Split on newlines outside quotes. MaxMind has no embedded newlines, so a
+  // line-based split is safe and keeps memory low for large files.
+  for (const raw of text.split(/\r?\n/)) {
+    if (raw === "") continue;
+    yield parseCsvLine(raw);
+  }
+}
+
+function indexOfHeader(header, name) {
+  const i = header.indexOf(name);
+  if (i < 0) throw new Error(`column "${name}" not found (have: ${header.join(", ")})`);
+  return i;
+}
+
+// ---- IP math (mirrors src/enrich/ip-dataset.ts; kept dependency-free here) ----
+function ipv4ToInt(ip) {
+  const p = ip.split(".");
+  if (p.length !== 4) return null;
+  let n = 0;
+  for (const o of p) {
+    if (!/^\d{1,3}$/.test(o) || +o > 255) return null;
+    n = n * 256 + +o;
+  }
+  return n >>> 0;
+}
+function ipv6ToBigInt(ip) {
+  let s = ip.trim();
+  if (s === "" || s.includes(":::")) return null;
+  const lc = s.lastIndexOf(":");
+  if (s.slice(lc + 1).includes(".")) {
+    const v4 = ipv4ToInt(s.slice(lc + 1));
+    if (v4 === null) return null;
+    s = s.slice(0, lc + 1) + ((v4 >>> 16) & 0xffff).toString(16) + ":" + (v4 & 0xffff).toString(16);
+  }
+  const halves = s.split("::");
+  if (halves.length > 2) return null;
+  const groups = (part) => {
+    if (part === "") return [];
+    const g = part.split(":");
+    const o = [];
+    for (const x of g) { if (!/^[0-9a-fA-F]{1,4}$/.test(x)) return null; o.push(parseInt(x, 16)); }
+    return o;
+  };
+  let hex;
+  if (halves.length === 2) {
+    const l = groups(halves[0]); const r = groups(halves[1]);
+    if (l === null || r === null) return null;
+    const fill = 8 - l.length - r.length;
+    if (fill < 1) return null;
+    hex = [...l, ...Array(fill).fill(0), ...r];
+  } else { const all = groups(s); if (all === null) return null; hex = all; }
+  if (hex.length !== 8) return null;
+  let n = 0n;
+  for (const h of hex) n = (n << 16n) | BigInt(h);
+  return n;
+}
+/** Start address of a network as a comparable BigInt (v4 mapped into v6 space-agnostic key). */
+function netKey(network) {
+  if (network.includes(":")) {
+    const base = ipv6ToBigInt(network.split("/")[0]);
+    return base === null ? null : { v6: true, key: base };
+  }
+  const base = ipv4ToInt(network.split("/")[0]);
+  return base === null ? null : { v6: false, key: BigInt(base) };
+}
+
+// ---- ASN range table for network-start lookup ----
+function buildAsnRanges(files) {
+  const v4 = []; const v6 = [];
+  for (const f of files) {
+    const text = readFileSync(f, "utf8");
+    const it = csvRows(text);
+    const header = it.next().value;
+    const netI = indexOfHeader(header, "network");
+    const asnI = indexOfHeader(header, "autonomous_system_number");
+    const orgI = indexOfHeader(header, "autonomous_system_organization");
+    for (const row of it) {
+      const network = row[netI];
+      if (!network) continue;
+      const k = netKey(network);
+      if (!k) continue;
+      const rec = { start: k.key, asn: row[asnI] ? `AS${row[asnI]}` : "", org: row[orgI] || "" };
+      (k.v6 ? v6 : v4).push(rec);
+    }
+  }
+  v4.sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0));
+  v6.sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0));
+  return { v4, v6 };
+}
+/** Largest range start <= key (binary search) — the ASN block containing the address. */
+function asnFor(ranges, v6, key) {
+  const arr = v6 ? ranges.v6 : ranges.v4;
+  let lo = 0, hi = arr.length - 1, ans = -1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (arr[mid].start <= key) { ans = mid; lo = mid + 1; } else hi = mid - 1;
+  }
+  return ans >= 0 ? arr[ans] : null;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || args.cityBlocks.length === 0 || !args.out) {
+    console.error("usage: build-ip-enrich-csv.mjs --city-blocks <f>[ --city-blocks <f6>] [--locations <f>] [--asn-blocks <f>...] --out <f>");
+    process.exit(args.help ? 0 : 2);
+  }
+
+  // locations: geoname_id → {country, city}
+  const loc = new Map();
+  if (args.locations) {
+    const text = readFileSync(args.locations, "utf8");
+    const it = csvRows(text);
+    const header = it.next().value;
+    const idI = indexOfHeader(header, "geoname_id");
+    const ccI = indexOfHeader(header, "country_iso_code");
+    const cityI = indexOfHeader(header, "city_name");
+    for (const row of it) {
+      if (!row[idI]) continue;
+      loc.set(row[idI], { country: row[ccI] || "", city: row[cityI] || "" });
+    }
+  }
+
+  const asn = args.asnBlocks.length ? buildAsnRanges(args.asnBlocks) : null;
+
+  const escapeCell = (v) => (v.includes(",") || v.includes('"') ? `"${v.replace(/"/g, '""')}"` : v);
+  const lines = ["network,country,city,asn,org,hosting"];
+  let rows = 0;
+
+  for (const f of args.cityBlocks) {
+    const text = readFileSync(f, "utf8");
+    const it = csvRows(text);
+    const header = it.next().value;
+    const netI = indexOfHeader(header, "network");
+    const geoI = indexOfHeader(header, "geoname_id");
+    for (const row of it) {
+      const network = row[netI];
+      if (!network) continue;
+      const k = netKey(network);
+      if (!k) continue;
+      const g = loc.get(row[geoI]) || { country: "", city: "" };
+      let a = { asn: "", org: "" };
+      if (asn) { const hit = asnFor(asn, k.v6, k.key); if (hit) a = hit; }
+      lines.push([network, g.country, g.city, a.asn, a.org, ""].map(escapeCell).join(","));
+      rows++;
+    }
+  }
+
+  writeFileSync(args.out, lines.join("\n") + "\n");
+  console.error(`wrote ${rows} rows to ${args.out}${asn ? " (with ASN/org)" : " (geo only — pass --asn-blocks to add ASN)"}`);
+}
+
+main();

--- a/scripts/build-ip-enrich-csv.test.mjs
+++ b/scripts/build-ip-enrich-csv.test.mjs
@@ -1,0 +1,79 @@
+// End-to-end tests for build-ip-enrich-csv.mjs. Spawns the real script
+// against synthetic MaxMind-shaped CSVs and asserts the enrich_ips output.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, writeFile, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = resolve(dirname(fileURLToPath(import.meta.url)), "build-ip-enrich-csv.mjs");
+
+const CITY_V4 = `network,geoname_id,registered_country_geoname_id,is_anonymous_proxy,is_satellite_provider,postal_code,latitude,longitude,accuracy_radius
+1.2.3.0/24,5391959,5391959,0,0,,37.77,-122.41,20
+10.0.0.0/8,2950159,2950159,0,0,,52.52,13.40,100`;
+
+const CITY_V6 = `network,geoname_id,registered_country_geoname_id,is_anonymous_proxy,is_satellite_provider,postal_code,latitude,longitude,accuracy_radius
+2001:db8::/32,5391959,5391959,0,0,,37.77,-122.41,20`;
+
+const LOCATIONS = `geoname_id,locale_code,continent_code,continent_name,country_iso_code,country_name,city_name
+5391959,en,NA,North America,US,United States,San Francisco
+2950159,en,EU,Europe,DE,Germany,Berlin`;
+
+// org name with an embedded comma → must be RFC-4180 quoted on the way in AND out.
+const ASN_V4 = `network,autonomous_system_number,autonomous_system_organization
+1.2.3.0/24,14618,"Amazon.com, Inc."
+10.0.0.0/8,3320,Deutsche Telekom`;
+
+async function run() {
+  const dir = await mkdtemp(join(tmpdir(), "ipenrich-"));
+  const f = (n) => join(dir, n);
+  await writeFile(f("city4.csv"), CITY_V4);
+  await writeFile(f("city6.csv"), CITY_V6);
+  await writeFile(f("loc.csv"), LOCATIONS);
+  await writeFile(f("asn4.csv"), ASN_V4);
+  const out = f("enrich.csv");
+  const r = spawnSync("node", [
+    SCRIPT,
+    "--city-blocks", f("city4.csv"),
+    "--city-blocks", f("city6.csv"),
+    "--locations", f("loc.csv"),
+    "--asn-blocks", f("asn4.csv"),
+    "--out", out,
+  ], { encoding: "utf8" });
+  const text = r.status === 0 ? await readFile(out, "utf8") : "";
+  return { r, text, dir };
+}
+
+test("converts MaxMind GeoLite2 City+ASN (v4 + v6) into enrich_ips CSV", async () => {
+  const { r, text, dir } = await run();
+  try {
+    assert.equal(r.status, 0, `exit ${r.status}: ${r.stderr}`);
+    const lines = text.trim().split("\n");
+    assert.equal(lines[0], "network,country,city,asn,org,hosting");
+
+    // v4 row joined geo (US/San Francisco) + ASN (quoted org with a comma)
+    const row1 = lines.find((l) => l.startsWith("1.2.3.0/24"));
+    assert.ok(row1, "v4 row present");
+    assert.match(row1, /^1\.2\.3\.0\/24,US,San Francisco,AS14618,"Amazon\.com, Inc\.",$/);
+
+    // v4 row 2: Berlin + Deutsche Telekom (unquoted, no comma)
+    const row2 = lines.find((l) => l.startsWith("10.0.0.0/8"));
+    assert.match(row2, /^10\.0\.0\.0\/8,DE,Berlin,AS3320,Deutsche Telekom,$/);
+
+    // v6 row joined geo (US/San Francisco), no ASN file match → blank asn/org
+    const row6 = lines.find((l) => l.startsWith("2001:db8::/32"));
+    assert.ok(row6, "v6 row present");
+    assert.match(row6, /^2001:db8::\/32,US,San Francisco,,,$/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("exits non-zero with usage when required args are missing", async () => {
+  const r = spawnSync("node", [SCRIPT, "--out", "x.csv"], { encoding: "utf8" });
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /usage:/);
+});


### PR DESCRIPTION
Closes the v3.3 candidate *"IPv6 support + bundled-dataset tooling for `enrich_ips`"*.

- **IPv6 in `enrich_ips`** — `ipv6ToBigInt` (`::` compression + IPv4-mapped tails) + `parseCidr6` (128-bit BigInt ranges); a separate v6 range table; lookup dispatches by family. IPv4 path unchanged. v6 CSV rows are now parsed, not skipped. Tool input accepts v4 **or** v6 (a valid-but-unmatched v6 is "unmatched", not "invalid").
- **Offline converter** `scripts/build-ip-enrich-csv.mjs` — dependency-free, reshapes a licensed **MaxMind GeoLite2** export (City + Locations + optional ASN, v4+v6) into the `enrich_ips` CSV. RFC-4180 parser (org names have commas). **Data stays operator-side; nothing bundled, no network call** — air-gapped guarantee intact.

Tests: v6 parse/cidr/lookup + v4/v6 independence + tool-level v6 + e2e converter spawn (added to `security.yml`). Docs updated. Reviewer-agent caught a real bug (validation not switched to the v4-or-v6 check) — fixed, 29/29 green. Part of the v3.3-candidates loop → v3.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)