### PR TITLE
chore(release): v3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.6.0] — 2026-06-11
+
+Closes the **last** open v3.3 candidate — the SCIM Provisioning UI.
+Additive / opt-in; migrating from 3.5 is non-breaking.
+
+### Added
+
+- **SCIM Provisioning dashboard sub-tab + `GET /api/provisioning`.** A
+  read-only view (under Access → Provisioning) of the Users and Groups an
+  identity provider has pushed via SCIM 2.0, so operators can confirm a
+  sync without poking the token-gated `/scim/v2` API from a browser. The
+  endpoint is admin-gated (`users:delete`, like `/api/subjects`) and its
+  projection is **secret-free** — userName/displayName/active/groups for
+  users and displayName/member-count for groups; the SCIM token, password,
+  raw meta/schemas and emails are never returned. When SCIM is not enabled
+  it returns `configured:false` with a "how to enable" note (not a 404),
+  and the UI renders that state; the tables have a client-side filter.
+
+### Notes
+
+- This completes the v3.3 candidate set — the candidate list is now empty.
+- The SDK (`@thotischner/observability-mcp-sdk`) is unchanged — a
+  gateway-surface + UI addition; the plugin contract did not move.
+
 ## [3.5.0] — 2026-06-11
 
 Candidate-cleanup release — closes the remaining v3.3 candidates. All

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,18 +43,24 @@ Closes two v3.3 candidates and hardens the remaining tools against the
 - ✅ Per-credential `raw_query` gating (`OMCP_KEY_RAW_QUERY`; effective gate = global OR per-credential)
 - ✅ Honest no-data/partial states across `list_services` / `list_sources` / `get_blast_radius` / `generate_postmortem`
 
+## v3.6 — shipped 2026-06-11
+
+Closes the last v3.3 candidate. See [CHANGELOG.md](CHANGELOG.md).
+
+- ✅ Read-only SCIM **Provisioning** dashboard sub-tab + `GET /api/provisioning` — an admin-gated, secret-free view of the Users/Groups an identity provider has pushed via `/scim/v2`
+
 ## v3.5 — shipped 2026-06-11
 
-Closes the remaining v3.3 candidates. See [CHANGELOG.md](CHANGELOG.md).
+Closes two more v3.3 candidates. See [CHANGELOG.md](CHANGELOG.md).
 
 - ✅ SCIM `filter` (`<attr> eq`) + `startIndex`/`count` pagination on the `/Users` and `/Groups` collection endpoints (RFC 7644); `ServiceProviderConfig` advertises `filter.supported`
 - ✅ Custom post-mortem template engine — `OMCP_POSTMORTEM_TEMPLATE` (`{{token}}` placeholders); built-in layout unchanged when unset
 
 ### v3.x — candidates
 
-Still open (vote via Discussions):
-
-- SCIM **Provisioning UI sub-tab** — a read-only dashboard view of the provisioned Users/Groups. (The SCIM filter/search backend ships in v3.5; this UI half is deferred because identity providers reconcile directly against `/scim/v2`.)
+The v3.3 candidate set is **complete** — every item shipped (see the v3.4 /
+v3.5 / v3.6 sections above). Future direction lives in the **Next** /
+**Later** sections below; vote via [Discussions](https://github.com/ThoTischner/observability-mcp/discussions).
 
 (The strict-mode MkDocs build already ships — `docs.yml` runs
 `mkdocs build --strict`, so a broken cross-repo link fails CI.)

--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,11 +4,11 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 2.5.0
+version: 2.6.0
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
-appVersion: "3.5.0"
+appVersion: "3.6.0"
 
 home: https://github.com/ThoTischner/observability-mcp
 sources:
@@ -51,14 +51,12 @@ annotations:
     url: https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc
   artifacthub.io/images: |
     - name: observability-mcp
-      image: ghcr.io/thotischner/observability-mcp:3.5.0
+      image: ghcr.io/thotischner/observability-mcp:3.6.0
       platforms:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
     - kind: changed
-      description: "appVersion → 3.5.0 (v3.3 candidate-cleanup release); chart points at the 3.5.0 image"
+      description: "appVersion → 3.6.0 (closes the last v3.3 candidate); chart points at the 3.6.0 image"
     - kind: added
-      description: "SCIM filter (<attr> eq) + startIndex/count pagination on GET /Users and /Groups (RFC 7644); ServiceProviderConfig advertises filter.supported"
-    - kind: added
-      description: "custom post-mortem template engine via OMCP_POSTMORTEM_TEMPLATE ({{token}} placeholders); default layout unchanged when unset"
+      description: "read-only SCIM Provisioning dashboard sub-tab + GET /api/provisioning (admin-gated, secret-free view of IdP-pushed Users/Groups)"

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thotischner/observability-mcp",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Closes the **last** open v3.3 candidate — the SCIM Provisioning UI.

| Slice | What | PR |
|-------|------|-----|
| Read-only SCIM **Provisioning** dashboard sub-tab + `GET /api/provisioning` (admin-gated, secret-free view of IdP-pushed Users/Groups) | v3.3 candidate | #480 |

Versions: mcp-server 3.5.0→**3.6.0** (minor — additive feature), helm chart 2.5.0→2.6.0 (appVersion 3.6.0). SDK unchanged. Full suite green (881 pass / 0 fail / 41 skip). **The v3.3 candidate set is now complete — every item shipped.** Reviewer-agent: **SHIP**.

Merging auto-tags v3.6.0 → docker/npm/helm + MCP-registry publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)