### PR TITLE
feat(inspect): dry-run (complain) mode + Deviations view (P4)

### DIFF
--- a/mcp-server/playwright/inspect.spec.mjs
+++ b/mcp-server/playwright/inspect.spec.mjs
@@ -94,4 +94,32 @@ test.describe("Inspect — Flows live graph", () => {
 
     expect(errors, `console errors: ${errors.join("\n")}`).toEqual([]);
   });
+
+  test("mode segmented control switches to Dry-run; Deviations tab renders", async ({ page }) => {
+    const errors = [];
+    page.on("console", (m) => { if (m.type() === "error") errors.push(m.text()); });
+    page.on("pageerror", (e) => errors.push(String(e)));
+
+    await page.goto(BASE, { waitUntil: "networkidle" });
+    await page.locator('[data-page="inspect"]').click();
+    await page.locator('#page-inspect .tab-btn', { hasText: "Profile" }).click();
+
+    // Flip Observe → Dry-run via the segmented control; the masthead chip and
+    // the description update to reflect the new mode.
+    await page.locator('#inspect-mode-seg button[data-mode="dryrun"]').click();
+    await expect(page.locator("#inspect-mode-chip")).toHaveText(/Dry-run/, { timeout: 10_000 });
+    await expect(page.locator('#inspect-mode-seg button[data-mode="dryrun"]')).toHaveClass(/active/);
+
+    // Deviations tab renders a table or an honest empty state.
+    await page.locator('#page-inspect .tab-btn', { hasText: "Deviations" }).click();
+    await expect(page.locator("#inspect-tab-deviations")).toHaveClass(/active/);
+    await expect(page.locator("#inspect-deviations")).toBeVisible();
+
+    // Restore observe so the test is idempotent against the shared demo server.
+    await page.locator('#page-inspect .tab-btn', { hasText: "Profile" }).click();
+    await page.locator('#inspect-mode-seg button[data-mode="observe"]').click();
+    await expect(page.locator("#inspect-mode-chip")).toHaveText(/Observe/, { timeout: 10_000 });
+
+    expect(errors, `console errors: ${errors.join("\n")}`).toEqual([]);
+  });
 });

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1520,18 +1520,20 @@ async function main() {
   // evaluation (dry-run/enforce) is wired in a later phase.
   const inspectStore = new InspectStore({ file: process.env.OMCP_INSPECT_FILE?.trim() || undefined });
   const inspectMode = new ModeController(bootMode(process.env.OMCP_INSPECT));
+  // Behavior profile (the learned ruleset). Accepted rules drive the
+  // evaluator: in dry-run the recorder records a `would-block` deviation for
+  // calls outside the profile (never blocks — enforce blocking is a later
+  // phase). Persists to OMCP_INSPECT_PROFILE_FILE when set.
+  const inspectProfile = new ProfileStore({ file: process.env.OMCP_INSPECT_PROFILE_FILE?.trim() || undefined });
   hookRegistry.register(
     createInspectRecorder(inspectStore, inspectMode, {
       onEvent: (e) => recordInspectEvent(e.tool, e.outcome, e.decision),
+      evaluator: inspectProfile,
     }),
   );
   if (inspectMode.get() !== "observe") {
     console.log(`[inspect] mode=${inspectMode.get()} (store ${inspectStore.persisted ? "persisted" : "in-memory"})`);
   }
-  // Behavior profile (the learned ruleset). Suggestions are derived from the
-  // observation store on demand; accepted rules drive dry-run/enforce (wired
-  // in a later phase). Persists to OMCP_INSPECT_PROFILE_FILE when set.
-  const inspectProfile = new ProfileStore({ file: process.env.OMCP_INSPECT_PROFILE_FILE?.trim() || undefined });
 
   // Phase F15: anomaly-history sink — opt-in via
   // OMCP_ANOMALY_HISTORY_REMOTE_WRITE. When configured, anomaly
@@ -2462,6 +2464,17 @@ async function main() {
     const ok = inspectProfile.remove(String(req.params.id));
     if (!ok) { res.status(404).json({ error: "rule not found" }); return; }
     res.json({ ok: true });
+  });
+
+  // Deviations: calls in the window that fell outside the accepted profile
+  // (decision != allow). In dry-run these are would-block; in enforce, blocked.
+  app.get("/api/inspect/deviations", need("inspection", "read"), (req, res) => {
+    const tenant = inspectScope(req);
+    const windowSecs = durationToSeconds(qstr(req.query.window) || "24h") ?? 86400;
+    let evs = inspectStore.since(Date.now() - windowSecs * 1000).filter((e) => e.decision !== "allow");
+    if (tenant) evs = evs.filter((e) => e.tenant === tenant);
+    evs.reverse(); // newest first
+    res.json({ deviations: evs, total: evs.length, mode: inspectMode.get(), scopedTo: tenant });
   });
 
   // --- /api/audit/dlq — webhook-sink dead-letter queue surface (P9) ---

