### PR TITLE
fix(docker): patch OpenSSL to clear Trivy base-image CVEs

### DIFF
--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -22,6 +22,13 @@ RUN npm prune --omit=dev
 # silences false-positive scans like the one ArtifactHub reported.
 FROM node:26-alpine@sha256:e71ac5e964b9201072425d59d2e876359efa25dc96bb1768cb73295728d6e4ea
 
+# Patch base-image OS packages that lag the pinned digest snapshot. The
+# digest carries libcrypto3/libssl3 3.5.6-r0 (a batch of OpenSSL CVEs);
+# the Alpine repo already ships the 3.5.7-r0 fix. Upgrade just those two
+# packages at build time so Trivy's image scan is clean without waiting
+# for a new base digest. --no-cache leaves no apk index behind.
+RUN apk upgrade --no-cache libcrypto3 libssl3
+
 ARG GIT_COMMIT=""
 ARG BUILD_DATE=""
 


### PR DESCRIPTION
All ~15 open Trivy alerts are the same OpenSSL pair — `libcrypto3`/`libssl3` **3.5.6-r0** in the pinned `node:26-alpine` digest. The Alpine repo already ships the **3.5.7-r0** fix, so the runtime stage runs `apk upgrade --no-cache libcrypto3 libssl3` — patches just those two at build time, no new-digest wait, no broad upgrade.

Verified: image builds; `libssl3`/`libcrypto3` are **3.5.7-r0** in the result → the Trivy image scan clears on the next run. Part of the security-sweep loop → v3.6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)