### PR TITLE
fix(ci): MCP-registry verify step no longer false-fails on exit 23

### DIFF
--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -87,7 +87,25 @@ jobs:
         run: ./mcp-publisher publish
 
       - name: Verify listing
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
         run: |
           set -euo pipefail
-          sleep 5
-          curl -fsS "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.ThoTischner/observability-mcp" | head -c 600
+          # The registry is eventually-consistent after publish; poll for the
+          # just-published VERSION to actually appear rather than printing a
+          # truncated blob. (The old `curl | head -c` tripped SIGPIPE → exit 23
+          # under pipefail and showed the pre-existing version, so it failed the
+          # job even when the publish succeeded.)
+          url="https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.ThoTischner/observability-mcp"
+          for i in $(seq 1 15); do
+            body="$(curl -fsS "$url")" || { echo "registry query failed — retry $i/15"; sleep 10; continue; }
+            if printf '%s' "$body" | grep -qF "\"version\":\"$VERSION\""; then
+              echo "registry lists $VERSION"
+              printf '%s' "$body" | head -c 600 || true
+              exit 0
+            fi
+            echo "registry does not list $VERSION yet — retry $i/15"
+            sleep 10
+          done
+          echo "registry never listed $VERSION after retries"
+          exit 1


### PR DESCRIPTION
## Problem

The `Verify listing` step of `mcp-registry-publish.yml` ran:

```bash
set -euo pipefail
curl -fsS "<url>" | head -c 600
```

`head -c 600` closes the pipe after 600 bytes → `curl` gets SIGPIPE / a write error and exits **23** → `pipefail` fails the whole job. This made the **Publish to MCP Registry** run go red on every release (e.g. v3.7.0 run 27411693652) **even though the publish succeeded** — the registry serves the new version fine. The step also never actually verified the published version; it just printed the first 600 bytes (which showed the *pre-existing* version).

## Fix

Poll loop that:
- captures the full response into a shell var (no pipe under `pipefail`),
- asserts the just-published `$VERSION` (from `steps.ver.outputs.version`) is listed with `grep -qF`,
- retries with backoff (registry is eventually-consistent after publish),
- prints a truncated preview guarded with `|| true`,
- still `exit 1`s if the version genuinely never appears.

No behavior change to the actual publish; this only makes the verification honest and non-flaky. Reviewer-agent: SHIP. YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)