### PR TITLE
feat(postmortem): custom report template engine

### DIFF
--- a/docs/postmortems.md
+++ b/docs/postmortems.md
@@ -127,6 +127,44 @@ returns.
 Every section is independently optional so a half-configured
 deployment still produces SOMETHING useful instead of failing.
 
+## Custom report template
+
+The default markdown layout suits most teams, but you can override it
+to match your own incident-report format. Point
+`OMCP_POSTMORTEM_TEMPLATE` at a file of `{{token}}` placeholders:
+
+```bash
+OMCP_POSTMORTEM_TEMPLATE=/etc/omcp/postmortem.md
+```
+
+```markdown
+## Incident — {{service}} ({{window}})
+
+{{synopsis}}
+
+### Timeline
+{{timeline}}
+
+### Blast radius
+{{blastRadius}}
+
+### Follow-ups
+{{followUps}}
+```
+
+Available tokens: `service`, `window`, `from`, `to`, `tenant`,
+`synopsis`, `timeline`, `blastRadius`, `signals`, `traces`,
+`logHighlights`, `followUps`. Each expands to a pre-rendered markdown
+block (tables for the data sections), so you compose the layout without
+re-implementing the rendering. An **unknown token is left verbatim** in
+the output — a typo is visible, not silently dropped. When the env var
+is unset the built-in layout is used; an unreadable template path falls
+back to the built-in layout (logged) rather than failing the report.
+
+> The no-signal honesty banner (when a report is built from zero signal)
+> still prepends a custom template — it's a correctness notice, not part
+> of the layout.
+
 ## Related
 
 - [`query_traces`](query-traces.md) — drill into a specific

--- a/mcp-server/src/postmortem/synthesizer.test.ts
+++ b/mcp-server/src/postmortem/synthesizer.test.ts
@@ -178,3 +178,34 @@ test("synthesizePostmortem: report carries the input window + iso bounds back in
   assert.equal(r.fromIso, "2026-06-06T00:00:00.000Z");
   assert.equal(r.toIso, "2026-06-06T01:00:00.000Z");
 });
