### PR TITLE
feat(scim): read-only Provisioning UI sub-tab + /api/provisioning

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -77,8 +77,9 @@ import {
   cspStrictReportFromEnv,
   CSP_NONCE_PLACEHOLDER,
 } from "./security/csp.js";
-import { createScimStore } from "./scim/store.js";
+import { createScimStore, type IScimStore } from "./scim/store.js";
 import { registerScimRoutes } from "./scim/routes.js";
+import { projectProvisioning } from "./scim/provisioning-view.js";
 import { BuiltinPolicyEngine, type PolicyEngine } from "./auth/policy/engine.js";
 import { loadPolicyFromFile, writePolicyFile, PolicyLoadError, VALID_RESOURCES, VALID_ACTIONS } from "./auth/policy/loader.js";
 import { OpaPolicyEngine } from "./auth/policy/opa.js";
@@ -2017,6 +2018,15 @@ async function main() {
     res.json(result);
   });
 
+  // --- /api/provisioning — read-only view of SCIM-provisioned identities --
+  // Set below when SCIM is enabled (OMCP_SCIM_TOKEN). Lets the dashboard show
+  // the IdP-pushed Users/Groups without exposing the token-gated /scim/v2 API
+  // to a browser session. Read-only; never returns secrets.
+  let provisioningStore: IScimStore | null = null;
+  app.get("/api/provisioning", need("users", "delete"), (_req, res) => {
+    res.json(projectProvisioning(provisioningStore));
+  });
+
   // --- /api/subjects — aggregated principals catalogue ------------------
   // The third k8s-shaped RBAC view: who the deployment knows about.
   // Three independent sources, returned in three independent arrays so
@@ -2616,6 +2626,8 @@ async function main() {
         redis: scimRedis,
         redisKey: process.env.OMCP_SCIM_REDIS_KEY?.trim(),
       });
+      // Expose the same store (read-only) to the dashboard's /api/provisioning.
+      provisioningStore = scimStore;
       registerScimRoutes(app, {
         store: scimStore,
         bearerToken: scimToken,

--- a/mcp-server/src/openapi.ts
+++ b/mcp-server/src/openapi.ts
@@ -670,6 +670,36 @@ export function buildOpenApiSpec(version: string): OpenAPIV3_1.Document {
           },
         },
       },
