### PR TITLE
feat(raw_query): per-credential gating via OMCP_KEY_RAW_QUERY

### DIFF
--- a/docs/raw-query.md
+++ b/docs/raw-query.md
@@ -9,14 +9,26 @@ default**.
 
 ## Enabling
 
+Two ways, and the effective gate is **either one** (`global OR
+per-credential`) — so enabling globally still works, and the
+per-credential form only *widens* access, never narrows a globally-enabled
+deployment.
+
 ```bash
+# Global — every caller may use raw_query.
 OMCP_RAW_QUERY=on      # also accepts: true, 1
+
+# Per-credential — only the named API-key credentials may use raw_query,
+# even with the global flag off. Needs OMCP_API_KEYS configured.
+OMCP_KEY_RAW_QUERY="agent,ci"
 ```
 
-When unset (the default) any call that passes `raw_query` is refused
-with a clear message — the param is still *advertised* in `tools/list`
-(so an agent can discover it and explain the requirement), but the
-server will not execute it.
+When neither is set (the default) any call that passes `raw_query` is
+refused with a clear message — the param is still *advertised* in
+`tools/list` (so an agent can discover it and explain the requirement),
+but the server will not execute it. Per-credential gating lets you hand a
+trusted automation credential the escape hatch while keeping anonymous /
+other sessions on the curated surface only.
 
 ## Usage
 

