### PR TITLE
feat(scim): filter + pagination on Users/Groups collection endpoints

### DIFF
--- a/mcp-server/src/scim/query.test.ts
+++ b/mcp-server/src/scim/query.test.ts
@@ -1,0 +1,81 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseScimFilter, applyScimList } from "./query.js";
+
+describe("parseScimFilter", () => {
+  it("returns null for absent/empty filter", () => {
+    assert.equal(parseScimFilter(undefined), null);
+    assert.equal(parseScimFilter("   "), null);
+  });
+  it("parses string eq (case-insensitive op)", () => {
+    assert.deepEqual(parseScimFilter('userName eq "alice@x.com"'), { attr: "userName", op: "eq", value: "alice@x.com" });
+    assert.deepEqual(parseScimFilter('displayName EQ "Admins"'), { attr: "displayName", op: "eq", value: "Admins" });
+  });
+  it("parses boolean eq for active", () => {
+    assert.deepEqual(parseScimFilter("active eq true"), { attr: "active", op: "eq", value: true });
+    assert.deepEqual(parseScimFilter("active eq false"), { attr: "active", op: "eq", value: false });
+  });
+  it("throws scimUnsupported for non-eq operators / malformed", () => {
+    for (const f of ['userName co "a"', 'userName sw "a"', 'userName pr', 'garbage']) {
+      assert.throws(() => parseScimFilter(f), (e: any) => e.scimUnsupported === true, `expected unsupported for: ${f}`);
+    }
+  });
+});
+
+describe("applyScimList", () => {
+  const users = [
+    { id: "1", userName: "alice@x.com", active: true },
+    { id: "2", userName: "bob@x.com", active: false },
+    { id: "3", userName: "carol@x.com", active: true },
+  ];
+
+  it("no filter, no pagination → all rows, correct envelope", () => {
+    const r = applyScimList(users, {});
+    assert.equal(r.totalResults, 3);
+    assert.equal(r.startIndex, 1);
+    assert.equal(r.itemsPerPage, 3);
+    assert.equal(r.resources.length, 3);
+  });
+
+  it("eq filter matches case-insensitively on the value", () => {
+    const r = applyScimList(users, { filter: 'userName eq "ALICE@X.COM"' });
+    assert.equal(r.totalResults, 1);
+    assert.equal(r.resources[0].id, "1");
+  });
+
+  it("eq filter with no match → empty, totalResults 0 (not all rows)", () => {
+    const r = applyScimList(users, { filter: 'userName eq "nobody@x.com"' });
+    assert.equal(r.totalResults, 0);
+    assert.equal(r.resources.length, 0);
+  });
+
+  it("boolean eq filters on active", () => {
+    assert.equal(applyScimList(users, { filter: "active eq true" }).totalResults, 2);
+    assert.equal(applyScimList(users, { filter: "active eq false" }).totalResults, 1);
+  });
+
+  it("pagination: startIndex + count slice; totalResults is the pre-page count", () => {
+    const r = applyScimList(users, { startIndex: "2", count: "1" });
+    assert.equal(r.totalResults, 3);
+    assert.equal(r.startIndex, 2);
+    assert.equal(r.itemsPerPage, 1);
+    assert.equal(r.resources[0].id, "2");
+  });
+
+  it("count=0 returns an empty page but the real totalResults", () => {
+    const r = applyScimList(users, { count: "0" });
+    assert.equal(r.totalResults, 3);
+    assert.equal(r.resources.length, 0);
+  });
+
+  it("filter + pagination compose", () => {
+    const r = applyScimList(users, { filter: "active eq true", startIndex: "2", count: "5" });
+    assert.equal(r.totalResults, 2); // alice + carol
+    assert.equal(r.resources.length, 1); // from index 2 of the 2 matches
+    assert.equal(r.resources[0].id, "3");
+  });
+
+  it("propagates the unsupported-filter error for the route to 400", () => {
+    assert.throws(() => applyScimList(users, { filter: 'userName co "x"' }), (e: any) => e.scimUnsupported === true);
+  });
+});