+      "/api/provisioning": {
+        get: {
+          tags: ["auth"],
+          summary: "Read-only view of SCIM-provisioned Users/Groups (admin-only).",
+          description: "Mirrors the directory an identity provider has pushed via SCIM 2.0 (/scim/v2). Read-only and secret-free — never returns the SCIM bearer token. When SCIM is not enabled (no OMCP_SCIM_TOKEN), returns configured:false with an explanatory note rather than a 404.",
+          responses: {
+            "200": {
+              description: "Provisioning payload.",
+              content: { "application/json": { schema: {
+                type: "object",
+                properties: {
+                  configured: { type: "boolean" },
+                  users: { type: "array", items: { type: "object", properties: {
+                    userName: { type: "string" }, displayName: { type: "string" },
+                    active: { type: "boolean" },
+                    groups: { type: "array", items: { type: "string" } },
+                    externalId: { type: "string" },
+                  } } },
+                  groups: { type: "array", items: { type: "object", properties: {
+                    displayName: { type: "string" }, members: { type: "integer" },
+                    externalId: { type: "string" },
+                  } } },
+                  note: { type: "string" },
+                },
+              } } },
+            },
+            "403": { description: "Missing users:delete permission (admin-only)." },
+          },
+        },
+      },
       "/api/subjects": {
         get: {
           tags: ["auth"],

--- a/mcp-server/src/scim/provisioning-view.test.ts
+++ b/mcp-server/src/scim/provisioning-view.test.ts
@@ -1,0 +1,72 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { projectProvisioning } from "./provisioning-view.js";
+import type { IScimStore } from "./store.js";
+import type { ScimUser, ScimGroup } from "./types.js";
+
+const meta = { resourceType: "User" as const, created: "", lastModified: "", location: "" };
+
+function storeWith(users: ScimUser[], groups: ScimGroup[]): IScimStore {
+  // Only listUsers/listGroups are exercised by the projection.
+  return { listUsers: () => users, listGroups: () => groups } as unknown as IScimStore;
+}
+
+describe("projectProvisioning", () => {
+  it("returns configured:false + a note when the store is null (SCIM not enabled)", () => {
+    const v = projectProvisioning(null);
+    assert.equal(v.configured, false);
+    assert.deepEqual(v.users, []);
+    assert.deepEqual(v.groups, []);
+    assert.match(v.note ?? "", /OMCP_SCIM_TOKEN/);
+  });
+
+  it("projects users to a compact, secret-free shape", () => {
+    const store = storeWith(
+      [{
+        schemas: [], id: "u1", userName: "alice@x.com", active: true,
+        displayName: "Alice", groups: [{ value: "g1", display: "Admins" }],
+        externalId: "ext-1", meta: { ...meta },
+      }],
+      [],
+    );
+    const v = projectProvisioning(store);
+    assert.equal(v.configured, true);
+    assert.deepEqual(v.users, [{
+      userName: "alice@x.com", displayName: "Alice", active: true,
+      groups: ["Admins"], externalId: "ext-1",
+    }]);
+    // No secret/raw fields leaked.
+    assert.ok(!("schemas" in v.users[0]) && !("meta" in v.users[0]));
+  });
+
+  it("active defaults to true when unset; displayName falls back to name.formatted", () => {
+    const store = storeWith(
+      [{ schemas: [], id: "u2", userName: "bob", name: { formatted: "Bob B" }, meta: { ...meta } }],
+      [],
+    );
+    const v = projectProvisioning(store);
+    assert.equal(v.users[0].active, true);
+    assert.equal(v.users[0].displayName, "Bob B");
+    assert.deepEqual(v.users[0].groups, []);
+  });
+
+  it("active:false is preserved", () => {
+    const store = storeWith(
+      [{ schemas: [], id: "u3", userName: "carol", active: false, meta: { ...meta } }],
+      [],
+    );
+    assert.equal(projectProvisioning(store).users[0].active, false);
+  });
+
+  it("projects groups with a member count, not the member list", () => {
+    const store = storeWith(
+      [],
+      [{
+        schemas: [], id: "g1", displayName: "Admins",
+        members: [{ value: "u1" }, { value: "u2" }], externalId: "grp-1", meta: { ...meta },
+      }],
+    );
+    const v = projectProvisioning(store);
+    assert.deepEqual(v.groups, [{ displayName: "Admins", members: 2, externalId: "grp-1" }]);
+  });
+});

--- a/mcp-server/src/scim/provisioning-view.ts
+++ b/mcp-server/src/scim/provisioning-view.ts
@@ -1,0 +1,53 @@
+// Read-only projection of the SCIM store for the dashboard's Provisioning
+// sub-tab (/api/provisioning). Pure + secret-free: only the fields the UI
+// table renders, never the SCIM bearer token or anything sensitive. Kept
+// separate from the route handler so it's unit-testable without booting the app.
+
+import type { IScimStore } from "./store.js";
+
+export interface ProvisioningUserView {
+  userName: string;
+  displayName: string;
+  active: boolean;
+  groups: string[];
+  externalId?: string;
+}
+
+export interface ProvisioningGroupView {
+  displayName: string;
+  members: number;
+  externalId?: string;
+}
+
+export interface ProvisioningView {
+  configured: boolean;
+  users: ProvisioningUserView[];
+  groups: ProvisioningGroupView[];
+  note?: string;
+}
+
+const NOT_CONFIGURED_NOTE =
+  "SCIM provisioning is not enabled. Set OMCP_SCIM_TOKEN (and OMCP_SCIM_BACKEND/store) " +
+  "to let an identity provider push Users/Groups — this view then mirrors that directory.";
+
+/** Project the SCIM store into the compact, secret-free shape the UI renders.
+ *  A null store (SCIM not enabled) yields configured:false + an explanatory
+ *  note, NOT an error — the dashboard shows "how to enable" instead of a 404. */
+export function projectProvisioning(store: IScimStore | null): ProvisioningView {
+  if (!store) {
+    return { configured: false, users: [], groups: [], note: NOT_CONFIGURED_NOTE };
+  }
+  const users: ProvisioningUserView[] = store.listUsers().map((u) => ({
+    userName: u.userName,
+    displayName: u.displayName || u.name?.formatted || "",
+    active: u.active !== false,
+    groups: (u.groups || []).map((g) => g.display || g.value),
+    externalId: u.externalId,
+  }));
+  const groups: ProvisioningGroupView[] = store.listGroups().map((g) => ({
+    displayName: g.displayName,
+    members: (g.members || []).length,
+    externalId: g.externalId,
+  }));
+  return { configured: true, users, groups };
+}

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -2226,6 +2226,7 @@ curl -X PUT http://localhost:3000/api/enterprise/catalog \
         <button class="pol-subtab" role="tab" aria-controls="pol-pane-roles" data-pol-tab="roles" onclick="polSetTab('roles')">Roles</button>
         <button class="pol-subtab" role="tab" aria-controls="pol-pane-bindings" data-pol-tab="bindings" onclick="polSetTab('bindings')">Bindings</button>
         <button class="pol-subtab" role="tab" aria-controls="pol-pane-subjects" data-pol-tab="subjects" onclick="polSetTab('subjects')">Subjects</button>
+        <button class="pol-subtab" role="tab" aria-controls="pol-pane-provisioning" data-pol-tab="provisioning" onclick="polSetTab('provisioning')">Provisioning</button>
         <button class="pol-subtab" role="tab" aria-controls="pol-pane-batch" data-pol-tab="batch" onclick="polSetTab('batch')">Batch evaluate</button>
       </nav>
 
@@ -2324,6 +2325,21 @@ curl -X PUT http://localhost:3000/api/enterprise/catalog \
             onclick="infoPop(this)">?</button>
         </h2></div>
         <div id="pol-subjects-body" class="content"><div class="empty">Loading…</div></div>
+      </div>
+
+      <!-- Provisioning sub-tab (C2b) — read-only view of the SCIM-provisioned
+           Users/Groups an identity provider has pushed via /scim/v2. -->
+      <div class="card pol-pane" id="pol-pane-provisioning" role="tabpanel" hidden>
+        <div class="card-header"><h2>Provisioning
+          <button class="info" aria-label="About provisioning"
+            data-title="SCIM provisioning"
+            data-info="Read-only view of the Users and Groups an identity provider (Entra, Okta) has pushed via SCIM 2.0 at /scim/v2. Enable by setting OMCP_SCIM_TOKEN. This dashboard never exposes the SCIM bearer token; the IdP reconciles directly against the /scim/v2 endpoints."
+            onclick="infoPop(this)">?</button>
+          <span style="flex:1"></span>
+          <input id="pol-provisioning-filter" type="search" class="input" placeholder="Filter…"
+            style="max-width:220px" oninput="polRenderProvisioning()" aria-label="Filter provisioned identities">
+        </div>
+        <div id="pol-provisioning-body" class="content"><div class="empty">Loading…</div></div>
       </div>
 
       <!-- Batch evaluate sub-tab (P4) — wraps POST /api/policy/dry-run-batch
@@ -3148,8 +3164,74 @@ function polSetTab(name) {
   // Lazy-load Subjects on first visit — it has its own endpoint
   // so deferring the fetch keeps the page-enter cost low.
   if (name === 'subjects') polLoadSubjects();
+  if (name === 'provisioning') polLoadProvisioning();
   if (name === 'bindings') polLoadBindings();
   if (name === 'batch') polBatchInit();
+}
+
+// --- Provisioning sub-tab (C2b) — read-only SCIM Users/Groups view ---
+let POL_PROVISIONING = null;
+async function polLoadProvisioning() {
+  const body = document.getElementById('pol-provisioning-body');
+  if (!body) return;
+  if (POL_PROVISIONING) { polRenderProvisioning(); return; }
+  try {
+    const r = await fetch('/api/provisioning');
+    if (!r.ok) {
+      body.innerHTML = '<div class="empty">Provisioning view requires the <code>users:delete</code> permission (admin role).</div>';
+      return;
+    }
+    POL_PROVISIONING = await r.json();
+    polRenderProvisioning();
+  } catch (e) {
+    body.innerHTML = '<div class="empty">Provisioning unavailable: ' + escHtml(String(e && e.message || e)) + '</div>';
+  }
+}
+function polRenderProvisioning() {
+  const body = document.getElementById('pol-provisioning-body');
+  const j = POL_PROVISIONING;
+  if (!body || !j) return;
+  if (!j.configured) {
+    body.innerHTML = '<div class="pol-subjects-empty" style="padding:var(--sp-4)">'
+      + escHtml(j.note || 'SCIM provisioning is not enabled.') + '</div>';
+    return;
+  }
+  const q = (document.getElementById('pol-provisioning-filter')?.value || '').toLowerCase();
+  const match = (s) => !q || String(s).toLowerCase().includes(q);
+  const users = (j.users || []).filter((u) => match(u.userName) || match(u.displayName) || (u.groups || []).some(match));
+  const groups = (j.groups || []).filter((g) => match(g.displayName));
+
+  const usersHtml = users.map((u) => `
+    <tr>
+      <td><code>${escHtml(u.userName)}</code></td>
+      <td>${escHtml(u.displayName || '') || '<span class="t-sm" style="opacity:.5">—</span>'}</td>
+      <td>${u.active ? '<span class="pill">active</span>' : '<span class="pill" style="background:var(--warning-soft);color:var(--warning)">inactive</span>'}</td>
+      <td>${(u.groups || []).map((g) => `<span class="pill">${escHtml(g)}</span>`).join(' ') || '<span class="t-sm" style="opacity:.5">—</span>'}</td>
+    </tr>`).join('');
+  const groupsHtml = groups.map((g) => `
+    <tr>
+      <td><code>${escHtml(g.displayName)}</code></td>
+      <td>${g.members}</td>
+    </tr>`).join('');
+
+  const usersTbl = usersHtml
+    ? `<table class="data-table" style="width:100%"><thead><tr><th>Username</th><th>Display name</th><th>Status</th><th>Groups</th></tr></thead><tbody>${usersHtml}</tbody></table>`
+    : `<div class="pol-subjects-empty">${q ? 'No users match the filter.' : 'No provisioned users yet — the identity provider has not pushed any.'}</div>`;
+  const groupsTbl = groupsHtml
+    ? `<table class="data-table" style="width:100%"><thead><tr><th>Group</th><th>Members</th></tr></thead><tbody>${groupsHtml}</tbody></table>`
+    : `<div class="pol-subjects-empty">${q ? 'No groups match the filter.' : 'No provisioned groups yet.'}</div>`;
+
+  body.innerHTML = `
+    <div class="pol-subjects-section">
+      <h3>Users <span class="pol-subjects-count">${(j.users || []).length}</span>
+        <span class="pol-subjects-source">via SCIM /scim/v2/Users</span></h3>
+      ${usersTbl}
+    </div>
+    <div class="pol-subjects-section">
+      <h3>Groups <span class="pol-subjects-count">${(j.groups || []).length}</span>
+        <span class="pol-subjects-source">via SCIM /scim/v2/Groups</span></h3>
+      ${groupsTbl}
+    </div>`;
 }
 
 // --- Batch evaluate sub-tab (P4) ---


### PR DESCRIPTION
Closes the **last** v3.3 candidate — the SCIM Provisioning UI sub-tab.

A read-only dashboard view of the Users/Groups an identity provider has pushed via SCIM 2.0, without exposing the token-gated `/scim/v2` API to a browser session.

- `scim/provisioning-view.ts`: `projectProvisioning(store)` — pure, **secret-free** projection (never the token/password/raw meta/emails). Null store (SCIM disabled) → `configured:false` + note, not a 404.
- `GET /api/provisioning` — admin-gated `need("users","delete")`, exactly like `/api/subjects`.
- UI: a **Provisioning** sub-tab under Access — read-only Users/Groups tables + client-side filter; not-configured / empty / no-match states; all values `escHtml`-escaped.
- OpenAPI path entry.

Tests: projection unit tests + openapi (23 pass). **Live-verified E2E**: no-SCIM → `configured:false`+note; SCIM-enabled → the pushed user appears projected, secret-free. Reviewer-agent: **SHIP** (secret-free, admin-gated, no XSS, scope-correct). → v3.6.0 then the v3.3 candidate list is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)