### PR TITLE
docs(roadmap): strict MkDocs already ships — drop from candidates

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,7 +49,9 @@ Still open (vote via Discussions):
 
 - A custom postmortem template engine (persistence + the Postmortems UI tab already ship)
 - SCIM filter/search on the collection endpoints + a UI Provisioning sub-tab
-- Strict-mode MkDocs build (resolve the cross-repo link warnings)
+
+(The strict-mode MkDocs build already ships — `docs.yml` runs
+`mkdocs build --strict`, so a broken cross-repo link fails CI.)
 
 ## v3.0 — shipped 2026-06-06
 


### PR DESCRIPTION
The "strict-mode MkDocs build" v3.3 candidate is **already done** — `docs.yml` runs `mkdocs build --strict`, so a broken cross-repo link fails CI. Verified `mkdocs build --strict` is clean (exit 0, no warnings). Removed from the candidate list with a one-line pointer (roadmap hygiene, same class as #467).

Docs-only. First slice of the remaining-v3.3-candidates loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)