+
+test("custom template: tokens are interpolated; default path unchanged when no template", () => {
+  const data = input({
+    anomalies: [anomaly("2026-06-06T00:10:00Z", 0.7, "mad", "warn", "cpu")],
+    blastRadius: { nodes: [{ id: "n1", kind: "pod", name: "payment-1", root: true }], edges: [] },
+    logHighlights: ["payment: 5xx spike"],
+  });
+  // Default (no template) still produces the built-in report.
+  const def = synthesizePostmortem(data);
+  assert.match(def.markdown, /^# Post-mortem — payment/);
+
+  // Custom template interpolates the known tokens.
+  const tpl = "INCIDENT {{service}} ({{window}})\n\n{{synopsis}}\n\nTIMELINE:\n{{timeline}}\n\nFOLLOWUPS:\n{{followUps}}\n\nLOGS:\n{{logHighlights}}";
+  const out = synthesizePostmortem({ ...data, template: tpl }).markdown;
+  assert.match(out, /^INCIDENT payment \(1h\)/);
+  assert.ok(!out.includes("# Post-mortem"), "custom template replaces the default layout");
+  assert.match(out, /TIMELINE:\n\| ts \| service \| score/);
+  assert.match(out, /LOGS:\n- payment: 5xx spike/);
+  assert.ok(out.includes(def.synopsis), "synopsis token expands to the computed synopsis");
+});
+
+test("custom template: unknown token is left verbatim (visible typo, not silent blank)", () => {
+  const out = synthesizePostmortem({ ...input(), template: "{{service}} / {{nope}}" }).markdown;
+  assert.equal(out, "payment / {{nope}}");
+});
+
+test("custom template: empty sections render their placeholder text, not a crash", () => {
+  const out = synthesizePostmortem({ ...input(), template: "T:{{timeline}} L:{{logHighlights}}" }).markdown;
+  assert.match(out, /T:_No anomaly samples in this window\._/);
+  assert.match(out, /L:_No log highlights\._/);
+});

--- a/mcp-server/src/postmortem/synthesizer.ts
+++ b/mcp-server/src/postmortem/synthesizer.ts
@@ -53,6 +53,13 @@ export interface PostmortemInput {
   traces: TraceSummary[];
   /** Optional log-error summary lines, e.g. ["payment-service: 412 5xx in window"]. */
   logHighlights?: string[];
+  /** Optional custom report template (issue: v3.3 candidate). When set, the
+   *  markdown body is rendered by interpolating `{{placeholder}}` tokens
+   *  instead of the built-in layout. Unset → the default report (unchanged).
+   *  Available tokens: service, window, from, to, tenant, synopsis, timeline,
+   *  blastRadius, signals, traces, logHighlights, followUps. An unknown token
+   *  is left verbatim so a typo is visible rather than silently dropped. */
+  template?: string;
 }
 
 export interface PostmortemReport {
@@ -92,7 +99,7 @@ export function synthesizePostmortem(input: PostmortemInput): PostmortemReport {
 
   const synopsis = synopsisFor(input, peakScore, errorTraces, blastSize);
 
-  const markdown = renderMarkdown({
+  const renderCtx = {
     input,
     timeline,
     contributingSignals,
@@ -102,7 +109,12 @@ export function synthesizePostmortem(input: PostmortemInput): PostmortemReport {
     blastSize,
     followUps,
     synopsis,
-  });
+  };
+  // Default layout unless the operator supplied a custom template — the
+  // default path is byte-for-byte unchanged.
+  const markdown = input.template
+    ? renderTemplate(input.template, buildTemplateVars(renderCtx))
+    : renderMarkdown(renderCtx);
 
   return {
     service: input.service,
@@ -285,4 +297,82 @@ function renderMarkdown(ctx: {
   // is normally a few KB but a pathological 10k-sample timeline
   // could approach MB without the slice() caps above.
   return lines.join("\n");
+}
+
+// --- Custom template engine (v3.3 candidate) -------------------------------
+// Operators can override the report layout with a template of `{{token}}`
+// placeholders. The default path (no template) is unchanged. Each token maps
+// to a pre-rendered markdown block so a template author composes sections
+// without re-implementing the table rendering.
+
+type RenderCtx = {
+  input: PostmortemInput;
+  timeline: PostmortemReport["sections"]["timeline"];
+  contributingSignals: PostmortemReport["sections"]["contributingSignals"];
+  peakNode: BlastRadiusNode | undefined;
+  peakScore: number;
+  errorTraces: number;
+  blastSize: number;
+  followUps: string[];
+  synopsis: string;
+};
+
+/** Build the `{{token}}` → markdown-block map for a custom template. */
+export function buildTemplateVars(ctx: RenderCtx): Record<string, string> {
+  const { input, timeline, contributingSignals, peakNode, errorTraces, followUps, synopsis } = ctx;
+
+  const timelineBlock = timeline.length === 0
+    ? "_No anomaly samples in this window._"
+    : ["| ts | service | score | severity | method |", "|---|---|---|---|---|",
+       ...timeline.slice(0, 20).map((t) => `| \`${t.ts}\` | \`${t.service}\` | ${t.score} | ${t.severity} | ${t.method} |`),
+       ...(timeline.length > 20 ? [`| … | _${timeline.length - 20} more rows_ |  |  |  |`] : [])].join("\n");
+
+  const brLines: string[] = [];
+  brLines.push(peakNode ? `Root node: **\`${peakNode.name}\`** (\`${peakNode.kind}\`).` : "_Topology snapshot empty._");
+  if (input.blastRadius.nodes.length > 0) {
+    brLines.push("", "| node | kind |", "|---|---|",
+      ...input.blastRadius.nodes.slice(0, 30).map((n) => `| \`${n.name}\`${n.root ? " *(root)*" : ""} | \`${n.kind}\` |`));
+  }
+  brLines.push("", `Edges in radius: **${input.blastRadius.edges.length}**.`);
+  const blastRadiusBlock = brLines.join("\n");
+
+  const signalsBlock = contributingSignals.length === 0
+    ? "_No anomaly samples to rank._"
+    : ["| signal | samples | mean score |", "|---|---|---|",
+       ...contributingSignals.slice(0, 10).map((s) => `| \`${s.signal}\` | ${s.count} | ${s.meanScore} |`)].join("\n");
+
+  const tracesBlock = input.traces.length === 0
+    ? "_No traces returned for the window. Configure a Tempo / Jaeger source if traces are expected._"
+    : ["| trace | service | duration ms | error |", "|---|---|---|---|",
+       ...input.traces.slice(0, 10).map((t) => `| \`${t.traceId}\` | \`${t.rootService}\` | ${t.durationMs} | ${t.hasError ? "yes" : "no"} |`),
+       ...(errorTraces > 0 ? [`\n_${errorTraces} of the returned traces carried error spans._`] : [])].join("\n");
+
+  const logHighlightsBlock = (input.logHighlights ?? []).length === 0
+    ? "_No log highlights._"
+    : input.logHighlights!.map((l) => `- ${l}`).join("\n");
+
+  const followUpsBlock = followUps.map((f) => `- ${f}`).join("\n");
+
+  return {
+    service: input.service,
+    window: input.window,
+    from: input.fromIso,
+    to: input.toIso,
+    tenant: input.tenant,
+    synopsis,
+    timeline: timelineBlock,
+    blastRadius: blastRadiusBlock,
+    signals: signalsBlock,
+    traces: tracesBlock,
+    logHighlights: logHighlightsBlock,
+    followUps: followUpsBlock,
+  };
+}
+
+/** Interpolate `{{token}}` placeholders. An unknown token is left verbatim so
+ *  a typo is visible in the output rather than silently producing a blank. */
+export function renderTemplate(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{\{\s*([a-zA-Z][\w]*)\s*\}\}/g, (whole, key: string) =>
+    Object.prototype.hasOwnProperty.call(vars, key) ? vars[key] : whole,
+  );
 }

--- a/mcp-server/src/tools/generate-postmortem.test.ts
+++ b/mcp-server/src/tools/generate-postmortem.test.ts
@@ -1,7 +1,10 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { ConnectorRegistry } from "../connectors/registry.js";
-import { generatePostmortemHandler } from "./generate-postmortem.js";
+import { generatePostmortemHandler, _resetPostmortemTemplateCache } from "./generate-postmortem.js";
 
 // R5 — a post-mortem built from ZERO signal (no anomaly/traces/topology/log
 // backend) must label itself, not render as an authoritative finding.
@@ -20,5 +23,49 @@ describe("generatePostmortemHandler — no-signal honesty (R5)", () => {
     const report = JSON.parse(out.content[0].text);
     assert.equal(report.builtFromSignal, false);
     assert.deepEqual(report.coverage, { anomalies: false, traces: false, topology: false, logs: false });
+  });
+});
+
+describe("generatePostmortemHandler — custom template via OMCP_POSTMORTEM_TEMPLATE (C3)", () => {
+  it("renders the operator's template when the env file is set; falls back when unset", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pm-tpl-"));
+    const file = join(dir, "tpl.md");
+    writeFileSync(file, "## Incident: {{service}} over {{window}}\n\n{{synopsis}}");
+    const prev = process.env.OMCP_POSTMORTEM_TEMPLATE;
+    try {
+      process.env.OMCP_POSTMORTEM_TEMPLATE = file;
+      _resetPostmortemTemplateCache();
+      const reg = new ConnectorRegistry();
+      const md = (await generatePostmortemHandler(reg, { service: "payment", duration: "2h" })).content[0].text;
+      // The custom template body is used (the no-signal honesty banner may
+      // still prepend it — that's deliberate and template-independent).
+      assert.match(md, /## Incident: payment over 2h/);
+      assert.ok(!md.includes("# Post-mortem —"), "custom template replaces the default layout");
+
+      // Unset → back to the built-in layout.
+      delete process.env.OMCP_POSTMORTEM_TEMPLATE;
+      _resetPostmortemTemplateCache();
+      const md2 = (await generatePostmortemHandler(reg, { service: "payment", duration: "2h" })).content[0].text;
+      assert.match(md2, /# Post-mortem — payment/);
+    } finally {
+      if (prev === undefined) delete process.env.OMCP_POSTMORTEM_TEMPLATE;
+      else process.env.OMCP_POSTMORTEM_TEMPLATE = prev;
+      _resetPostmortemTemplateCache();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("an unreadable template path falls back to the default layout, doesn't throw", async () => {
+    const prev = process.env.OMCP_POSTMORTEM_TEMPLATE;
+    try {
+      process.env.OMCP_POSTMORTEM_TEMPLATE = "/nonexistent/nope.md";
+      _resetPostmortemTemplateCache();
+      const md = (await generatePostmortemHandler(new ConnectorRegistry(), { service: "x", duration: "1h" })).content[0].text;
+      assert.match(md, /# Post-mortem — x/);
+    } finally {
+      if (prev === undefined) delete process.env.OMCP_POSTMORTEM_TEMPLATE;
+      else process.env.OMCP_POSTMORTEM_TEMPLATE = prev;
+      _resetPostmortemTemplateCache();
+    }
   });
 });

--- a/mcp-server/src/tools/generate-postmortem.ts
+++ b/mcp-server/src/tools/generate-postmortem.ts
@@ -8,6 +8,7 @@
 // this handler is just the orchestration: pull each upstream
 // primitive in parallel, hand the result to the synthesizer.
 
+import { readFileSync } from "node:fs";
 import type { ConnectorRegistry } from "../connectors/registry.js";
 import { defaultContext, type RequestContext } from "../context.js";
 import { validateDuration, validateServiceName, errorResponse } from "./validation.js";
@@ -18,6 +19,30 @@ import {
   type TraceSummary,
 } from "../postmortem/synthesizer.js";
 import type { MetricResult, TraceResult } from "../types.js";
+
+// Optional operator-supplied report template (v3.3 candidate). Set
+// OMCP_POSTMORTEM_TEMPLATE to a file of `{{token}}` placeholders to override
+// the built-in layout; unset → the default report. Read once and cached; a
+// read error falls back to the default (logged once) rather than failing the
+// tool — a broken template must not break incident reporting.
+let _templateCache: string | null | undefined;
+function loadPostmortemTemplate(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  if (_templateCache !== undefined) return _templateCache ?? undefined;
+  const path = env.OMCP_POSTMORTEM_TEMPLATE?.trim();
+  if (!path) { _templateCache = null; return undefined; }
+  try {
+    _templateCache = readFileSync(path, "utf8");
+  } catch (err) {
+    console.error("OMCP_POSTMORTEM_TEMPLATE unreadable, using the built-in layout:", err instanceof Error ? err.message : err);
+    _templateCache = null;
+  }
+  return _templateCache ?? undefined;
+}
+
+/** Test seam: reset the cached template (so tests can vary the env). */
+export function _resetPostmortemTemplateCache(): void {
+  _templateCache = undefined;
+}
 
 export const generatePostmortemDefinition = {
   name: "generate_postmortem" as const,
@@ -74,6 +99,7 @@ export async function generatePostmortemHandler(
     blastRadius,
     traces,
     logHighlights,
+    template: loadPostmortemTemplate(),
   });
 
   // Which primitives actually carried data. A post-mortem synthesised from


### PR DESCRIPTION
Closes the v3.3 candidate *"custom postmortem template engine"*.

`generate_postmortem`'s markdown layout is now overridable via `OMCP_POSTMORTEM_TEMPLATE` (a file of `{{token}}` placeholders). Unset → the built-in layout, **byte-for-byte unchanged** (the default path doesn't go near the template code).

- Tokens: `service`/`window`/`from`/`to`/`tenant`/`synopsis`/`timeline`/`blastRadius`/`signals`/`traces`/`logHighlights`/`followUps` — each a pre-rendered markdown block. An **unknown token is left verbatim** (visible typo, not a silent blank).
- Template file read once + cached; unreadable path → fallback to built-in layout (logged), never fails the report. The R5 no-signal banner still prepends (template-independent).

Tests: interpolation + empty-section placeholders + tool env-load/fallback (27 pass). Docs: postmortems.md. Reviewer-agent: **SHIP** (back-compat verified, no ReDoS, prototype-safe lookup). Closes the remaining-v3.3-candidates loop → v3.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)