--- a/mcp-server/src/inspect/recorder.test.ts
+++ b/mcp-server/src/inspect/recorder.test.ts
@@ -92,6 +92,34 @@ describe("createInspectRecorder", () => {
     assert.deepEqual(r, { allow: true });
   });
 
+  it("dry-run: records would-block + deviation kind for a profile deviation", async () => {
+    const store = new InspectStore();
+    const evaluator = { evaluate: () => ({ verdict: "deviation" as const, kind: "new-resource" }) };
+    const reg = createInspectRecorder(store, new ModeController("dryrun"), { evaluator });
+    await reg.handler(ctx({ target: "query_logs" }), { args: { service: "novel" }, result: {} });
+    const o = store.all()[0];
+    assert.equal(o.decision, "would-block");
+    assert.equal(o.deviation, "new-resource");
+  });
+
+  it("dry-run: records allow when the call is within profile", async () => {
+    const store = new InspectStore();
+    const evaluator = { evaluate: () => ({ verdict: "allow" as const }) };
+    const reg = createInspectRecorder(store, new ModeController("dryrun"), { evaluator });
+    await reg.handler(ctx(), { args: {}, result: {} });
+    assert.equal(store.all()[0].decision, "allow");
+  });
+
+  it("observe mode never consults the evaluator (always allow)", async () => {
+    const store = new InspectStore();
+    let consulted = false;
+    const evaluator = { evaluate: () => { consulted = true; return { verdict: "deviation" as const, kind: "new-tool" }; } };
+    const reg = createInspectRecorder(store, new ModeController("observe"), { evaluator });
+    await reg.handler(ctx(), { args: {}, result: {} });
+    assert.equal(store.all()[0].decision, "allow");
+    assert.equal(consulted, false);
+  });
+
   it("fires the onEvent metrics seam", async () => {
     const seen: Array<{ tool: string; outcome: string; decision: string }> = [];
     const reg = createInspectRecorder(new InspectStore(), new ModeController("observe"), {

--- a/mcp-server/src/inspect/recorder.ts
+++ b/mcp-server/src/inspect/recorder.ts
@@ -21,16 +21,29 @@ export function authKind(principal: string): string {
   return principal === "anonymous" ? "anonymous" : "apikey";
 }
 
+/** A profile evaluation seam — given a derived call signature, returns the
+ *  verdict against the accepted profile. Absent in pure observe mode. */
+export interface ProfileEvaluator {
+  evaluate(call: {
+    principal: string; tool: string; source?: string; service?: string; namespace?: string; argShape: Record<string, string>;
+  }): { verdict: "allow" | "deviation"; kind?: string };
+}
+
 export interface RecorderOptions {
   /** Metrics seam — called once per recorded observation. */
   onEvent?: (e: { tool: string; outcome: Outcome; decision: Decision }) => void;
+  /** Accepted-profile evaluator. Consulted only when mode.evaluating
+   *  (dry-run / enforce). When a call deviates it is recorded `would-block`
+   *  — this post-invoke recorder never blocks (enforce blocking is a separate
+   *  pre-invoke hook). */
+  evaluator?: ProfileEvaluator;
 }
 
 /**
- * Build the observe-mode recorder hook. Records every tool call as an
- * allow-observation when the mode is recording (anything but `off`).
- * Dry-run/enforce decisioning is a separate pre-invoke hook (added later);
- * this one only ever records `decision: "allow"`.
+ * Build the recorder hook (tool_post_invoke, permissive). Records every call
+ * while the mode is recording. In dry-run / enforce it also evaluates the call
+ * against the accepted profile and records a `would-block` decision + deviation
+ * kind for calls outside the profile — but never blocks (it runs post-invoke).
  */
 export function createInspectRecorder(
   store: InspectStore,
@@ -43,6 +56,19 @@ export function createInspectRecorder(
       const red = redactValue((payload as { args?: unknown }).args);
       const sig = deriveSignature(ctx.target, red.value);
       const outcome: Outcome = isErrorResult((payload as { result?: unknown }).result) ? "error" : "ok";
+      let decision: Decision = "allow";
+      let deviation: string | undefined;
+      if (mode.evaluating && opts.evaluator) {
+        const ev = opts.evaluator.evaluate({
+          principal: ctx.principal, tool: ctx.target,
+          source: sig.source, service: sig.service, namespace: sig.namespace,
+          argShape: sig.argShape,
+        });
+        if (ev.verdict === "deviation") {
+          decision = "would-block";
+          deviation = ev.kind;
+        }
+      }
       store.record({
         principal: ctx.principal,
         auth: authKind(ctx.principal),
@@ -53,10 +79,11 @@ export function createInspectRecorder(
         namespace: sig.namespace,
         argShape: sig.argShape,
         outcome,
-        decision: "allow",
+        decision,
+        deviation,
         redactions: red.totalMatches,
       });
-      opts.onEvent?.({ tool: ctx.target, outcome, decision: "allow" });
+      opts.onEvent?.({ tool: ctx.target, outcome, decision });
     } catch {
       // Observation must never affect the call path.
     }

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -1837,6 +1837,7 @@
       <div class="tabs">
         <button class="tab-btn active" onclick="showInspectTab('flows')">Flows</button>
         <button class="tab-btn" onclick="showInspectTab('profile')">Profile</button>
+        <button class="tab-btn" onclick="showInspectTab('deviations')">Deviations</button>
       </div>
       <div id="inspect-tab-flows" class="tab-content active">
         <div class="card">
@@ -1864,6 +1865,18 @@
         </div>
       </div>
       <div id="inspect-tab-profile" class="tab-content">
+        <div class="card" style="margin-bottom:8px; padding:12px 14px;">
+          <div style="display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap;">
+            <div>
+              <div style="font-weight:600;">Mode</div>
+              <div class="muted t-xs" id="inspect-mode-desc">…</div>
+            </div>
+            <div class="pg-seg" id="inspect-mode-seg" role="group" aria-label="Inspection mode">
+              <button data-mode="observe" onclick="inspectSetMode('observe')">Observe</button>
+              <button data-mode="dryrun" onclick="inspectSetMode('dryrun')">Dry-run</button>
+            </div>
+          </div>
+        </div>
         <div class="card">
           <div class="card-header">
             <h2>Behavior profile <span class="muted t-xs" style="font-weight:400;">learn a baseline from observed traffic, then accept the rules that look right</span></h2>
@@ -1885,6 +1898,18 @@
             <h3 style="font-size: var(--fs-md); margin: 20px 0 8px;">Accepted rules <span class="muted t-xs" id="inspect-acc-count"></span></h3>
             <div id="inspect-accepted-rules"><div class="empty" style="margin: 16px 0;">No accepted rules yet. Accept suggestions above to build the enforceable profile.</div></div>
           </div>
+        </div>
+      </div>
+      <div id="inspect-tab-deviations" class="tab-content">
+        <div class="card">
+          <div class="card-header">
+            <h2>Deviations <span class="muted t-xs" style="font-weight:400;">calls outside the accepted profile — would-block in dry-run, blocked in enforce</span></h2>
+            <div style="display:flex; gap:8px; align-items:center;">
+              <span id="inspect-dev-stat" class="muted t-xs"></span>
+              <button class="btn btn-sm" onclick="inspectLoadDeviations()">Refresh</button>
+            </div>
+          </div>
+          <div id="inspect-deviations" style="padding:0 16px 16px;"><div class="empty" style="margin:16px 0;">Switch to <b>Dry-run</b> and accept some rules — calls that fall outside them show up here as “would-block”, so you can verify the profile before enforcing.</div></div>
         </div>
       </div>
     </div>
@@ -7497,7 +7522,47 @@ function showInspectTab(name){
   const btn=[...document.querySelectorAll('#page-inspect .tab-btn')].find(b=>b.textContent.trim().toLowerCase()===name);
   if(btn) btn.classList.add('active');
   const c=document.getElementById('inspect-tab-'+name); if(c) c.classList.add('active');
-  if(name==='profile') inspectLoadProfile();
+  if(name==='profile'){ inspectRefreshMode(); inspectLoadProfile(); }
+  if(name==='deviations') inspectLoadDeviations();
+}
+
+const INSPECT_MODE_DESC={
+  off:'Disabled — no recording.',
+  observe:'Recording only — every tool call is captured; nothing is evaluated or blocked.',
+  dryrun:'Evaluating against accepted rules — deviations are flagged (see Deviations) but still allowed.',
+  enforce:'Enforcing — calls outside the accepted profile are blocked.'
+};
+
+async function inspectRefreshMode(){
+  try{ const r=await fetch('/api/inspect/mode'); if(r.ok) updateInspectModeChip(await r.json()); }catch(e){}
+}
+
+async function inspectSetMode(mode){
+  try{
+    const r=await fetch('/api/inspect/mode',{method:'PUT',headers:{'content-type':'application/json'},body:JSON.stringify({mode})});
+    if(!r.ok){ toast(r.status===403?'Need inspection:write to change mode':'Mode change failed','error'); return; }
+    const j=await r.json();
+    toast('Inspection mode: '+(j.mode||mode),'ok');
+    inspectRefreshMode();
+    if(document.getElementById('inspect-tab-deviations').classList.contains('active')) inspectLoadDeviations();
+  }catch(e){ toast('Mode change failed','error'); }
+}
+
+async function inspectLoadDeviations(){
+  try{
+    const win=(document.getElementById('inspect-window')||{}).value||'24h';
+    const r=await fetch('/api/inspect/deviations?window='+encodeURIComponent(win));
+    const box=document.getElementById('inspect-deviations');
+    if(!r.ok){ box.innerHTML='<div class="empty" style="margin:16px 0;">'+(r.status===403?'You don’t have permission to view deviations.':'Unavailable.')+'</div>'; return; }
+    const j=await r.json();
+    document.getElementById('inspect-dev-stat').textContent=(j.total||0)+' in window · mode '+(j.mode||'');
+    const devs=j.deviations||[];
+    if(!devs.length){ box.innerHTML='<div class="empty" style="margin:16px 0;">No deviations in this window. In <b>Observe</b> mode nothing is evaluated; switch to <b>Dry-run</b> with accepted rules to surface would-block calls.</div>'; return; }
+    box.innerHTML='<table class="dtable"><thead><tr><th>When</th><th>Identity</th><th>Tool</th><th>Backend</th><th>Why</th><th>Decision</th></tr></thead><tbody>'
+      +devs.map(d=>{ const backend=d.service||d.source||d.namespace||'—'; const dec=d.decision==='blocked'?'<span class="stchip bad">blocked</span>':'<span class="stchip warn">would-block</span>';
+        return '<tr><td class="muted t-xs">'+esc((d.ts||'').replace('T',' ').replace(/\..*/,''))+'</td><td>'+esc(d.principal)+'</td><td>'+esc(d.tool)+'</td><td>'+esc(backend)+'</td><td class="t-xs">'+esc(d.deviation||'deviation')+(d.detail?(' · '+esc(d.detail)):'')+'</td><td>'+dec+'</td></tr>'; }).join('')
+      +'</tbody></table>';
+  }catch(e){}
 }
 
 // --- Inspect: behavior profile (learn / review) ---
@@ -7610,6 +7675,11 @@ function updateInspectModeChip(m){
   chip.textContent='● '+label;
   chip.className='stchip '+(mode==='enforce'?'bad':mode==='dryrun'?'warn':mode==='off'?'':'ok');
   chip.title='Inspection mode: '+label+(m.size!=null?(' · '+m.size+' observations stored'):'');
+  // Reflect into the Profile-tab segmented control + description, when present.
+  const seg=document.getElementById('inspect-mode-seg');
+  if(seg) seg.querySelectorAll('button[data-mode]').forEach(b=>b.classList.toggle('active', b.getAttribute('data-mode')===mode));
+  const desc=document.getElementById('inspect-mode-desc');
+  if(desc) desc.textContent=(typeof INSPECT_MODE_DESC!=='undefined'&&INSPECT_MODE_DESC[mode])||'';
 }
 
 function showInspectGraphMessage(msg){


### PR DESCRIPTION
**Phase 4** — dry-run (complain) mode. Evaluates calls against the accepted profile and surfaces deviations; **never blocks** (blocking is P5).

- **recorder.ts**: optional `evaluator`; when `mode.evaluating` (dryrun/enforce) the post-invoke recorder evaluates the derived signature and records `would-block` + deviation kind for out-of-profile calls. Returns `allow:true` on every path — cannot block or throw. Observe never consults the evaluator.
- **index.ts**: `ProfileStore` constructed before the recorder and passed as the evaluator; `GET /api/inspect/deviations` (decision≠allow in window, tenant-scoped, `inspection:read`).
- **UI**: Observe↔Dry-run **segmented control** in Profile (PUT mode, `inspection:write`+audited) with a live description; **Deviations sub-tab** table. All user-derived cells escaped via `esc`.

### Tests
3 new dry-run recorder unit tests; Playwright mode-switch + Deviations test green in a real browser (no console errors). Full suite **948 pass / 0 fail**, tsc clean. Reviewer: **SHIP** — confirmed no blocking leak (no new pre-invoke hook, `allow:true` always) and every Deviations cell escaped.

Enforce blocking + full E2E is P5. **Not** released until final review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)