### PR TITLE
feat(inspect): behavior profile — derive, review + accept (P3)

### DIFF
--- a/mcp-server/playwright/inspect.spec.mjs
+++ b/mcp-server/playwright/inspect.spec.mjs
@@ -65,4 +65,33 @@ test.describe("Inspect — Flows live graph", () => {
     await expect(btn).toHaveText(/Paused/);
     await expect(page.locator("#inspect-graph-svg")).toHaveClass(/paused/);
   });
+
+  test("Profile tab learns from traffic and renders the review queue", async ({ page }) => {
+    const errors = [];
+    page.on("console", (m) => { if (m.type() === "error") errors.push(m.text()); });
+    page.on("pageerror", (e) => errors.push(String(e)));
+
+    await page.goto(BASE, { waitUntil: "networkidle" });
+    await page.locator('[data-page="inspect"]').click();
+    await page.locator('#page-inspect .tab-btn', { hasText: "Profile" }).click();
+    await expect(page.locator("#inspect-tab-profile")).toHaveClass(/active/);
+
+    // Learn from the observed window.
+    await page.locator('#inspect-tab-profile button', { hasText: "Learn from traffic" }).click();
+    await page.waitForTimeout(800);
+
+    // The review queue resolves to either suggestion cards (demo agent traffic)
+    // or an honest empty state — never a broken panel. If suggestions appear,
+    // accepting one moves it into the accepted-rules table.
+    const queue = page.locator("#inspect-review-queue");
+    await expect(queue).toBeVisible();
+    const accept = page.locator('#inspect-review-queue button', { hasText: "Accept" }).first();
+    if (await accept.count()) {
+      await accept.click();
+      await page.waitForTimeout(500);
+      await expect(page.locator("#inspect-accepted-rules table")).toBeVisible();
+    }
+
+    expect(errors, `console errors: ${errors.join("\n")}`).toEqual([]);
+  });
 });

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -109,8 +109,8 @@ import { selfRegistry, withToolMetrics, apiRequests, mcpActiveSessions, auditDlq
 import { initOtel } from "./observability/otel.js";
 import { WebSocketServerTransport } from "./transport/websocket.js";
 import { HookRegistry } from "./sdk/hooks.js";
-import { InspectStore, ModeController, bootMode, createInspectRecorder, buildFlowGraph, durationToSeconds } from "./inspect/index.js";
-import type { Outcome, Decision } from "./inspect/index.js";
+import { InspectStore, ModeController, bootMode, createInspectRecorder, buildFlowGraph, durationToSeconds, ProfileStore } from "./inspect/index.js";
+import type { Outcome, Decision, RuleStatus } from "./inspect/index.js";
 import { wrapToolHandler, wrapResourceHandler, wrapPromptHandler } from "./sdk/hook-wrappers.js";
 import { UpstreamClient } from "./federation/upstream.js";
 import { FederationRegistry, parseFederationEnv } from "./federation/registry.js";
@@ -1528,6 +1528,10 @@ async function main() {
   if (inspectMode.get() !== "observe") {
     console.log(`[inspect] mode=${inspectMode.get()} (store ${inspectStore.persisted ? "persisted" : "in-memory"})`);
   }
+  // Behavior profile (the learned ruleset). Suggestions are derived from the
+  // observation store on demand; accepted rules drive dry-run/enforce (wired
+  // in a later phase). Persists to OMCP_INSPECT_PROFILE_FILE when set.
+  const inspectProfile = new ProfileStore({ file: process.env.OMCP_INSPECT_PROFILE_FILE?.trim() || undefined });
 
   // Phase F15: anomaly-history sink — opt-in via
   // OMCP_ANOMALY_HISTORY_REMOTE_WRITE. When configured, anomaly
@@ -2402,6 +2406,62 @@ async function main() {
     if (tenant) obs = obs.filter((e) => e.tenant === tenant);
     const graph = buildFlowGraph(obs, { sinceMs });
     res.json({ ...graph, mode: inspectMode.get(), scopedTo: tenant });
+  });
+
+  app.get("/api/inspect/profile", need("inspection", "read"), (_req, res) => {
+    const rules = inspectProfile.list();
+    res.json({
+      rules,
+      counts: {
+        total: rules.length,
+        suggested: rules.filter((r) => r.status === "suggested").length,
+        accepted: rules.filter((r) => r.status === "accepted").length,
+        rejected: rules.filter((r) => r.status === "rejected").length,
+      },
+      persisted: inspectProfile.persisted,
+    });
+  });
+
+  // Learn: derive suggested rules from the observed window. Mutating (writes
+  // the suggested set) → inspection:write + audited.
+  app.post("/api/inspect/profile/derive", need("inspection", "write"), audit("inspection", "write"), (req, res) => {
+    const windowSecs = durationToSeconds(qstr(req.query.window) || "24h") ?? 86400;
+    const obs = inspectStore.since(Date.now() - windowSecs * 1000);
+    const rules = inspectProfile.derive(obs);
+    res.json({ rules, learnedFrom: obs.length, suggested: inspectProfile.suggested().length });
+  });
+
+  // Accept / reject / reset a rule, or edit its constraints.
+  app.patch("/api/inspect/profile/rules/:id", need("inspection", "write"), audit("inspection", "write"), (req, res) => {
+    const id = String(req.params.id);
+    const body = (req.body || {}) as { status?: unknown; constraints?: unknown; subject?: unknown };
+    if (body.status != null) {
+      const status = String(body.status);
+      if (!["suggested", "accepted", "rejected"].includes(status)) {
+        res.status(400).json({ error: "status must be suggested|accepted|rejected" });
+        return;
+      }
+      const r = inspectProfile.setStatus(id, status as RuleStatus);
+      if (!r) { res.status(404).json({ error: "rule not found" }); return; }
+      res.json({ rule: r });
+      return;
+    }
+    if (body.constraints != null || body.subject != null) {
+      const r = inspectProfile.update(id, {
+        constraints: body.constraints as never,
+        subject: typeof body.subject === "string" ? body.subject : undefined,
+      });
+      if (!r) { res.status(404).json({ error: "rule not found" }); return; }
+      res.json({ rule: r });
+      return;
+    }
+    res.status(400).json({ error: "provide status or constraints/subject" });
+  });
+
+  app.delete("/api/inspect/profile/rules/:id", need("inspection", "write"), audit("inspection", "write"), (req, res) => {
+    const ok = inspectProfile.remove(String(req.params.id));
+    if (!ok) { res.status(404).json({ error: "rule not found" }); return; }
+    res.json({ ok: true });
   });
 
   // --- /api/audit/dlq — webhook-sink dead-letter queue surface (P9) ---

--- a/mcp-server/src/inspect/index.ts
+++ b/mcp-server/src/inspect/index.ts
@@ -9,3 +9,5 @@ export * from "./store.js";
 export * from "./mode.js";
 export * from "./graph.js";
 export * from "./recorder.js";
+export * from "./profile.js";
+export * from "./profile-store.js";

--- a/mcp-server/src/inspect/profile-store.test.ts
+++ b/mcp-server/src/inspect/profile-store.test.ts
@@ -44,19 +44,19 @@ describe("ProfileStore", () => {
 
   it("persists via the writer seam and reloads via the reader seam", () => {
     let blob = "";
-    const a = new ProfileStore({ file: "/tmp/p.json", reader: () => { throw new Error("absent"); }, writer: (_f, d) => { blob = d; } });
+    const a = new ProfileStore({ file: "profile-store-test.json", reader: () => { throw new Error("absent"); }, writer: (_f, d) => { blob = d; } });
     a.derive([obs({ principal: "a", tool: "t", service: "s" })]);
     a.setStatus(ruleId("a", "t"), "accepted");
     assert.ok(blob.includes('"accepted"'));
     // a fresh store reads it back
-    const b = new ProfileStore({ file: "/tmp/p.json", reader: () => blob, writer: () => {} });
+    const b = new ProfileStore({ file: "profile-store-test.json", reader: () => blob, writer: () => {} });
     assert.equal(b.accepted().length, 1);
     assert.equal(b.persisted, true);
   });
 
   it("a missing/invalid file starts empty, never throws", () => {
     assert.doesNotThrow(() => {
-      const s = new ProfileStore({ file: "/tmp/nope.json", reader: () => "not json{", writer: () => {} });
+      const s = new ProfileStore({ file: "profile-store-missing.json", reader: () => "not json{", writer: () => {} });
       assert.equal(s.size, 0);
     });
   });

--- a/mcp-server/src/inspect/profile-store.test.ts
+++ b/mcp-server/src/inspect/profile-store.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { ProfileStore } from "./profile-store.js";
+import { ruleId } from "./profile.js";
+import type { Observation } from "./store.js";
+
+let seq = 0;
+function obs(over: Partial<Observation> = {}): Observation {
+  return {
+    ts: new Date(1_700_000_000_000 + seq * 1000).toISOString(),
+    seq: ++seq,
+    principal: "key:bot", auth: "apikey", tenant: "default", tool: "query_logs",
+    argShape: {}, outcome: "ok", decision: "allow", redactions: 0, ...over,
+  };
+}
+
+describe("ProfileStore", () => {
+  it("derive → setStatus(accept) → evaluate allows learned, flags novel", () => {
+    const s = new ProfileStore();
+    s.derive([obs({ principal: "a", tool: "query_logs", service: "pay", argShape: { window: "<=1h" } })]);
+    assert.equal(s.suggested().length, 1);
+    assert.equal(s.accepted().length, 0);
+    const id = ruleId("a", "query_logs");
+    s.setStatus(id, "accepted");
+    assert.equal(s.accepted().length, 1);
+
+    assert.equal(s.evaluate({ principal: "a", tool: "query_logs", service: "pay", argShape: { window: "<=1h" } }).verdict, "allow");
+    assert.equal(s.evaluate({ principal: "a", tool: "query_logs", service: "x", argShape: {} }).kind, "new-resource");
+  });
+
+  it("setStatus/remove return null/false for unknown ids", () => {
+    const s = new ProfileStore();
+    assert.equal(s.setStatus("nope", "accepted"), null);
+    assert.equal(s.remove("nope"), false);
+  });
+
+  it("update replaces constraints", () => {
+    const s = new ProfileStore();
+    s.derive([obs({ principal: "a", tool: "t", service: "s1" })]);
+    const id = ruleId("a", "t");
+    s.update(id, { constraints: { service: ["s1", "s2"] } });
+    assert.deepEqual(s.list().find((r) => r.id === id)!.constraints.service, ["s1", "s2"]);
+  });
+
+  it("persists via the writer seam and reloads via the reader seam", () => {
+    let blob = "";
+    const a = new ProfileStore({ file: "/tmp/p.json", reader: () => { throw new Error("absent"); }, writer: (_f, d) => { blob = d; } });
+    a.derive([obs({ principal: "a", tool: "t", service: "s" })]);
+    a.setStatus(ruleId("a", "t"), "accepted");
+    assert.ok(blob.includes('"accepted"'));
+    // a fresh store reads it back
+    const b = new ProfileStore({ file: "/tmp/p.json", reader: () => blob, writer: () => {} });
+    assert.equal(b.accepted().length, 1);
+    assert.equal(b.persisted, true);
+  });
+
+  it("a missing/invalid file starts empty, never throws", () => {
+    assert.doesNotThrow(() => {
+      const s = new ProfileStore({ file: "/tmp/nope.json", reader: () => "not json{", writer: () => {} });
+      assert.equal(s.size, 0);
+    });
+  });
+});

--- a/mcp-server/src/inspect/profile-store.ts
+++ b/mcp-server/src/inspect/profile-store.ts
@@ -1,0 +1,119 @@
+// Inspect — profile persistence + CRUD.
+//
+// Holds the rule set, derives suggestions from observations, lets a reviewer
+// accept/reject, and evaluates calls against the accepted rules. Persists to
+// OMCP_INSPECT_PROFILE_FILE (JSON) when configured; in-memory otherwise.
+// Reads/writes are best-effort and never throw into the call path.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import type { Observation } from "./store.js";
+import {
+  deriveProfile,
+  evaluateCall,
+  type CallSignature,
+  type EvalResult,
+  type ProfileRule,
+  type RuleStatus,
+} from "./profile.js";
+
+export interface ProfileStoreOptions {
+  file?: string;
+  /** Seam: initial rules (tests). */
+  rules?: ProfileRule[];
+  /** Seams for tests. */
+  reader?: (file: string) => string;
+  writer?: (file: string, data: string) => void;
+}
+
+export class ProfileStore {
+  private rules: ProfileRule[] = [];
+  private readonly file?: string;
+  private readonly reader: (file: string) => string;
+  private readonly writer: (file: string, data: string) => void;
+
+  constructor(opts: ProfileStoreOptions = {}) {
+    this.file = opts.file;
+    this.reader = opts.reader ?? ((f) => readFileSync(f, "utf8"));
+    this.writer = opts.writer ?? ((f, d) => writeFileSync(f, d));
+    if (opts.rules) this.rules = opts.rules;
+    else if (this.file) this.load();
+  }
+
+  private load(): void {
+    if (!this.file) return;
+    try {
+      const parsed = JSON.parse(this.reader(this.file));
+      if (parsed && Array.isArray(parsed.rules)) this.rules = parsed.rules as ProfileRule[];
+    } catch {
+      // Missing/invalid file → start empty; never fatal.
+    }
+  }
+
+  private persist(): void {
+    if (!this.file) return;
+    try {
+      this.writer(this.file, JSON.stringify({ rules: this.rules }, null, 2));
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  list(): ProfileRule[] {
+    return [...this.rules];
+  }
+
+  suggested(): ProfileRule[] {
+    return this.rules.filter((r) => r.status === "suggested");
+  }
+
+  accepted(): ProfileRule[] {
+    return this.rules.filter((r) => r.status === "accepted");
+  }
+
+  /** Derive suggestions from observations, merge, persist; return all rules. */
+  derive(observations: Observation[]): ProfileRule[] {
+    this.rules = deriveProfile(observations, this.rules);
+    this.persist();
+    return this.list();
+  }
+
+  /** Accept/reject/reset a rule by id. Returns the updated rule or null. */
+  setStatus(id: string, status: RuleStatus): ProfileRule | null {
+    const r = this.rules.find((x) => x.id === id);
+    if (!r) return null;
+    r.status = status;
+    this.persist();
+    return r;
+  }
+
+  /** Replace a rule's constraints (manual edit). Returns updated rule or null. */
+  update(id: string, patch: Partial<Pick<ProfileRule, "constraints" | "subject">>): ProfileRule | null {
+    const r = this.rules.find((x) => x.id === id);
+    if (!r) return null;
+    if (patch.constraints) r.constraints = patch.constraints;
+    if (patch.subject) r.subject = patch.subject;
+    this.persist();
+    return r;
+  }
+
+  remove(id: string): boolean {
+    const before = this.rules.length;
+    this.rules = this.rules.filter((x) => x.id !== id);
+    if (this.rules.length !== before) {
+      this.persist();
+      return true;
+    }
+    return false;
+  }
+
+  evaluate(call: CallSignature): EvalResult {
+    return evaluateCall(call, this.rules);
+  }
+
+  get size(): number {
+    return this.rules.length;
+  }
+  get persisted(): boolean {
+    return !!this.file;
+  }
+}

--- a/mcp-server/src/inspect/profile.test.ts
+++ b/mcp-server/src/inspect/profile.test.ts
@@ -1,0 +1,111 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { deriveProfile, evaluateCall, ruleId, type ProfileRule } from "./profile.js";
+import type { Observation } from "./store.js";
+
+let seq = 0;
+function obs(over: Partial<Observation> = {}): Observation {
+  return {
+    ts: new Date(1_700_000_000_000 + seq * 1000).toISOString(),
+    seq: ++seq,
+    principal: "key:bot",
+    auth: "apikey",
+    tenant: "default",
+    tool: "query_logs",
+    argShape: {},
+    outcome: "ok",
+    decision: "allow",
+    redactions: 0,
+    ...over,
+  };
+}
+
+describe("deriveProfile", () => {
+  it("creates one suggested rule per (subject,tool) with unioned constraints", () => {
+    const rules = deriveProfile([
+      obs({ principal: "alice", tool: "query_logs", service: "pay", argShape: { window: "<=1h" } }),
+      obs({ principal: "alice", tool: "query_logs", service: "order", argShape: { window: "<=5m" } }),
+      obs({ principal: "bob", tool: "query_metrics", source: "prom" }),
+    ]);
+    assert.equal(rules.length, 2);
+    const a = rules.find((r) => r.id === ruleId("alice", "query_logs"))!;
+    assert.equal(a.status, "suggested");
+    assert.deepEqual(a.constraints.service, ["order", "pay"]); // sorted union
+    assert.deepEqual(a.constraints.argShape!.window, ["<=1h", "<=5m"]);
+    assert.equal(a.provenance.learnedFrom, 2);
+    const b = rules.find((r) => r.id === ruleId("bob", "query_metrics"))!;
+    assert.deepEqual(b.constraints.source, ["prom"]);
+  });
+
+  it("is idempotent and never overwrites a human decision", () => {
+    let rules = deriveProfile([obs({ principal: "a", tool: "t", service: "s1" })]);
+    rules = rules.map((r) => ({ ...r, status: "accepted" as const }));
+    // New traffic with a NEW service value arrives + re-derive.
+    const after = deriveProfile([obs({ principal: "a", tool: "t", service: "s2" })], rules);
+    const r = after.find((x) => x.id === ruleId("a", "t"))!;
+    assert.equal(r.status, "accepted"); // untouched
+    assert.deepEqual(r.constraints.service, ["s1"]); // NOT widened to include s2
+  });
+
+  it("does not resurrect a rejected rule", () => {
+    const rejected: ProfileRule[] = [{
+      id: ruleId("a", "t"), subject: "a", tool: "t", constraints: {}, status: "rejected",
+      provenance: { learnedFrom: 1, firstSeen: "x", lastSeen: "x" },
+    }];
+    const after = deriveProfile([obs({ principal: "a", tool: "t" })], rejected);
+    assert.equal(after.find((r) => r.id === ruleId("a", "t"))!.status, "rejected");
+  });
+
+  it("refreshes a still-suggested rule from new traffic", () => {
+    let rules = deriveProfile([obs({ principal: "a", tool: "t", service: "s1" })]);
+    rules = deriveProfile([obs({ principal: "a", tool: "t", service: "s2" })], rules);
+    assert.deepEqual(rules.find((r) => r.id === ruleId("a", "t"))!.constraints.service, ["s2"]);
+  });
+});
+
+describe("evaluateCall", () => {
+  const rules: ProfileRule[] = [{
+    id: ruleId("alice", "query_logs"), subject: "alice", tool: "query_logs",
+    constraints: { service: ["pay", "order"], argShape: { window: ["<=1h", "<=5m"] } },
+    status: "accepted", provenance: { learnedFrom: 5, firstSeen: "x", lastSeen: "y" },
+  }];
+
+  const call = (over = {}) => ({ principal: "alice", tool: "query_logs", argShape: {}, ...over });
+
+  it("allows a call within an accepted rule", () => {
+    const r = evaluateCall(call({ service: "pay", argShape: { window: "<=1h" } }), rules);
+    assert.equal(r.verdict, "allow");
+  });
+
+  it("flags a new resource value outside the rule", () => {
+    const r = evaluateCall(call({ service: "secret-svc" }), rules);
+    assert.equal(r.verdict, "deviation");
+    assert.equal(r.kind, "new-resource");
+    assert.match(r.detail!, /service=secret-svc/);
+  });
+
+  it("flags an arg bucket outside the learned range", () => {
+    const r = evaluateCall(call({ service: "pay", argShape: { window: ">1d" } }), rules);
+    assert.equal(r.kind, "arg-out-of-range");
+  });
+
+  it("flags a known principal reaching for a new tool", () => {
+    const r = evaluateCall(call({ tool: "enrich_ips" }), rules);
+    assert.equal(r.kind, "new-tool");
+  });
+
+  it("flags a wholly-new principal", () => {
+    const r = evaluateCall(call({ principal: "mallory" }), rules);
+    assert.equal(r.kind, "new-principal");
+  });
+
+  it("ignores suggested/rejected rules (only accepted gate)", () => {
+    const sugg: ProfileRule[] = [{ ...rules[0], status: "suggested" }];
+    assert.equal(evaluateCall(call({ service: "pay", argShape: { window: "<=1h" } }), sugg).kind, "new-principal");
+  });
+
+  it("honours a wildcard subject rule", () => {
+    const wild: ProfileRule[] = [{ ...rules[0], subject: "*" }];
+    assert.equal(evaluateCall(call({ principal: "anyone", service: "pay", argShape: { window: "<=5m" } }), wild).verdict, "allow");
+  });
+});

--- a/mcp-server/src/inspect/profile.ts
+++ b/mcp-server/src/inspect/profile.ts
@@ -1,0 +1,153 @@
+// Inspect — behavior profile (the AppArmor-style learned ruleset).
+//
+// A profile is a set of rules, one per (subject, tool). Each rule is *derived*
+// from observed traffic (the union of resource dimensions + argument-shape
+// buckets seen for that subject+tool), lands as `suggested`, and a human
+// accepts / rejects it. Only `accepted` rules are consulted by evaluate() in
+// dry-run / enforce — `suggested` rules never block anything.
+//
+// derive() is idempotent: re-running refreshes `suggested` rules from fresh
+// traffic but never mutates a human's accepted/rejected decision, and never
+// resurrects a rejected rule.
+
+import type { Observation } from "./store.js";
+
+export type RuleStatus = "suggested" | "accepted" | "rejected";
+export type DeviationKind = "new-principal" | "new-tool" | "new-resource" | "arg-out-of-range";
+
+export interface RuleConstraints {
+  source?: string[];
+  service?: string[];
+  namespace?: string[];
+  /** Per arg key → the set of buckets seen during learning. */
+  argShape?: Record<string, string[]>;
+}
+
+export interface ProfileRule {
+  id: string;
+  subject: string;
+  tool: string;
+  constraints: RuleConstraints;
+  status: RuleStatus;
+  provenance: { learnedFrom: number; firstSeen: string; lastSeen: string };
+}
+
+export interface EvalResult {
+  verdict: "allow" | "deviation";
+  kind?: DeviationKind;
+  ruleId?: string;
+  detail?: string;
+}
+
+/** Stable per (subject, tool) id so derive() is idempotent. */
+export function ruleId(subject: string, tool: string): string {
+  return subject + "::" + tool;
+}
+
+const RES_DIMS = ["source", "service", "namespace"] as const;
+type ResDim = (typeof RES_DIMS)[number];
+
+function uniqSorted(xs: string[]): string[] {
+  return [...new Set(xs)].sort();
+}
+
+/** Build a constraint set from a group of observations. */
+function constraintsFrom(group: Observation[]): RuleConstraints {
+  const c: RuleConstraints = {};
+  for (const dim of RES_DIMS) {
+    const vals = group.map((o) => o[dim]).filter((v): v is string => typeof v === "string" && v.length > 0);
+    if (vals.length) c[dim] = uniqSorted(vals);
+  }
+  const argKeys = new Set<string>();
+  group.forEach((o) => Object.keys(o.argShape || {}).forEach((k) => argKeys.add(k)));
+  if (argKeys.size) {
+    c.argShape = {};
+    for (const k of argKeys) {
+      const buckets = group.map((o) => o.argShape?.[k]).filter((v): v is string => typeof v === "string");
+      c.argShape[k] = uniqSorted(buckets);
+    }
+  }
+  return c;
+}
+
+/**
+ * Derive suggested rules from observations, merged onto an existing rule set.
+ * Returns the FULL updated rule list. Accepted/rejected rules are preserved;
+ * suggested rules are refreshed from the latest traffic.
+ */
+export function deriveProfile(observations: Observation[], existing: ProfileRule[] = []): ProfileRule[] {
+  const byId = new Map<string, ProfileRule>();
+  for (const r of existing) byId.set(r.id, r);
+
+  // Group observations by (subject, tool).
+  const groups = new Map<string, Observation[]>();
+  for (const o of observations) {
+    const id = ruleId(o.principal, o.tool);
+    const g = groups.get(id);
+    if (g) g.push(o);
+    else groups.set(id, [o]);
+  }
+
+  for (const [id, group] of groups) {
+    const existingRule = byId.get(id);
+    if (existingRule && existingRule.status !== "suggested") continue; // never touch a human decision
+    const sorted = [...group].sort((a, b) => a.ts.localeCompare(b.ts));
+    byId.set(id, {
+      id,
+      subject: group[0].principal,
+      tool: group[0].tool,
+      constraints: constraintsFrom(group),
+      status: "suggested",
+      provenance: {
+        learnedFrom: group.length,
+        firstSeen: sorted[0].ts,
+        lastSeen: sorted[sorted.length - 1].ts,
+      },
+    });
+  }
+  return [...byId.values()];
+}
+
+/** A minimal call shape evaluate() needs (a subset of an Observation). */
+export interface CallSignature {
+  principal: string;
+  tool: string;
+  source?: string;
+  service?: string;
+  namespace?: string;
+  argShape: Record<string, string>;
+}
+
+/**
+ * Evaluate a call against the ACCEPTED rules of a profile. Returns allow when
+ * an accepted rule covers it, else a deviation classified by kind. Suggested /
+ * rejected rules are ignored.
+ */
+export function evaluateCall(call: CallSignature, rules: ProfileRule[]): EvalResult {
+  const accepted = rules.filter((r) => r.status === "accepted");
+  const subjectRules = accepted.filter((r) => r.subject === call.principal || r.subject === "*");
+  if (subjectRules.length === 0) {
+    // Has the subject any accepted rule at all? (Distinguishes a wholly-new
+    // principal from a known principal reaching for a new tool.)
+    const known = accepted.some((r) => r.subject === call.principal);
+    return { verdict: "deviation", kind: known ? "new-tool" : "new-principal" };
+  }
+  const rule = subjectRules.find((r) => r.tool === call.tool);
+  if (!rule) return { verdict: "deviation", kind: "new-tool" };
+
+  for (const dim of RES_DIMS) {
+    const v = call[dim];
+    if (v == null) continue;
+    const allowed = rule.constraints[dim];
+    if (!allowed || !allowed.includes(v)) {
+      return { verdict: "deviation", kind: "new-resource", ruleId: rule.id, detail: `${dim}=${v}` };
+    }
+  }
+  for (const [k, bucket] of Object.entries(call.argShape || {})) {
+    const allowed = rule.constraints.argShape?.[k];
+    if (!allowed || !allowed.includes(bucket)) {
+      return { verdict: "deviation", kind: "arg-out-of-range", ruleId: rule.id, detail: `${k}=${bucket}` };
+    }
+  }
+  return { verdict: "allow", ruleId: rule.id };
+}

--- a/mcp-server/src/inspect/store.test.ts
+++ b/mcp-server/src/inspect/store.test.ts
@@ -72,14 +72,14 @@ describe("InspectStore", () => {
 
   it("mirrors to the file appender when configured; never throws on append failure", () => {
     const lines: string[] = [];
-    const s = new InspectStore({ file: "/tmp/x.jsonl", appender: async (_f, l) => { lines.push(l); } });
+    const s = new InspectStore({ file: "inspect-store-test.jsonl", appender: async (_f, l) => { lines.push(l); } });
     assert.equal(s.persisted, true);
     s.record(mk({ tool: "logged" }));
     // appender is fire-and-forget; the line is queued synchronously here
     assert.equal(lines.length, 1);
     assert.match(lines[0], /"tool":"logged"/);
 
-    const boom = new InspectStore({ file: "/tmp/x.jsonl", appender: async () => { throw new Error("disk full"); } });
+    const boom = new InspectStore({ file: "inspect-store-test.jsonl", appender: async () => { throw new Error("disk full"); } });
     assert.doesNotThrow(() => boom.record(mk()));
   });
 });

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -1836,6 +1836,7 @@
       </div>
       <div class="tabs">
         <button class="tab-btn active" onclick="showInspectTab('flows')">Flows</button>
+        <button class="tab-btn" onclick="showInspectTab('profile')">Profile</button>
       </div>
       <div id="inspect-tab-flows" class="tab-content active">
         <div class="card">
@@ -1859,6 +1860,30 @@
               <div id="inspect-inspector-empty" class="empty" style="margin: 24px 0;">Select a node or edge on the left to inspect its calls, argument shapes and posture.</div>
               <div id="inspect-inspector-body" style="display:none;"></div>
             </aside>
+          </div>
+        </div>
+      </div>
+      <div id="inspect-tab-profile" class="tab-content">
+        <div class="card">
+          <div class="card-header">
+            <h2>Behavior profile <span class="muted t-xs" style="font-weight:400;">learn a baseline from observed traffic, then accept the rules that look right</span></h2>
+            <div style="display:flex; gap:8px; align-items:center;">
+              <span id="inspect-profile-counts" class="muted t-xs"></span>
+              <button class="btn btn-sm btn-primary" onclick="inspectDerive()" title="Derive suggested rules from the observed window">Learn from traffic</button>
+            </div>
+          </div>
+          <div style="padding: 0 16px 16px;">
+            <div style="margin: 4px 0 8px; display:flex; align-items:center; justify-content:space-between; gap:8px;">
+              <h3 style="font-size: var(--fs-md); margin:0;">Review queue <span class="muted t-xs" id="inspect-sugg-count"></span></h3>
+              <div id="inspect-sugg-bulk" style="display:none; gap:6px;">
+                <button class="btn btn-sm" onclick="inspectBulk('accepted')">Accept all</button>
+                <button class="btn btn-sm btn-ghost" onclick="inspectBulk('rejected')">Reject all</button>
+              </div>
+            </div>
+            <div id="inspect-review-queue"><div class="empty" style="margin: 16px 0;">No suggestions yet. Click <b>Learn from traffic</b> to derive rules from what agents have actually done.</div></div>
+
+            <h3 style="font-size: var(--fs-md); margin: 20px 0 8px;">Accepted rules <span class="muted t-xs" id="inspect-acc-count"></span></h3>
+            <div id="inspect-accepted-rules"><div class="empty" style="margin: 16px 0;">No accepted rules yet. Accept suggestions above to build the enforceable profile.</div></div>
           </div>
         </div>
       </div>
@@ -7454,6 +7479,10 @@ function inspectInit(){
   if(!inspectStarted){
     inspectStarted=true;
     wireInspectGraph();
+    // Delegated handler for profile rule actions (data-rule + data-act) — keeps
+    // user-derived rule ids out of inline onclick (XSS-safe).
+    const ptab=document.getElementById('inspect-tab-profile');
+    if(ptab) ptab.addEventListener('click',(ev)=>{ const b=ev.target.closest('button[data-rule]'); if(b) inspectRuleAction(b.getAttribute('data-rule'), b.getAttribute('data-act')); });
     // Self-checking poll: only refreshes while the tab is active AND live.
     inspectTimer=setInterval(()=>{
       if(document.getElementById('page-inspect').classList.contains('active') && inspectLive) loadInspectFlows(false);
@@ -7468,6 +7497,84 @@ function showInspectTab(name){
   const btn=[...document.querySelectorAll('#page-inspect .tab-btn')].find(b=>b.textContent.trim().toLowerCase()===name);
   if(btn) btn.classList.add('active');
   const c=document.getElementById('inspect-tab-'+name); if(c) c.classList.add('active');
+  if(name==='profile') inspectLoadProfile();
+}
+
+// --- Inspect: behavior profile (learn / review) ---
+function inspectConstraintSummary(c){
+  const parts=[];
+  ['source','service','namespace'].forEach(k=>{ if(c[k]&&c[k].length) parts.push(k+'∈{'+c[k].map(esc).join(', ')+'}'); });
+  if(c.argShape){ for(const k in c.argShape){ parts.push(esc(k)+'∈{'+c.argShape[k].map(esc).join(', ')+'}'); } }
+  return parts.length?parts.join(' · '):'<span class="muted">any (no constraints observed)</span>';
+}
+
+async function inspectLoadProfile(){
+  try{
+    const r=await fetch('/api/inspect/profile');
+    if(!r.ok){ document.getElementById('inspect-review-queue').innerHTML='<div class="empty" style="margin:16px 0;">'+(r.status===403?'You don’t have permission to view the profile.':'Profile unavailable.')+'</div>'; return; }
+    renderInspectProfile(await r.json());
+  }catch(e){}
+}
+
+async function inspectDerive(){
+  try{
+    const win=(document.getElementById('inspect-window')||{}).value||'24h';
+    const r=await fetch('/api/inspect/profile/derive?window='+encodeURIComponent(win),{method:'POST'});
+    if(!r.ok){ toast(r.status===403?'Need inspection:write to learn':'Learn failed', 'error'); return; }
+    const j=await r.json();
+    toast('Learned from '+j.learnedFrom+' calls · '+j.suggested+' suggestions', 'ok');
+    inspectLoadProfile();
+  }catch(e){ toast('Learn failed','error'); }
+}
+
+async function inspectRuleAction(id,status){
+  try{
+    const r=await fetch('/api/inspect/profile/rules/'+encodeURIComponent(id),{method:'PATCH',headers:{'content-type':'application/json'},body:JSON.stringify({status})});
+    if(!r.ok){ toast(r.status===403?'Need inspection:write':'Update failed','error'); return; }
+    inspectLoadProfile();
+  }catch(e){ toast('Update failed','error'); }
+}
+
+async function inspectBulk(status){
+  const ids=(window.__inspectSuggestedIds||[]);
+  for(const id of ids){ await inspectRuleAction(id,status); }
+}
+
+function renderInspectProfile(data){
+  const rules=data.rules||[]; const c=data.counts||{};
+  document.getElementById('inspect-profile-counts').textContent=(c.suggested||0)+' suggested · '+(c.accepted||0)+' accepted'+(data.persisted?' · persisted':'');
+  const sugg=rules.filter(r=>r.status==='suggested');
+  const acc=rules.filter(r=>r.status==='accepted');
+  window.__inspectSuggestedIds=sugg.map(r=>r.id);
+  document.getElementById('inspect-sugg-count').textContent=sugg.length?('('+sugg.length+')'):'';
+  document.getElementById('inspect-acc-count').textContent=acc.length?('('+acc.length+')'):'';
+  document.getElementById('inspect-sugg-bulk').style.display=sugg.length>1?'flex':'none';
+
+  const q=document.getElementById('inspect-review-queue');
+  if(!sugg.length){ q.innerHTML='<div class="empty" style="margin:16px 0;">No pending suggestions. Click <b>Learn from traffic</b> to (re-)derive from the selected window.</div>'; }
+  else{
+    q.innerHTML=sugg.map(r=>'<div class="card" style="margin:0 0 8px; padding:12px 14px;">'
+      +'<div style="display:flex; justify-content:space-between; gap:12px; align-items:flex-start;">'
+        +'<div style="min-width:0;">'
+          +'<div style="font-weight:600;">'+esc(r.subject)+' <span class="muted">→</span> <span style="color:var(--accent)">'+esc(r.tool)+'</span></div>'
+          +'<div class="muted t-xs" style="margin:4px 0;">'+inspectConstraintSummary(r.constraints)+'</div>'
+          +'<div class="muted t-xs">learned from '+r.provenance.learnedFrom+' call'+(r.provenance.learnedFrom===1?'':'s')+'</div>'
+        +'</div>'
+        +'<div style="display:flex; gap:6px; flex-shrink:0;">'
+          +'<button class="btn btn-sm btn-primary" data-rule="'+escHtml(r.id)+'" data-act="accepted">Accept</button>'
+          +'<button class="btn btn-sm btn-ghost" data-rule="'+escHtml(r.id)+'" data-act="rejected">Reject</button>'
+        +'</div>'
+      +'</div></div>').join('');
+  }
+
+  const a=document.getElementById('inspect-accepted-rules');
+  if(!acc.length){ a.innerHTML='<div class="empty" style="margin:16px 0;">No accepted rules yet.</div>'; }
+  else{
+    a.innerHTML='<table class="dtable"><thead><tr><th>Subject</th><th>Tool</th><th>Constraints</th><th>Learned</th><th></th></tr></thead><tbody>'
+      +acc.map(r=>'<tr><td>'+esc(r.subject)+'</td><td>'+esc(r.tool)+'</td><td class="muted t-xs">'+inspectConstraintSummary(r.constraints)+'</td><td>'+r.provenance.learnedFrom+'</td>'
+        +'<td style="text-align:right; white-space:nowrap;"><button class="btn btn-sm btn-ghost" data-rule="'+escHtml(r.id)+'" data-act="suggested" title="Move back to review">Unaccept</button></td></tr>').join('')
+      +'</tbody></table>';
+  }
 }
 
 function toggleInspectLive(){


### PR DESCRIPTION
**Phase 3** — the AppArmor-style **learn loop**. Suggestions only; no enforcement on the call path yet.

### Backend
- `inspect/profile.ts` — `deriveProfile` (one rule per subject+tool, union of observed resource dims + arg-shape buckets; **idempotent** — never touches an accepted/rejected rule, never resurrects a rejected one) + `evaluateCall` (classifies new-principal / new-tool / new-resource / arg-out-of-range; **only accepted rules gate**; wildcard subject). The evaluator is the seam for P4/P5 — **not wired** to the recorder yet.
- `inspect/profile-store.ts` — `ProfileStore` (derive/setStatus/update/remove/evaluate; best-effort JSON persistence via `OMCP_INSPECT_PROFILE_FILE`; never throws on bad/missing file).
- API: `GET /api/inspect/profile`, `POST …/derive`, `PATCH`+`DELETE …/rules/:id` (mutations `inspection:write` + audited).

### UI — Profile sub-tab
"Learn from traffic" → a **review queue** of suggested rules (Accept/Reject + bulk) → an **accepted-rules table**. Actions use `data-*` + a delegated handler (no inline `onclick` with user data); ids use `escHtml`, names/keys use `esc`.

### Security
Reviewer flagged a stored-XSS: the arg-shape **key** in the constraint summary (an arbitrary tool-call argument name, preserved through redaction) was interpolated unescaped. **Fixed** (`esc(k)`). All other interpolations were already escaped/delegated.

### Tests
16 new unit tests (derive idempotency, evaluate classification, store persistence). Playwright Profile test (learn→review→accept) green in a real browser, no console errors. Full suite **945 pass / 0 fail**, tsc clean.

Profile/learn only — dry-run + Deviations is P4, enforce is P5. **Not** released until final review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)