### PR TITLE
chore(release): v3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.6.1] — 2026-06-11
+
+Security + agent-feedback patch. Additive / non-breaking.
+
+### Fixed
+
+- **`enrich_ips` now advertises IPv6 in its MCP tool surface (#476).** IPv6
+  lookup shipped in 3.4.0, but the agent-facing `tools/list` description +
+  `ips` param (the inline registration in index.ts) still said "IPv4
+  addresses" — so an agent would pre-filter IPv6 clients out before calling,
+  hiding the capability at its core use case. Both now say "IPv4 or IPv6"
+  with a v6 example; a conformance assertion guards the advertised surface.
+- **OpenSSL base-image CVEs cleared.** The pinned `node:26-alpine` digest
+  carried `libcrypto3`/`libssl3` 3.5.6-r0 (a batch of OpenSSL CVEs flagged by
+  the Trivy image scan); the runtime stage now `apk upgrade`s just those two
+  packages to 3.5.7-r0 at build time.
+
+### Security
+
+- Triaged the 14 open CodeQL alerts on our code: all were verified
+  false-positive / won't-fix / used-in-tests and dismissed with written
+  justifications — the code already carried the relevant guards (a
+  `__proto__`/`constructor`/`prototype` deny-set + allow-lists on the
+  batch-dry-run matrix, `sanitizeForLog` on logged user input, an operator-
+  config-only fs path, and linear/anchored regexes on trusted input). No
+  code change was required; this is recorded for auditability.
+
+### Notes
+
+- The SDK (`@thotischner/observability-mcp-sdk`) is unchanged.
+
 ## [3.6.0] — 2026-06-11
 
 Closes the **last** open v3.3 candidate — the SCIM Provisioning UI.

--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,11 +4,11 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 2.6.0
+version: 2.6.1
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
-appVersion: "3.6.0"
+appVersion: "3.6.1"
 
 home: https://github.com/ThoTischner/observability-mcp
 sources:
@@ -51,12 +51,14 @@ annotations:
     url: https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc
   artifacthub.io/images: |
     - name: observability-mcp
-      image: ghcr.io/thotischner/observability-mcp:3.6.0
+      image: ghcr.io/thotischner/observability-mcp:3.6.1
       platforms:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
     - kind: changed
-      description: "appVersion → 3.6.0 (closes the last v3.3 candidate); chart points at the 3.6.0 image"
-    - kind: added
-      description: "read-only SCIM Provisioning dashboard sub-tab + GET /api/provisioning (admin-gated, secret-free view of IdP-pushed Users/Groups)"
+      description: "appVersion → 3.6.1 (security + agent-feedback patch); chart points at the 3.6.1 image"
+    - kind: fixed
+      description: "enrich_ips advertises IPv6 in its MCP tool description + ips param (was IPv4-only in tools/list despite working since 3.4.0) (#476)"
+    - kind: security
+      description: "OpenSSL libssl3/libcrypto3 upgraded to 3.5.7-r0 in the runtime image, clearing the Trivy base-image CVEs"

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thotischner/observability-mcp",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Security + agent-feedback patch.

| Change | Ref |
|--------|-----|
| `enrich_ips` advertises IPv6 in its MCP tool description + `ips` param (was IPv4-only in `tools/list` despite working since 3.4.0) | #476 |
| OpenSSL `libssl3`/`libcrypto3` → **3.5.7-r0** in the runtime image — clears the Trivy base-image CVEs | — |
| 14 CodeQL alerts triaged + **dismissed** (false-positive / won't-fix / used-in-tests; code already defensive) — no code change, recorded for audit | — |

Versions: mcp-server 3.6.0→**3.6.1**, helm chart 2.6.0→2.6.1 (appVersion 3.6.1). SDK unchanged. Reviewer-agent: **SHIP**. Security-sweep loop; RDAP (#477) follows as v3.7.0.

Merging auto-tags v3.6.1 → docker/npm/helm + MCP-registry publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)