--- a/mcp-server/src/auth/credentials.test.ts
+++ b/mcp-server/src/auth/credentials.test.ts
@@ -20,7 +20,7 @@ describe("single-tenant auth primitive", () => {
     assert.equal(creds.length, 2);
     assert.deepEqual(
       creds[0],
-      { name: "ci", token: "tok_abc", allowedSources: undefined, bypassRedaction: undefined, tenant: undefined, productId: undefined }
+      { name: "ci", token: "tok_abc", allowedSources: undefined, bypassRedaction: undefined, allowRawQuery: undefined, tenant: undefined, productId: undefined }
     );
     assert.equal(creds[1].name, "key");
     assert.equal(creds[1].token, "tok_bare");
@@ -50,6 +50,22 @@ describe("single-tenant auth primitive", () => {
   it("OMCP_KEY_BYPASS_REDACTION absent → no key bypasses (least privilege default)", () => {
     const creds = loadCredentials({ OMCP_API_KEYS: "agent:tok1,ci:tok2" });
     for (const c of creds) assert.equal(c.bypassRedaction, undefined);
+  });
+
+  it("parses OMCP_KEY_RAW_QUERY → flags only the listed names", () => {
+    const creds = loadCredentials({
+      OMCP_API_KEYS: "agent:tok1,ci:tok2,unprivileged:tok3",
+      OMCP_KEY_RAW_QUERY: "agent, ci",
+    });
+    assert.equal(creds.find((c) => c.name === "agent")?.allowRawQuery, true);
+    assert.equal(creds.find((c) => c.name === "ci")?.allowRawQuery, true);
+    // Unlisted keys MUST be undefined (not false) so it only widens.
+    assert.equal(creds.find((c) => c.name === "unprivileged")?.allowRawQuery, undefined);
+  });
+
+  it("OMCP_KEY_RAW_QUERY absent → no key may raw_query per-credential (global flag still applies)", () => {
+    const creds = loadCredentials({ OMCP_API_KEYS: "agent:tok1,ci:tok2" });
+    for (const c of creds) assert.equal(c.allowRawQuery, undefined);
   });
 
   it("parses OMCP_KEY_TENANTS → assigns tenant to named keys; unlisted stays undefined (default)", () => {

--- a/mcp-server/src/auth/credentials.ts
+++ b/mcp-server/src/auth/credentials.ts
@@ -16,6 +16,11 @@
  *                  # via the bypass_redaction tool arg. Off by default
  *                  # for every key — pair with the redaction:bypass
  *                  # RBAC permission for the management-plane angle.
+ *   OMCP_KEY_RAW_QUERY="agent,ci"
+ *                  # optional comma-separated list of key NAMES allowed to
+ *                  # run raw_query even when the global OMCP_RAW_QUERY
+ *                  # capability is off. Effective gate = global OR per-key,
+ *                  # so it only widens; off by default for every key.
  *   OMCP_KEY_TENANTS="agent=acme;ci=bigco"
  *                  # optional per-key tenant assignment. Unlisted keys
  *                  # land in the "default" tenant — identical to the
@@ -45,6 +50,11 @@ export interface Credential {
    *  to explicitly set `bypass_redaction: true` in the tool args —
    *  this flag only authorises it; it never auto-disables redaction. */
   bypassRedaction?: boolean;
+  /** True when the operator opted this credential into running `raw_query`
+   *  even with the global OMCP_RAW_QUERY capability off. Configured via
+   *  OMCP_KEY_RAW_QUERY. The effective gate is `global OR per-credential` —
+   *  it only widens access, never narrows a globally-enabled deployment. */
+  allowRawQuery?: boolean;
   /** Tenant this credential belongs to. Omitted → DEFAULT_TENANT. */
   tenant?: string;
   /** Product id this credential is bound to. When set, /mcp tools/list
@@ -94,6 +104,7 @@ export function loadCredentials(env: NodeJS.ProcessEnv = process.env): Credentia
   if (!raw) return [];
   const keySources = parseKeySources(env.OMCP_KEY_SOURCES);
   const bypassNames = parseBypassSet(env.OMCP_KEY_BYPASS_REDACTION);
+  const rawQueryNames = parseBypassSet(env.OMCP_KEY_RAW_QUERY);
   const keyTenants = parseKeyTenants(env.OMCP_KEY_TENANTS);
   const keyProducts = parseKeyProducts(env.OMCP_KEY_PRODUCTS);
   const creds: Credential[] = [];
@@ -107,6 +118,7 @@ export function loadCredentials(env: NodeJS.ProcessEnv = process.env): Credentia
       token,
       allowedSources: keySources.get(name),
       bypassRedaction: bypassNames.has(name) || undefined,
+      allowRawQuery: rawQueryNames.has(name) || undefined,
       tenant: keyTenants.get(name) || undefined,
       productId: keyProducts.get(name) || undefined,
     });

--- a/mcp-server/src/context.test.ts
+++ b/mcp-server/src/context.test.ts
@@ -36,6 +36,13 @@ test("principalContext — passes allowedTools through; empty array → undefine
   assert.equal(ctx3.allowedTools, undefined);
 });
 
+test("principalContext — allowRawQuery passes through, off by default (R4 per-credential raw_query)", () => {
+  assert.equal(principalContext("agent").allowRawQuery, undefined);
+  assert.equal(principalContext("agent", undefined, {}).allowRawQuery, undefined);
+  assert.equal(principalContext("agent", undefined, { allowRawQuery: false }).allowRawQuery, undefined);
+  assert.equal(principalContext("agent", undefined, { allowRawQuery: true }).allowRawQuery, true);
+});
+
 test("defaultContext — no allowedTools (anonymous sees every tool, back-compat)", () => {
   const ctx = defaultContext();
   assert.equal(ctx.allowedTools, undefined);

--- a/mcp-server/src/context.ts
+++ b/mcp-server/src/context.ts
@@ -27,6 +27,12 @@ export interface RequestContext {
    *  tool call ALSO sets `bypass_redaction: true` in its args. Default
    *  false. Configured via OMCP_KEY_BYPASS_REDACTION. */
   allowBypassRedaction?: boolean;
+  /** When true, this credential may run `raw_query` even if the global
+   *  OMCP_RAW_QUERY capability is off. Per-credential gating (configured via
+   *  OMCP_KEY_RAW_QUERY) — the effective gate is `global OR per-credential`,
+   *  so a global enable still works and this only widens, never narrows.
+   *  Default false. */
+  allowRawQuery?: boolean;
   /** Tenant the request operates in. ALWAYS set — defaults to
    *  "default" for anonymous principals + missing-tenant credentials,
    *  preserving the single-namespace behaviour of pre-E7 deployments. */
@@ -63,13 +69,14 @@ export function defaultContext(opts: { allowBypassRedaction?: boolean } = {}): R
 export function principalContext(
   principalId: string,
   allowedSources?: string[],
-  opts: { allowBypassRedaction?: boolean; tenant?: string; allowedTools?: string[] } = {},
+  opts: { allowBypassRedaction?: boolean; allowRawQuery?: boolean; tenant?: string; allowedTools?: string[] } = {},
 ): RequestContext {
   return {
     principalId,
     auth: "apikey",
     allowedSources: allowedSources && allowedSources.length > 0 ? allowedSources : undefined,
     allowBypassRedaction: opts.allowBypassRedaction || undefined,
+    allowRawQuery: opts.allowRawQuery || undefined,
     tenant: normaliseTenant(opts.tenant),
     allowedTools: opts.allowedTools && opts.allowedTools.length > 0 ? opts.allowedTools : undefined,
     correlationId: randomUUID(),

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -713,7 +713,7 @@ async function main() {
     { title: "Query Metrics", readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     async (args) => {
       await enforceEntitledAccess(ctx, { tool: "query_metrics", source: (args as any)?.source, service: (args as any)?.service });
-      const result = await withToolMetrics("query_metrics", () => queryMetricsHandler(registry, args, ctx, { allowRawQuery: RAW_QUERY_ENABLED }));
+      const result = await withToolMetrics("query_metrics", () => queryMetricsHandler(registry, args, ctx, { allowRawQuery: RAW_QUERY_ENABLED || ctx.allowRawQuery === true }));
       return chargeTokenBudget(result, ctx, "query_metrics");
     }
   );
@@ -812,7 +812,7 @@ async function main() {
     { title: "Query Logs", readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     async (args) => {
       await enforceEntitledAccess(ctx, { tool: "query_logs", source: (args as any)?.source, service: (args as any)?.service });
-      const result = await withToolMetrics("query_logs", () => queryLogsHandler(registry, args, ctx, { allowRawQuery: RAW_QUERY_ENABLED }));
+      const result = await withToolMetrics("query_logs", () => queryLogsHandler(registry, args, ctx, { allowRawQuery: RAW_QUERY_ENABLED || ctx.allowRawQuery === true }));
       // Redact PII / secrets from the log payload before it crosses the
       // MCP boundary into the agent's context. Per-call bypass kicks in
       // only when BOTH (a) the credential is OMCP_KEY_BYPASS_REDACTION
@@ -3699,6 +3699,7 @@ async function main() {
     }
     return principalContext(cred.name, cred.allowedSources, {
       allowBypassRedaction: cred.bypassRedaction,
+      allowRawQuery: cred.allowRawQuery,
       tenant: cred.tenant,
       allowedTools,
     });
@@ -3942,6 +3943,7 @@ async function main() {
     return {
       ctx: principalContext(cred.name, cred.allowedSources, {
         allowBypassRedaction: cred.bypassRedaction,
+        allowRawQuery: cred.allowRawQuery,
         tenant: cred.tenant,
         allowedTools,
       }),

--- a/mcp-server/src/tools/query-logs.ts
+++ b/mcp-server/src/tools/query-logs.ts
@@ -80,7 +80,7 @@ export async function queryLogsHandler(
   const isRaw = !!args.raw_query;
   if (isRaw && !opts.allowRawQuery) {
     return errorResponse(
-      "raw_query is disabled. The operator must enable the raw-query capability (OMCP_RAW_QUERY=on) to run verbatim LogQL — it bypasses the curated log surface, so it is off by default."
+      "raw_query is disabled. The operator must enable the raw-query capability (OMCP_RAW_QUERY=on globally, or per-credential via OMCP_KEY_RAW_QUERY) to run verbatim LogQL — it bypasses the curated log surface, so it is off by default."
     );
   }
   if (isRaw && args.aggregate) {

--- a/mcp-server/src/tools/query-metrics.ts
+++ b/mcp-server/src/tools/query-metrics.ts
@@ -66,7 +66,7 @@ export async function queryMetricsHandler(
   const isRaw = !!args.raw_query;
   if (isRaw && !opts.allowRawQuery) {
     return errorResponse(
-      "raw_query is disabled. The operator must enable the raw-query capability (OMCP_RAW_QUERY=on) to run verbatim PromQL — it bypasses the curated metric surface, so it is off by default."
+      "raw_query is disabled. The operator must enable the raw-query capability (OMCP_RAW_QUERY=on globally, or per-credential via OMCP_KEY_RAW_QUERY) to run verbatim PromQL — it bypasses the curated metric surface, so it is off by default."
     );
   }
 


### PR DESCRIPTION
Closes the v3.3 candidate *"per-credential / RBAC gating for `raw_query`"*.

`raw_query` was global-only (`OMCP_RAW_QUERY=on`). Now a credential can be granted it individually via `OMCP_KEY_RAW_QUERY="agent,ci"` (credential **names**, not tokens) — mirroring the `OMCP_KEY_BYPASS_REDACTION` precedent exactly. **Effective gate = global OR per-credential**: only widens (a global enable still works; anonymous with neither stays gated off). Threaded credential → `ctx.allowRawQuery` → call-site `RAW_QUERY_ENABLED || ctx.allowRawQuery === true`; handler logic unchanged.

Tests: credential parse + principalContext passthrough (33 pass). Docs: raw-query.md. Reviewer-agent: **SHIP** (verified back-compat, no third ctx path drops the opt, no RBAC double-gate). Part of the v3.3-candidates loop → v3.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)