### PR TITLE
chore(release): v3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.5.0] — 2026-06-11
+
+Candidate-cleanup release — closes the remaining v3.3 candidates. All
+additive / opt-in; migrating from 3.4 is non-breaking.
+
+### Added
+
+- **SCIM filter + pagination on the collection endpoints** (v3.3
+  candidate). `GET /scim/v2/Users` and `/Groups` now support the SCIM
+  `filter` query param (`<attr> eq "value"`, plus `active eq true`) and
+  `startIndex`/`count` pagination (RFC 7644 §3.4.2) — Okta requires
+  `filter` for reconciliation and large directories need paging. A non-`eq`
+  / malformed filter returns **400** rather than a misleading full list;
+  `ServiceProviderConfig` now advertises `filter.supported: true`. The
+  no-param list response is unchanged (back-compat).
+- **Custom post-mortem template engine** (v3.3 candidate).
+  `generate_postmortem`'s markdown layout is overridable via
+  `OMCP_POSTMORTEM_TEMPLATE` (a file of `{{token}}` placeholders:
+  service/window/from/to/tenant/synopsis/timeline/blastRadius/signals/
+  traces/logHighlights/followUps). Unset → the built-in layout, unchanged.
+  An unknown token is left verbatim; an unreadable template path falls back
+  to the built-in layout (logged), never failing the report. See
+  [postmortems.md](docs/postmortems.md#custom-report-template).
+
+### Changed
+
+- ROADMAP reconciled again: the strict-mode MkDocs build was already
+  shipping (`docs.yml` runs `mkdocs build --strict`), so it was dropped
+  from the candidate list.
+
+### Notes
+
+- The SCIM **Provisioning UI sub-tab** half of that candidate is
+  intentionally deferred — identity providers reconcile directly against
+  `/scim/v2`, so the dashboard view is lower-value; it remains the one open
+  v3.3 candidate.
+- The SDK (`@thotischner/observability-mcp-sdk`) is unchanged — these are
+  gateway-surface and tooling changes; the plugin contract did not move.
+
 ## [3.4.0] — 2026-06-11
 
 Roadmap-candidate release — closes two v3.3 candidates and proactively

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,12 +43,18 @@ Closes two v3.3 candidates and hardens the remaining tools against the
 - ✅ Per-credential `raw_query` gating (`OMCP_KEY_RAW_QUERY`; effective gate = global OR per-credential)
 - ✅ Honest no-data/partial states across `list_services` / `list_sources` / `get_blast_radius` / `generate_postmortem`
 
+## v3.5 — shipped 2026-06-11
+
+Closes the remaining v3.3 candidates. See [CHANGELOG.md](CHANGELOG.md).
+
+- ✅ SCIM `filter` (`<attr> eq`) + `startIndex`/`count` pagination on the `/Users` and `/Groups` collection endpoints (RFC 7644); `ServiceProviderConfig` advertises `filter.supported`
+- ✅ Custom post-mortem template engine — `OMCP_POSTMORTEM_TEMPLATE` (`{{token}}` placeholders); built-in layout unchanged when unset
+
 ### v3.x — candidates
 
 Still open (vote via Discussions):
 
-- A custom postmortem template engine (persistence + the Postmortems UI tab already ship)
-- SCIM filter/search on the collection endpoints + a UI Provisioning sub-tab
+- SCIM **Provisioning UI sub-tab** — a read-only dashboard view of the provisioned Users/Groups. (The SCIM filter/search backend ships in v3.5; this UI half is deferred because identity providers reconcile directly against `/scim/v2`.)
 
 (The strict-mode MkDocs build already ships — `docs.yml` runs
 `mkdocs build --strict`, so a broken cross-repo link fails CI.)

--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,11 +4,11 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 2.4.0
+version: 2.5.0
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
-appVersion: "3.4.0"
+appVersion: "3.5.0"
 
 home: https://github.com/ThoTischner/observability-mcp
 sources:
@@ -51,16 +51,14 @@ annotations:
     url: https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc
   artifacthub.io/images: |
     - name: observability-mcp
-      image: ghcr.io/thotischner/observability-mcp:3.4.0
+      image: ghcr.io/thotischner/observability-mcp:3.5.0
       platforms:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
     - kind: changed
-      description: "appVersion → 3.4.0 (roadmap-candidate release); chart points at the 3.4.0 image"
+      description: "appVersion → 3.5.0 (v3.3 candidate-cleanup release); chart points at the 3.5.0 image"
     - kind: added
-      description: "enrich_ips now supports IPv6 + an offline MaxMind GeoLite2 → CSV converter (scripts/build-ip-enrich-csv.mjs); data stays operator-side, air-gapped"
+      description: "SCIM filter (<attr> eq) + startIndex/count pagination on GET /Users and /Groups (RFC 7644); ServiceProviderConfig advertises filter.supported"
     - kind: added
-      description: "per-credential raw_query gating via OMCP_KEY_RAW_QUERY (effective gate = global OR per-credential; only widens)"
-    - kind: fixed
-      description: "honest no-data/partial states: list_services (note + partial/failedSources), list_sources (note), get_blast_radius (no-topology-connector note), generate_postmortem (coverage + no-signal banner)"
+      description: "custom post-mortem template engine via OMCP_POSTMORTEM_TEMPLATE ({{token}} placeholders); default layout unchanged when unset"

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thotischner/observability-mcp",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Candidate-cleanup release — closes the remaining v3.3 candidates.

| Slice | What | PR |
|-------|------|-----|
| SCIM `filter` + pagination on `/Users`,`/Groups` (RFC 7644; `ServiceProviderConfig` advertises `filter.supported`) | v3.3 candidate | #475 |
| Custom post-mortem template engine (`OMCP_POSTMORTEM_TEMPLATE`, `{{token}}`) | v3.3 candidate | #478 |
| ROADMAP reconcile — strict MkDocs already ships | hygiene | #473 |

Versions: mcp-server 3.4.0→**3.5.0** (minor — two additive features), helm chart 2.4.0→2.5.0 (appVersion 3.5.0). SDK unchanged. Full suite green (876 pass / 0 fail / 41 skip). The **SCIM Provisioning UI sub-tab** is the one remaining v3.3 candidate (deferred — IdPs reconcile directly via `/scim/v2`). Reviewer-agent: **SHIP**.

Merging auto-tags v3.5.0 → docker/npm/helm + MCP-registry publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)