### PR TITLE
fix(tools): honest no-data/partial states across remaining tools (R5 audit)

### DIFF
--- a/mcp-server/src/tools/generate-postmortem.test.ts
+++ b/mcp-server/src/tools/generate-postmortem.test.ts
@@ -1,0 +1,24 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { ConnectorRegistry } from "../connectors/registry.js";
+import { generatePostmortemHandler } from "./generate-postmortem.js";
+
+// R5 — a post-mortem built from ZERO signal (no anomaly/traces/topology/log
+// backend) must label itself, not render as an authoritative finding.
+describe("generatePostmortemHandler — no-signal honesty (R5)", () => {
+  it("markdown leads with a 'no signal' banner when nothing was found", async () => {
+    const reg = new ConnectorRegistry(); // no backends → every primitive empty
+    const out = await generatePostmortemHandler(reg, { service: "ghost-service", duration: "1h" });
+    const md = out.content[0].text;
+    assert.match(md, /No signal in this window/i);
+    assert.match(md, /backends aren't configured/i);
+  });
+
+  it("json form carries explicit coverage flags + builtFromSignal=false", async () => {
+    const reg = new ConnectorRegistry();
+    const out = await generatePostmortemHandler(reg, { service: "ghost-service", duration: "1h", format: "json" });
+    const report = JSON.parse(out.content[0].text);
+    assert.equal(report.builtFromSignal, false);
+    assert.deepEqual(report.coverage, { anomalies: false, traces: false, topology: false, logs: false });
+  });
+});

--- a/mcp-server/src/tools/generate-postmortem.ts
+++ b/mcp-server/src/tools/generate-postmortem.ts
@@ -76,16 +76,36 @@ export async function generatePostmortemHandler(
     logHighlights,
   });
 
+  // Which primitives actually carried data. A post-mortem synthesised from
+  // ZERO signal still renders a full, authoritative-looking document — an
+  // on-call could paste it into a ticket as if it were a real finding. Make
+  // the coverage explicit so an empty report is self-labelling (the
+  // "absent ≠ zero" class, cf. #453/#462).
+  const coverage = {
+    anomalies: anomalies.length > 0,
+    traces: traces.length > 0,
+    topology: blastRadius.nodes.length > 0,
+    logs: logHighlights.length > 0,
+  };
+  const anySignal = Object.values(coverage).some(Boolean);
+  const reportWithCoverage = { ...report, coverage, builtFromSignal: anySignal };
+
   if ((args.format || "markdown").toLowerCase() === "json") {
     return {
-      content: [{ type: "text" as const, text: JSON.stringify(report) }],
+      content: [{ type: "text" as const, text: JSON.stringify(reportWithCoverage) }],
       isError: false,
     };
   }
-  // Default: return the markdown body. The structured sections live
-  // in JSON if the caller asked for them.
+  // Default: return the markdown body. When there was no signal at all, lead
+  // with a banner so the document isn't mistaken for a real finding.
+  const banner = anySignal
+    ? ""
+    : "> ⚠️ **No signal in this window.** This report was built from zero anomalies, traces, " +
+      "topology, and log highlights. Either the window was genuinely clean, or the relevant " +
+      "backends aren't configured/writing (anomaly-history sink, traces connector, topology " +
+      "connector). Verify coverage before relying on this.\n\n";
   return {
-    content: [{ type: "text" as const, text: report.markdown }],
+    content: [{ type: "text" as const, text: banner + report.markdown }],
     isError: false,
   };
 }

--- a/mcp-server/src/tools/handlers.test.ts
+++ b/mcp-server/src/tools/handlers.test.ts
@@ -166,6 +166,40 @@ describe("listServicesHandler", () => {
     const data = JSON.parse(result.content[0].text);
     assert.equal(data.total, 0);
   });