--- a/mcp-server/src/scim/query.ts
+++ b/mcp-server/src/scim/query.ts
@@ -1,0 +1,94 @@
+// SCIM 2.0 list query: filter + pagination (RFC 7644 §3.4.2).
+//
+// Identity providers (Entra, Okta) reconcile by issuing
+//   GET /Users?filter=userName eq "alice@example.com"
+// and page large directories with startIndex/count. Without filter support a
+// provider has to pull the whole list and match client-side — slow and, for
+// Okta, a hard requirement. We support the `eq` operator on top-level string
+// attributes (userName, displayName, externalId, id) plus `active eq true`,
+// which covers what Entra/Okta actually send. Other operators are reported as
+// unsupported (400) rather than silently returning everything — silence here
+// would make a provider think "no match" when it means "not implemented".
+
+export interface ScimFilter {
+  attr: string;
+  op: "eq";
+  /** Comparison value: a string, or a boolean for `active eq true`. */
+  value: string | boolean;
+}
+
+/** Parse a SCIM `filter` expression. Returns null for an empty/absent filter,
+ *  or throws {unsupported:true} for a syntactically-valid filter we don't
+ *  implement (a non-eq operator) so the caller can answer 400, not 200. */
+export function parseScimFilter(raw: string | undefined): ScimFilter | null {
+  if (!raw || !raw.trim()) return null;
+  const s = raw.trim();
+  // <attr> eq "value"   |   <attr> eq true|false
+  const m = /^([A-Za-z][\w.]*)\s+(eq)\s+(?:"([^"]*)"|(true|false))$/i.exec(s);
+  if (!m) {
+    // Either an unsupported operator (co, sw, gt, …) or malformed. Signal
+    // unsupported so the route returns 400 instead of an all-rows 200.
+    const err = new Error(`Unsupported or malformed SCIM filter: ${raw}`);
+    (err as { scimUnsupported?: boolean }).scimUnsupported = true;
+    throw err;
+  }
+  const attr = m[1];
+  const value = m[3] !== undefined ? m[3] : m[4].toLowerCase() === "true";
+  return { attr, op: "eq", value };
+}
+
+/** Read a top-level attribute off a SCIM resource for `eq` comparison.
+ *  Only flat attributes are supported (userName/displayName/externalId/id/
+ *  active) — nested paths (name.familyName) aren't part of the eq surface. */
+function attrValue(resource: Record<string, unknown>, attr: string): unknown {
+  // Case-insensitive attribute match per the SCIM spec (attribute names are
+  // case-insensitive); providers send `userName`, some send `username`.
+  const key = Object.keys(resource).find((k) => k.toLowerCase() === attr.toLowerCase());
+  return key ? resource[key] : undefined;
+}
+
+export interface ScimListResult<T> {
+  resources: T[];
+  totalResults: number;
+  startIndex: number;
+  itemsPerPage: number;
+}
+
+/**
+ * Apply a SCIM `eq` filter + startIndex/count pagination to a resource list.
+ * `filter`/`startIndex`/`count` are the raw query-string values.
+ *
+ * - filter: only `eq` (string, case-insensitive; or boolean for `active`).
+ * - startIndex: 1-based (SCIM); clamped to >= 1; default 1.
+ * - count: page size; clamped to [0, 1000]; absent → all remaining.
+ *
+ * Throws a {scimUnsupported:true} error for a non-eq filter so the route can
+ * return 400 rather than a misleading full list.
+ */
+export function applyScimList<T extends Record<string, unknown>>(
+  all: T[],
+  q: { filter?: string; startIndex?: string; count?: string },
+): ScimListResult<T> {
+  const filter = parseScimFilter(q.filter);
+  let filtered = all;
+  if (filter) {
+    filtered = all.filter((r) => {
+      const v = attrValue(r, filter.attr);
+      if (typeof filter.value === "boolean") return Boolean(v) === filter.value;
+      // String eq is case-insensitive per the SCIM spec for these attrs.
+      return v !== undefined && String(v).toLowerCase() === filter.value.toLowerCase();
+    });
+  }
+
+  const total = filtered.length;
+  const startIndex = Math.max(1, Number.parseInt(q.startIndex ?? "1", 10) || 1);
+  const from = startIndex - 1;
+  const rawCount = q.count === undefined ? undefined : Number.parseInt(q.count, 10);
+  const count =
+    rawCount === undefined || Number.isNaN(rawCount)
+      ? undefined
+      : Math.min(1000, Math.max(0, rawCount));
+  const page = count === undefined ? filtered.slice(from) : filtered.slice(from, from + count);
+
+  return { resources: page, totalResults: total, startIndex, itemsPerPage: page.length };
+}

--- a/mcp-server/src/scim/routes.ts
+++ b/mcp-server/src/scim/routes.ts
@@ -4,7 +4,7 @@
 //   GET    /scim/v2/ServiceProviderConfig
 //   GET    /scim/v2/ResourceTypes
 //   GET    /scim/v2/Schemas
