### PR TITLE
chore(release): v3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,66 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.4.0] — 2026-06-11
+
+Roadmap-candidate release — closes two v3.3 candidates and proactively
+hardens the remaining tools against the "absent ≠ zero" empty-state class
+(the root of #453/#462) before it could be reported again. All additive /
+opt-in; migrating from 3.3 is non-breaking.
+
+### Added
+
+- **IPv6 in `enrich_ips` + an offline dataset converter** (v3.3 candidate).
+  `enrich_ips` now resolves IPv6 as well as IPv4 (128-bit longest-prefix
+  lookup, `::` compression and IPv4-mapped tails parse); v6 rows in the
+  dataset are loaded, not skipped, and the tool accepts v6 inputs.
+  `scripts/build-ip-enrich-csv.mjs` reshapes a licensed **MaxMind
+  GeoLite2** export (City + Locations + optional ASN, v4 + v6) into the
+  `enrich_ips` CSV — dependency-free, RFC-4180-aware. The geo/ASN data
+  stays operator-side; nothing is bundled and there is no network call,
+  preserving the air-gapped guarantee. See [ip-enrichment.md](docs/ip-enrichment.md).
+- **Per-credential `raw_query` gating** (v3.3 candidate). `raw_query` was a
+  global-only capability (`OMCP_RAW_QUERY=on`); a credential can now be
+  granted it individually via `OMCP_KEY_RAW_QUERY="agent,ci"` (credential
+  names, mirroring `OMCP_KEY_BYPASS_REDACTION`). Effective gate is
+  `global OR per-credential` — it only widens, never narrows a
+  globally-enabled deployment. See [raw-query.md](docs/raw-query.md).
+
+### Fixed
+
+- **Honest no-data / partial states across the remaining tools** (proactive
+  sweep of the #453/#462 class):
+  - `list_services` distinguishes *no backends configured* / *discovery
+    failed on all sources* / *genuinely none* via a `note`, and surfaces
+    `partial:true` + `failedSources[]` when only some sources fail
+    (previously a down source silently halved the fleet).
+  - `list_sources` adds an explanatory `note` when nothing is configured.
+  - `get_blast_radius` returns an explicit "no topology connector" note
+    when no topology source is configured, instead of a generic
+    "resource not found" that misattributed the cause.
+  - `generate_postmortem` computes `coverage{anomalies,traces,topology,logs}`
+    + `builtFromSignal` and leads the markdown with a banner when the report
+    was built from zero signal — so it isn't mistaken for a real finding.
+
+### Changed
+
+- **ROADMAP reconciled** against shipped state — the stale `Next`/`Later`
+  vision lists (and a duplicate `v3.0 — next` block) had items that already
+  shipped (verifiable offline, query_traces, plugin SDK on npm, multi-tenant,
+  auto-postmortems, embeddable analysis library); these moved to the landed
+  sections. A dead internal anchor and two links to a private directory were
+  removed.
+- The `hash-password` policy-sync test no longer emits a spurious failure
+  under the docker-first partial mount — it skips when the repo-root script
+  is unreachable, but still asserts in CI (full checkout).
+
+### Notes
+
+- `MetricResult.summary`/`MetricGroup.summary` have been nullable since
+  3.3.2 (the #462 no-data fix); no further type change here.
+- The SDK (`@thotischner/observability-mcp-sdk`) is unchanged — these are
+  gateway tool-surface and tooling changes; the plugin contract did not move.
+
 ## [3.3.2] — 2026-06-11
 
 Agent-feedback patch — two more reports against 3.3.1 (#462 and the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,15 +34,22 @@ real-world feedback in issue #415. All additive / opt-in. See
 - ✅ `get_topology` explicit no-connector note (issue #415, signal vs. silence)
 - ✅ `query_logs` `labels`/`aggregate` made reachable over MCP (3.1.1 hotfix — 3.1.0 ship gap)
 
-### v3.3 — candidates
+## v3.4 — shipped 2026-06-11
+
+Closes two v3.3 candidates and hardens the remaining tools against the
+"absent ≠ zero" empty-state class. See [CHANGELOG.md](CHANGELOG.md).
+
+- ✅ IPv6 in `enrich_ips` + an offline MaxMind GeoLite2 → CSV converter (`scripts/build-ip-enrich-csv.mjs`); data stays operator-side, air-gapped
+- ✅ Per-credential `raw_query` gating (`OMCP_KEY_RAW_QUERY`; effective gate = global OR per-credential)
+- ✅ Honest no-data/partial states across `list_services` / `list_sources` / `get_blast_radius` / `generate_postmortem`
+
+### v3.x — candidates
 
 Still open (vote via Discussions):
 
 - A custom postmortem template engine (persistence + the Postmortems UI tab already ship)
 - SCIM filter/search on the collection endpoints + a UI Provisioning sub-tab
 - Strict-mode MkDocs build (resolve the cross-repo link warnings)
-- IPv6 support + bundled-dataset tooling for `enrich_ips`
-- Per-credential / RBAC gating for `raw_query` (today it's a global capability flag)
 
 ## v3.0 — shipped 2026-06-06
 

--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,11 +4,11 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 2.3.2
+version: 2.4.0
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
-appVersion: "3.3.2"
+appVersion: "3.4.0"
 
 home: https://github.com/ThoTischner/observability-mcp
 sources:
@@ -51,16 +51,16 @@ annotations:
     url: https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc
   artifacthub.io/images: |
     - name: observability-mcp
-      image: ghcr.io/thotischner/observability-mcp:3.3.2
+      image: ghcr.io/thotischner/observability-mcp:3.4.0
       platforms:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
     - kind: changed
-      description: "appVersion → 3.3.2 (agent-feedback patch); chart points at the 3.3.2 image"
-    - kind: fixed
-      description: "query_metrics reports no-data honestly (summary:null + note) instead of false all-zeros for a service with no matching series (#462)"
-    - kind: fixed
-      description: "query_logs error/no-data responses report `window` (the look-back) not `duration`, so a fast failure isn't misread as a 5-minute hang (#452)"
+      description: "appVersion → 3.4.0 (roadmap-candidate release); chart points at the 3.4.0 image"
     - kind: added
-      description: "regression guard: label-filtered count_over_time emits well-formed sum-wrapped LogQL (#452)"
+      description: "enrich_ips now supports IPv6 + an offline MaxMind GeoLite2 → CSV converter (scripts/build-ip-enrich-csv.mjs); data stays operator-side, air-gapped"
+    - kind: added
+      description: "per-credential raw_query gating via OMCP_KEY_RAW_QUERY (effective gate = global OR per-credential; only widens)"
+    - kind: fixed
+      description: "honest no-data/partial states: list_services (note + partial/failedSources), list_sources (note), get_blast_radius (no-topology-connector note), generate_postmortem (coverage + no-signal banner)"

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.3.2",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thotischner/observability-mcp",
-      "version": "3.3.2",
+      "version": "3.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.3.2",
+  "version": "3.4.0",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Roadmap-candidate release — bundles **five** merged slices into v3.4.0.

| Slice | What | PR |
|-------|------|-----|
| `enrich_ips` IPv6 + offline GeoLite2 → CSV converter | v3.3 candidate | #469 |
| per-credential `raw_query` gating (`OMCP_KEY_RAW_QUERY`) | v3.3 candidate | #470 |
| honest no-data/partial states (list_services/list_sources/get_blast_radius/generate_postmortem) | proactive #453/#462-class sweep | #471 |
| ROADMAP reconciled against shipped state | hygiene | #467 |
| hash-password test de-flaked under partial mount | CI hygiene | #468 |

Versions: mcp-server 3.3.2→**3.4.0** (minor — two additive features), helm chart 2.3.2→2.4.0 (appVersion 3.4.0). SDK unchanged. Full suite green (859 pass / 0 fail / 41 skip — hash-password now skips under the docker-first mount). Two v3.3 candidates moved to a v3.4-shipped ROADMAP section. Reviewer-agent: **SHIP**.

Merging auto-tags v3.4.0 → docker/npm/helm + MCP-registry publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)