+
+  it("no backends configured → note distinguishes 'none configured' from 'zero services' (R5)", async () => {
+    const data = JSON.parse((await listServicesHandler(new ConnectorRegistry(), {})).content[0].text);
+    assert.equal(data.total, 0);
+    assert.match(data.note, /No observability backends are configured/i);
+  });
+
+  it("all sources fail discovery → note + not a silent 'zero services' (R5)", async () => {
+    const reg = createRegistryWithMocks([
+      createMockConnector({ name: "prom1", type: "prometheus", signalType: "metrics", listServices: async () => { throw new Error("down"); } }),
+    ]);
+    const data = JSON.parse((await listServicesHandler(reg, {})).content[0].text);
+    assert.equal(data.total, 0);
+    assert.match(data.note, /failed on all 1 configured source/i);
+  });
+
+  it("partial source failure → result is flagged partial with the failed source (R5)", async () => {
+    const reg = createRegistryWithMocks([
+      createMockConnector({ name: "prom1", type: "prometheus", signalType: "metrics", listServices: async () => { throw new Error("down"); } }),
+      createMockConnector({ name: "loki1", type: "loki", signalType: "logs", listServices: async () => [{ name: "order-service", source: "loki1", signalType: "logs" }] }),
+    ]);
+    const data = JSON.parse((await listServicesHandler(reg, {})).content[0].text);
+    assert.equal(data.total, 1);
+    assert.equal(data.partial, true);
+    assert.deepEqual(data.failedSources, ["prom1"]);
+  });
+});
+
+describe("listSourcesHandler — no-data honesty (R5)", () => {
+  it("no backends configured → explanatory note, not a bare empty list", async () => {
+    const data = JSON.parse((await listSourcesHandler(new ConnectorRegistry())).content[0].text);
+    assert.deepEqual(data.sources, []);
+    assert.match(data.note, /No observability backends are configured/i);
+  });
 });
 
 describe("detectAnomaliesHandler — fleet coverage (issue #453B)", () => {

--- a/mcp-server/src/tools/list-services.ts
+++ b/mcp-server/src/tools/list-services.ts
@@ -25,6 +25,10 @@ export async function listServicesHandler(
   // Tenant-scoped: only consult sources the caller can see.
   const connectors = registry.getByTenant(ctx.tenant);
   const allServices: ServiceInfo[] = [];
+  // Track per-connector discovery failures so an empty result isn't silently
+  // partial — a down source must not make half the fleet vanish without a
+  // signal (the "absent ≠ zero" class, cf. #453).
+  const failedSources: string[] = [];
 
   for (const connector of connectors) {
     try {
@@ -32,6 +36,7 @@ export async function listServicesHandler(
       allServices.push(...services);
     } catch (err) {
       console.error(`Failed to list services from ${connector.name}:`, err);
+      failedSources.push(connector.name);
     }
   }
 
@@ -66,11 +71,36 @@ export async function listServicesHandler(
     services = services.filter((s) => s.name.toLowerCase().includes(f));
   }
 
+  // An empty result is ambiguous — say *why* so an agent doesn't read it as
+  // "this environment has no services". Distinguish: no backends configured,
+  // discovery failed on some/all sources, or genuinely none discovered.
+  let note: string | undefined;
+  if (connectors.length === 0) {
+    note = "No observability backends are configured for this tenant — add one via the Sources tab or config/sources.yaml. This is not 'zero services'.";
+  } else if (failedSources.length === connectors.length) {
+    note = `Service discovery failed on all ${connectors.length} configured source(s) (${failedSources.join(", ")}) — the empty result is an error, not 'zero services'. Check source health via list_sources.`;
+  } else if (services.length === 0 && !args.filter) {
+    note = "No services discovered — the configured backend(s) returned none in this tenant.";
+  }
+
   return {
     content: [
       {
         type: "text" as const,
-        text: JSON.stringify({ services, total: services.length }, null, 2),
+        text: JSON.stringify(
+          {
+            services,
+            total: services.length,
+            // Only present when some (but not all) sources failed — a partial
+            // result the caller should know is incomplete.
+            ...(failedSources.length > 0 && failedSources.length < connectors.length
+              ? { partial: true, failedSources }
+              : {}),
+            ...(note ? { note } : {}),
+          },
+          null,
+          2,
+        ),
       },
     ],
   };

--- a/mcp-server/src/tools/list-sources.ts
+++ b/mcp-server/src/tools/list-sources.ts
@@ -30,11 +30,19 @@ export async function listSourcesHandler(
     latencyMs: healthResults[c.name]?.latencyMs,
   }));
 
+  // An empty list is ambiguous on its own — name the cause so an agent
+  // doesn't read it as a transient/permission blip (the "absent ≠ zero"
+  // class). When nothing is configured, say so explicitly.
+  const note =
+    sources.length === 0
+      ? "No observability backends are configured for this tenant. Add one via the Sources tab or config/sources.yaml — this is 'none configured', not a query error."
+      : undefined;
+
   return {
     content: [
       {
         type: "text" as const,
-        text: JSON.stringify({ sources }, null, 2),
+        text: JSON.stringify({ sources, ...(note ? { note } : {}) }, null, 2),
       },
     ],
   };

--- a/mcp-server/src/tools/topology.test.ts
+++ b/mcp-server/src/tools/topology.test.ts
@@ -244,6 +244,17 @@ describe("get_blast_radius tool", () => {
     assert.match(out.error, /No resource found/);
   });
 
+  it("no topology connector → explicit note, not a misleading 'resource not found' (R5)", async () => {
+    // An empty registry has no topology source. The cause is "no graph", not
+    // "wrong name" — the response must say so rather than blame the resource.
+    const reg = new ConnectorRegistry(new PluginLoader());
+    const result = await getBlastRadiusHandler(reg, { resource: "anything" });
+    assert.equal((result as { isError?: boolean }).isError, true);
+    const out = parseTool(result);
+    assert.match(out.note, /No topology-capable connector is configured/i);
+    assert.ok(!out.error || !/No resource found/.test(out.error), "must not misattribute to a not-found name");
+  });
+
   it("uses ownership root, not direct owner, when grouping co-tenants", async () => {
     // api-aaa is OWNED_BY a ReplicaSet which is OWNED_BY a Deployment.
     // The blast-radius should bucket api-aaa under the Deployment, not the RS.

--- a/mcp-server/src/tools/topology.ts
+++ b/mcp-server/src/tools/topology.ts
@@ -226,6 +226,28 @@ export async function getBlastRadiusHandler(
   ctx: RequestContext = defaultContext(),
 ) {
   const agg = await aggregateTopology(registry, ctx.tenant);
+
+  // No topology-capable connector → the resource can't be found because there
+  // IS no graph, not because the name is wrong. Say so explicitly instead of a
+  // generic "not found" that misattributes the cause (the "absent ≠ zero"
+  // class, consistent with get_topology's empty-graph note).
+  if (agg.sources.length === 0) {
+    return {
+      isError: true,
+      content: [{
+        type: "text" as const,
+        text: JSON.stringify({
+          resource: args.resource,
+          hosts: [],
+          note:
+            "No topology-capable connector is configured, so there is no blast radius to compute. " +
+            "Add a topology source (the built-in `kubernetes` connector, or aws/gcp/istio/linkerd/consul) " +
+            "— a metrics/logs-only deployment has no topology graph. This is not 'resource not found'.",
+        }, null, 2),
+      }],
+    };
+  }
+
   const found = resolveResource(args.resource, agg.resources);
   if ("error" in found) {
     return {


### PR DESCRIPTION
A systematic sweep for the **"absent ≠ zero / silent-partial"** class (behind #453/#462) across all 12 tools found 4 remaining gaps — all fixed additively (success-path output unchanged):

| Tool | Before | After |
|------|--------|-------|
| `list_services` | bare `total:0` (no-backends = failed = empty, indistinguishable; per-source failures only logged) | `note` names the cause; `partial:true`+`failedSources[]` on partial failure |
| `list_sources` | bare `[]` | `note` when nothing configured |
| `get_blast_radius` | generic "resource not found" with no topology connector | explicit "no topology connector" note |
| `generate_postmortem` | full authoritative report from zero signal | `coverage`+`builtFromSignal`; "no signal" banner when empty |

Tests for each (40 pass). Reviewer-agent: **SHIP** (all additive, mutually-correct branches, honest tests). Closes the proactive-quality slice of the v3.3-candidates loop → v3.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)