### PR TITLE
fix(enrich_ips): advertise IPv6 in the MCP tool description + ips param (#476)

### DIFF
--- a/mcp-server/src/conformance/mcp-2025-11-25.test.ts
+++ b/mcp-server/src/conformance/mcp-2025-11-25.test.ts
@@ -524,3 +524,16 @@ test("E2E: initialize advertises non-empty instructions pointing at the usage gu
   assert.match(r.instructions!, /omcp:\/\/guide\/agent-usage/, "must point at the usage-guide resource");
   assert.match(r.instructions!, /aggregate/i, "must carry the filter+aggregate golden rule");
 });
+
+test("E2E: enrich_ips advertises IPv6 in its description + ips param (issue #476)", opts, async () => {
+  const session = await newSession();
+  const { response } = await jsonRpc("tools/list", {}, { id: 40, session });
+  const r = response.result as {
+    tools?: Array<{ name?: string; description?: string; inputSchema?: { properties?: Record<string, { description?: string }> } }>;
+  };
+  const tool = r.tools?.find((t) => t.name === "enrich_ips");
+  assert.ok(tool, "enrich_ips must be advertised");
+  assert.match(tool.description ?? "", /IPv6/, "description must mention IPv6 (not IPv4-only)");
+  const ipsDesc = tool.inputSchema?.properties?.ips?.description ?? "";
+  assert.match(ipsDesc, /IPv6/, "the ips param must mention IPv6");
+});

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1041,8 +1041,8 @@ async function main() {
   registerTool(
     "enrich_ips",
     [
-      "Resolve a batch of IPv4 addresses to geo (country/city), ASN/org, and a hosting/proxy flag.",
-      "When to use: answering 'where are these visitors from?' or 'which of these IPs are bots / datacenter / VPN exit nodes?' over access logs, without an out-of-band geo-API call per IP.",
+      "Resolve a batch of IPv4 or IPv6 addresses to geo (country/city), ASN/org, and a hosting/proxy flag.",
+      "When to use: answering 'where are these visitors from?' or 'which of these IPs are bots / datacenter / VPN exit nodes?' over access logs, without an out-of-band geo-API call per IP. Both IPv4 and IPv6 clients are resolved — don't pre-filter v6 out.",
       "Behavior: read-only. Looks each IP up in a LOCAL offline dataset the operator configured (OMCP_IP_ENRICH_FILE) — there is no external network call, so it is safe in air-gapped deployments. Returns one row per input IP with found=true/false plus any known fields. If no dataset is configured it returns a clear notice explaining how to enable it.",
       "Related: pull the IPs from `query_logs` (use `labels`/`aggregate` to find the IPs of interest first).",
     ].join(" "),
@@ -1050,7 +1050,7 @@ async function main() {
       ips: z
         .array(z.string())
         .describe(
-          "Required. IPv4 address strings to enrich (e.g. ['203.0.113.5','198.51.100.9']). Max 1000 per call; invalid entries are returned with found=false rather than failing the batch.",
+          "Required. IPv4 or IPv6 address strings to enrich (e.g. ['203.0.113.5','2001:db8::1']). Max 1000 per call; invalid entries are returned with found=false rather than failing the batch.",
         ),
     },
     { title: "Enrich IPs", readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },


### PR DESCRIPTION
IPv6 lookup shipped in 3.4.0 (#469), but the **agent-facing** `tools/list` surface (the inline `registerTool` description + `ips` param in index.ts) still said *"IPv4 addresses"*. An agent reads the schema, not the repo docs — so it would pre-filter IPv6 clients out before calling, leaving the capability invisible at its core use case.

Fix: both strings → "IPv4 or IPv6", a v6 example, + a don't-pre-filter-v6 hint. Conformance assertion (live tools/list) + **live-verified** (desc + ips param both advertise IPv6). First slice of the security-sweep loop → v3.6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)