### PR TITLE
chore(release): v3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.7.0] — 2026-06-12
+
+Feature release. Additive / non-breaking — the air-gapped default is unchanged.
+
+### Added
+
+- **`enrich_ips` optional online RDAP fallback (#477).** For deployments that
+  aren't air-gapped, you can now enable an opt-in online backend that resolves
+  IPs via authoritative-registry **RDAP** (RFC 9082/9083) over HTTPS, instead of
+  building a MaxMind dataset:
+  - **OFF by default** — set `OMCP_IP_ENRICH_RDAP=on` to enable (optionally
+    `OMCP_IP_ENRICH_RDAP_URL` to override the default `https://rdap.org`
+    bootstrap). No external call is ever made unless you opt in; the
+    air-gapped guarantee holds in the default config.
+  - **Offline dataset stays preferred.** RDAP is only consulted for IPs the
+    local CSV didn't cover (or when no dataset is configured). Hits carry
+    `via: "dataset"` / `via: "rdap"`; the summary reports `viaRdap`.
+  - **Returns country + org only** — RDAP has no city-level geo or
+    hosting/proxy flag (the org name is the bot-vs-human signal). Results are
+    cached with a TTL; a flaky RIR returns a miss, never a hard error.
+  - The new outbound call is registered in the verifiable-offline egress
+    policy as an opt-in destination, so the "no telemetry/phone-home" guard
+    still holds.
+
 ## [3.6.1] — 2026-06-11
 
 Security + agent-feedback patch. Additive / non-breaking.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,6 +34,12 @@ real-world feedback in issue #415. All additive / opt-in. See
 - ✅ `get_topology` explicit no-connector note (issue #415, signal vs. silence)
 - ✅ `query_logs` `labels`/`aggregate` made reachable over MCP (3.1.1 hotfix — 3.1.0 ship gap)
 
+## v3.7 — shipped 2026-06-12
+
+Optional online enrichment for non-air-gapped deployments. See [CHANGELOG.md](CHANGELOG.md).
+
+- ✅ `enrich_ips` optional online **RDAP** fallback (RFC 9082/9083) — OFF by default (`OMCP_IP_ENRICH_RDAP=on`); offline CSV stays preferred; country/org only; registered as an opt-in egress destination so the air-gapped default is unchanged (#477)
+
 ## v3.4 — shipped 2026-06-11
 
 Closes two v3.3 candidates and hardens the remaining tools against the

--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,11 +4,11 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 2.6.1
+version: 2.7.0
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
-appVersion: "3.6.1"
+appVersion: "3.7.0"
 
 home: https://github.com/ThoTischner/observability-mcp
 sources:
@@ -51,14 +51,12 @@ annotations:
     url: https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc
   artifacthub.io/images: |
     - name: observability-mcp
-      image: ghcr.io/thotischner/observability-mcp:3.6.1
+      image: ghcr.io/thotischner/observability-mcp:3.7.0
       platforms:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
     - kind: changed
-      description: "appVersion → 3.6.1 (security + agent-feedback patch); chart points at the 3.6.1 image"
-    - kind: fixed
-      description: "enrich_ips advertises IPv6 in its MCP tool description + ips param (was IPv4-only in tools/list despite working since 3.4.0) (#476)"
-    - kind: security
-      description: "OpenSSL libssl3/libcrypto3 upgraded to 3.5.7-r0 in the runtime image, clearing the Trivy base-image CVEs"
+      description: "appVersion → 3.7.0 (optional online RDAP enrich_ips backend); chart points at the 3.7.0 image"
+    - kind: added
+      description: "enrich_ips optional online RDAP fallback (OFF by default; OMCP_IP_ENRICH_RDAP=on). Offline CSV stays preferred; the air-gapped default is unchanged (#477)"

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thotischner/observability-mcp",
-      "version": "3.6.1",
+      "version": "3.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Feature release for the optional online **RDAP** `enrich_ips` backend (#477).

Additive / non-breaking — **OFF by default**, the air-gapped default is unchanged.

- mcp-server `3.6.1 → 3.7.0` (+ lockfile root version, 2 lines only)
- helm chart `2.6.1 → 2.7.0`, appVersion/image `→ 3.7.0`, artifacthub changes block
- CHANGELOG `[3.7.0]` + ROADMAP `v3.7 — shipped`

Tests: 894 pass / 0 fail (Docker). Reviewer-agent: SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)