-//   GET    /scim/v2/Users        list (no filter support yet)
+//   GET    /scim/v2/Users        list (filter: <attr> eq "x"; startIndex/count)
 //   GET    /scim/v2/Users/:id
 //   POST   /scim/v2/Users
 //   PATCH  /scim/v2/Users/:id    minimal: replace top-level attrs
@@ -31,6 +31,7 @@ import {
   type ScimPatchRequest,
 } from "./types.js";
 import { ScimNotFoundError, type IScimStore, ScimValidationError } from "./store.js";
+import { applyScimList } from "./query.js";
 
 export interface ScimRoutesDeps {
   store: IScimStore;
@@ -76,7 +77,7 @@ export function registerScimRoutes(app: Application, deps: ScimRoutesDeps): void
       documentationUri: "https://thotischner.github.io/observability-mcp/scim-provisioning/",
       patch: { supported: true },
       bulk: { supported: false, maxOperations: 0, maxPayloadSize: 0 },
-      filter: { supported: false, maxResults: 200 },
+      filter: { supported: true, maxResults: 200 },
       changePassword: { supported: false },
       sort: { supported: false },
       etag: { supported: false },
@@ -130,14 +131,24 @@ export function registerScimRoutes(app: Application, deps: ScimRoutesDeps): void
   });
 
   // ---- Users ----
-  app.get("/scim/v2/Users", (_req, res) => {
+  app.get("/scim/v2/Users", (req, res) => {
     const users = store.listUsers().map((u) => withGroups(u, store));
+    let page;
+    try {
+      page = applyScimList(users as unknown as Record<string, unknown>[], req.query as Record<string, string>);
+    } catch (e) {
+      if ((e as { scimUnsupported?: boolean }).scimUnsupported) {
+        res.status(400).json(scimError(400, (e as Error).message));
+        return;
+      }
+      throw e;
+    }
     res.json({
       schemas: [SCIM_SCHEMA_LIST_RESPONSE],
-      totalResults: users.length,
-      itemsPerPage: users.length,
-      startIndex: 1,
-      Resources: users,
+      totalResults: page.totalResults,
+      itemsPerPage: page.itemsPerPage,
+      startIndex: page.startIndex,
+      Resources: page.resources,
     });
   });
 
@@ -182,14 +193,24 @@ export function registerScimRoutes(app: Application, deps: ScimRoutesDeps): void
   });
 
   // ---- Groups ----
-  app.get("/scim/v2/Groups", (_req, res) => {
+  app.get("/scim/v2/Groups", (req, res) => {
     const groups = store.listGroups();
+    let page;
+    try {
+      page = applyScimList(groups as unknown as Record<string, unknown>[], req.query as Record<string, string>);
+    } catch (e) {
+      if ((e as { scimUnsupported?: boolean }).scimUnsupported) {
+        res.status(400).json(scimError(400, (e as Error).message));
+        return;
+      }
+      throw e;
+    }
     res.json({
       schemas: [SCIM_SCHEMA_LIST_RESPONSE],
-      totalResults: groups.length,
-      itemsPerPage: groups.length,
-      startIndex: 1,
-      Resources: groups,
+      totalResults: page.totalResults,
+      itemsPerPage: page.itemsPerPage,
+      startIndex: page.startIndex,
+      Resources: page.resources,
     });
   });
 


### PR DESCRIPTION
SCIM 2.0 v3.3 candidate. `GET /Users` and `/Groups` gain `filter` (`<attr> eq "x"`, + `active eq true`) and `startIndex`/`count` pagination (RFC 7644 §3.4.2) — Okta requires filter for reconciliation; large directories need paging.

- new `scim/query.ts`: `parseScimFilter` + `applyScimList` (case-insensitive eq, pagination, `totalResults` = pre-page count). A non-eq/malformed filter → **400** (not a misleading 200 full list). `ServiceProviderConfig` now advertises `filter.supported: true`.
- No-param GET unchanged (full list, same envelope) — back-compat.

Tests: eq match/no-match, boolean eq, pagination, count=0, compose, unsupported→400 (27 pass). Reviewer-agent: **SHIP**.

**Scope:** delivers the standards-required *backend* half of the candidate (what IdPs use). The optional UI Provisioning sub-tab is deferred (IdPs reconcile directly via `/scim/v2`; the dashboard view is lower-value) — tracked as a follow-up. Part of the remaining-v3.3-candidates loop → v3.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)