### PR TITLE
feat(inspect): enforce mode — block out-of-profile calls + full E2E (P5)

### DIFF
--- a/mcp-server/playwright/inspect.spec.mjs
+++ b/mcp-server/playwright/inspect.spec.mjs
@@ -122,4 +122,25 @@ test.describe("Inspect — Flows live graph", () => {
 
     expect(errors, `console errors: ${errors.join("\n")}`).toEqual([]);
   });
+
+  test("Enforce is gated behind a confirmation (Cancel does not enforce)", async ({ page }) => {
+    // This test deliberately only opens + cancels the confirm — it must NOT
+    // actually switch the shared demo server into enforce mode.
+    await page.goto(BASE, { waitUntil: "networkidle" });
+    await page.locator('[data-page="inspect"]').click();
+    await page.locator('#page-inspect .tab-btn', { hasText: "Profile" }).click();
+
+    // Clicking Enforce reveals a confirmation with an impact warning — it does
+    // not change the mode yet.
+    await page.locator('#inspect-mode-seg button[data-mode="enforce"]').click();
+    const confirm = page.locator("#inspect-enforce-confirm");
+    await expect(confirm).toBeVisible();
+    await expect(confirm).toContainText(/block/i);
+    await expect(page.locator("#inspect-mode-chip")).not.toHaveText(/Enforce/);
+
+    // Cancel dismisses it; mode stays unchanged.
+    await confirm.locator("button", { hasText: "Cancel" }).click();
+    await expect(confirm).toBeHidden();
+    await expect(page.locator("#inspect-mode-chip")).not.toHaveText(/Enforce/);
+  });
 });

--- a/mcp-server/src/conformance/inspect-e2e.test.ts
+++ b/mcp-server/src/conformance/inspect-e2e.test.ts
@@ -80,3 +80,51 @@ test("/api/inspect/mode reports a recording mode", opts, async () => {
   const m = (await res.json()) as { mode: string; recording: boolean };
   assert.ok(["off", "observe", "dryrun", "enforce"].includes(m.mode));
 });
+
+test("enforce: an out-of-profile tool call is blocked end-to-end", opts, async () => {
+  // CSRF double-submit: grab the issued token, echo it on every mutation.
+  const probe = await fetch(`${base}/api/inspect/mode`);
+  const sc = probe.headers.get("set-cookie") || "";
+  const tok = (sc.match(/omcp-csrf=([^;]+)/) || [])[1];
+  const csrf: Record<string, string> = tok ? { "x-csrf-token": decodeURIComponent(tok), cookie: `omcp-csrf=${tok}` } : {};
+  const write = (path: string, method: string, body: unknown) =>
+    fetch(`${base}${path}`, { method, headers: { "content-type": "application/json", ...csrf }, body: JSON.stringify(body) });
+
+  // MCP session + an observed list_sources call (gives us a rule to accept).
+  const init = await rpc("initialize", { protocolVersion: "2025-11-25", capabilities: {}, clientInfo: { name: "inspect-e2e", version: "0" } });
+  const session = init.session!;
+  await fetch(URL_ENV!, { method: "POST", headers: { "content-type": "application/json", accept: "application/json, text/event-stream", "mcp-session-id": session }, body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized", params: {} }) });
+  await rpc("tools/call", { name: "list_sources", arguments: {} }, session);
+  await new Promise((r) => setTimeout(r, 250));
+
+  try {
+    // Learn, then accept ONLY the list_sources rule — so list_sources is
+    // allow-listed but every other tool deviates, regardless of demo traffic.
+    await write("/api/inspect/profile/derive?window=24h", "POST", {});
+    const prof = (await (await fetch(`${base}/api/inspect/profile`)).json()) as { rules: Array<{ id: string; tool: string; status: string }> };
+    const lsRule = prof.rules.find((r) => r.tool === "list_sources");
+    assert.ok(lsRule, "a list_sources rule was derived");
+    const acc = await write(`/api/inspect/profile/rules/${encodeURIComponent(lsRule!.id)}`, "PATCH", { status: "accepted" });
+    assert.equal(acc.status, 200, "rule accepted (CSRF + inspection:write OK)");
+
+    // Switch to enforce.
+    const setRes = await write("/api/inspect/mode", "PUT", { mode: "enforce" });
+    assert.equal(setRes.status, 200, "mode set to enforce");
+
+    // list_sources is within the accepted rule → NOT blocked.
+    const okCall = await rpc("tools/call", { name: "list_sources", arguments: {} }, session);
+    assert.doesNotMatch(okCall.text, /Blocked by the inspection profile/, "accepted tool allowed under enforce");
+
+    // list_services has no accepted rule → blocked by the enforcer.
+    const blocked = await rpc("tools/call", { name: "list_services", arguments: {} }, session);
+    assert.match(blocked.text, /Blocked by the inspection profile/, "out-of-profile tool blocked under enforce");
+
+    // The block is recorded as a deviation.
+    await new Promise((r) => setTimeout(r, 200));
+    const devs = (await (await fetch(`${base}/api/inspect/deviations?window=1h`)).json()) as { deviations: Array<{ tool: string; decision: string }> };
+    assert.ok(devs.deviations.some((d) => d.tool === "list_services" && d.decision === "blocked"), "blocked deviation recorded");
+  } finally {
+    // ALWAYS restore observe so we never leave the shared demo server enforcing.
+    await write("/api/inspect/mode", "PUT", { mode: "observe" }).catch(() => {});
+  }
+});

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -109,7 +109,7 @@ import { selfRegistry, withToolMetrics, apiRequests, mcpActiveSessions, auditDlq
 import { initOtel } from "./observability/otel.js";
 import { WebSocketServerTransport } from "./transport/websocket.js";
 import { HookRegistry } from "./sdk/hooks.js";
-import { InspectStore, ModeController, bootMode, createInspectRecorder, buildFlowGraph, durationToSeconds, ProfileStore } from "./inspect/index.js";
+import { InspectStore, ModeController, bootMode, createInspectRecorder, createInspectEnforcer, buildFlowGraph, durationToSeconds, ProfileStore } from "./inspect/index.js";
 import type { Outcome, Decision, RuleStatus } from "./inspect/index.js";
 import { wrapToolHandler, wrapResourceHandler, wrapPromptHandler } from "./sdk/hook-wrappers.js";
 import { UpstreamClient } from "./federation/upstream.js";
@@ -1529,6 +1529,13 @@ async function main() {
     createInspectRecorder(inspectStore, inspectMode, {
       onEvent: (e) => recordInspectEvent(e.tool, e.outcome, e.decision),
       evaluator: inspectProfile,
+    }),
+  );
+  // Enforcer: pre-invoke gate that blocks (and records) calls outside the
+  // accepted profile — only when mode is `enforce`. Pass-through otherwise.
+  hookRegistry.register(
+    createInspectEnforcer(inspectStore, inspectMode, inspectProfile, {
+      onEvent: (e) => recordInspectEvent(e.tool, e.outcome, e.decision),
     }),
   );
   if (inspectMode.get() !== "observe") {

--- a/mcp-server/src/inspect/enforcer.test.ts
+++ b/mcp-server/src/inspect/enforcer.test.ts
@@ -1,0 +1,72 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createInspectEnforcer } from "./enforcer.js";
+import { InspectStore } from "./store.js";
+import { ModeController } from "./mode.js";
+import type { HookContext } from "../sdk/hooks.js";
+
+const ctx = (over: Partial<HookContext> = {}): HookContext => ({
+  principal: "key:bot", tenant: "default", kind: "tool_pre_invoke", target: "query_logs", ...over,
+});
+const allowEval = { evaluate: () => ({ verdict: "allow" as const }) };
+const denyEval = { evaluate: () => ({ verdict: "deviation" as const, kind: "new-resource" }) };
+
+describe("createInspectEnforcer", () => {
+  it("registers as a permissive tool_pre_invoke hook", () => {
+    const reg = createInspectEnforcer(new InspectStore(), new ModeController("enforce"), allowEval);
+    assert.equal(reg.kind, "tool_pre_invoke");
+    assert.equal(reg.mode, "permissive");
+    assert.equal(reg.pluginName, "inspect-enforcer");
+  });
+
+  it("enforce: BLOCKS a deviation and records a blocked observation", async () => {
+    const store = new InspectStore();
+    const reg = createInspectEnforcer(store, new ModeController("enforce"), denyEval);
+    const r = await reg.handler(ctx({ target: "query_logs" }), { args: { service: "novel" } });
+    assert.equal(r.allow, false);
+    assert.match(r.reason!, /Blocked by the inspection profile/);
+    assert.match(r.reason!, /new-resource/);
+    const o = store.all()[0];
+    assert.equal(o.decision, "blocked");
+    assert.equal(o.deviation, "new-resource");
+    assert.equal(o.tool, "query_logs");
+  });
+
+  it("enforce: ALLOWS an in-profile call and records nothing (post-invoke recorder will)", async () => {
+    const store = new InspectStore();
+    const reg = createInspectEnforcer(store, new ModeController("enforce"), allowEval);
+    const r = await reg.handler(ctx(), { args: {} });
+    assert.deepEqual(r, { allow: true });
+    assert.equal(store.size, 0);
+  });
+
+  it("observe + dry-run never block (pass-through, no eval)", async () => {
+    for (const mode of ["off", "observe", "dryrun"] as const) {
+      let consulted = false;
+      const evaluator = { evaluate: () => { consulted = true; return { verdict: "deviation" as const, kind: "new-tool" }; } };
+      const store = new InspectStore();
+      const reg = createInspectEnforcer(store, new ModeController(mode), evaluator);
+      const r = await reg.handler(ctx(), { args: {} });
+      assert.deepEqual(r, { allow: true }, `mode=${mode} must pass through`);
+      assert.equal(consulted, false, `mode=${mode} must not evaluate`);
+      assert.equal(store.size, 0);
+    }
+  });
+
+  it("fails OPEN — an evaluator that throws never blocks the call", async () => {
+    const store = new InspectStore();
+    const boom = { evaluate: () => { throw new Error("inspector bug"); } };
+    const reg = createInspectEnforcer(store, new ModeController("enforce"), boom);
+    const r = await reg.handler(ctx(), { args: {} });
+    assert.deepEqual(r, { allow: true });
+  });
+
+  it("fires the onEvent metrics seam on a block", async () => {
+    const seen: Array<{ tool: string; decision: string }> = [];
+    const reg = createInspectEnforcer(new InspectStore(), new ModeController("enforce"), denyEval, {
+      onEvent: (e) => seen.push(e),
+    });
+    await reg.handler(ctx({ target: "enrich_ips" }), { args: {} });
+    assert.deepEqual(seen, [{ tool: "enrich_ips", outcome: "error", decision: "blocked" }]);
+  });
+});

--- a/mcp-server/src/inspect/enforcer.ts
+++ b/mcp-server/src/inspect/enforcer.ts
@@ -1,0 +1,79 @@
+// Inspect — the enforcer.
+//
+// A `tool_pre_invoke` hook that BLOCKS calls falling outside the accepted
+// profile, but ONLY when the mode is `enforce`. In observe/dry-run it is a
+// pass-through (dry-run's would-block recording happens in the post-invoke
+// recorder). When it blocks, it records a `blocked` observation itself —
+// because a pre-invoke denial short-circuits the dispatch, so the post-invoke
+// recorder never runs for blocked calls (no double-recording).
+//
+// Fail-open: any internal error returns allow:true. An inspector bug must
+// never become a denial-of-service for the agent's tools.
+
+import type { HookContext, HookPayload, HookRegistration, HookResult } from "../sdk/hooks.js";
+import { redactValue } from "../policy/redact.js";
+import { deriveSignature } from "./signature.js";
+import type { InspectStore } from "./store.js";
+import type { ModeController } from "./mode.js";
+import { authKind, type ProfileEvaluator } from "./recorder.js";
+
+export interface EnforcerOptions {
+  onEvent?: (e: { tool: string; outcome: "ok" | "error"; decision: "blocked" }) => void;
+}
+
+/**
+ * Build the enforce-mode pre-invoke hook. Blocks (and records) calls outside
+ * the accepted profile only when mode is `enforce`; pass-through otherwise.
+ */
+export function createInspectEnforcer(
+  store: InspectStore,
+  mode: ModeController,
+  evaluator: ProfileEvaluator,
+  opts: EnforcerOptions = {},
+): HookRegistration {
+  const handler = (ctx: HookContext, payload: HookPayload): HookResult => {
+    try {
+      if (!mode.blocking) return { allow: true };
+      const red = redactValue((payload as { args?: unknown }).args);
+      const sig = deriveSignature(ctx.target, red.value);
+      const ev = evaluator.evaluate({
+        principal: ctx.principal, tool: ctx.target,
+        source: sig.source, service: sig.service, namespace: sig.namespace,
+        argShape: sig.argShape,
+      });
+      if (ev.verdict === "deviation") {
+        store.record({
+          principal: ctx.principal,
+          auth: authKind(ctx.principal),
+          tenant: ctx.tenant,
+          tool: ctx.target,
+          source: sig.source,
+          service: sig.service,
+          namespace: sig.namespace,
+          argShape: sig.argShape,
+          outcome: "error",
+          decision: "blocked",
+          deviation: ev.kind,
+          redactions: red.totalMatches,
+        });
+        opts.onEvent?.({ tool: ctx.target, outcome: "error", decision: "blocked" });
+        return {
+          allow: false,
+          reason: `Blocked by the inspection profile (${ev.kind ?? "deviation"}). This call falls outside the accepted baseline for ${ctx.principal}; review it under Inspect → Deviations.`,
+        };
+      }
+    } catch {
+      // Fail open — an inspector error must never block a tool call.
+      return { allow: true };
+    }
+    return { allow: true };
+  };
+
+  return {
+    pluginName: "inspect-enforcer",
+    kind: "tool_pre_invoke",
+    priority: 5,
+    mode: "permissive",
+    handler,
+  };
+}

--- a/mcp-server/src/inspect/index.ts
+++ b/mcp-server/src/inspect/index.ts
@@ -9,5 +9,6 @@ export * from "./store.js";
 export * from "./mode.js";
 export * from "./graph.js";
 export * from "./recorder.js";
+export * from "./enforcer.js";
 export * from "./profile.js";
 export * from "./profile-store.js";

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -1874,6 +1874,14 @@
             <div class="pg-seg" id="inspect-mode-seg" role="group" aria-label="Inspection mode">
               <button data-mode="observe" onclick="inspectSetMode('observe')">Observe</button>
               <button data-mode="dryrun" onclick="inspectSetMode('dryrun')">Dry-run</button>
+              <button data-mode="enforce" onclick="inspectRequestEnforce()">Enforce</button>
+            </div>
+          </div>
+          <div id="inspect-enforce-confirm" style="display:none; margin-top:10px; padding:10px 12px; border:1px solid var(--danger); background:var(--danger-soft); border-radius:6px;">
+            <div id="inspect-enforce-msg" style="margin-bottom:8px; font-size:var(--fs-sm);"></div>
+            <div style="display:flex; gap:8px;">
+              <button class="btn btn-sm btn-danger" onclick="inspectSetMode('enforce', true)">Enforce — block deviations</button>
+              <button class="btn btn-sm" onclick="inspectCancelEnforce()">Cancel</button>
             </div>
           </div>
         </div>
@@ -7537,7 +7545,11 @@ async function inspectRefreshMode(){
   try{ const r=await fetch('/api/inspect/mode'); if(r.ok) updateInspectModeChip(await r.json()); }catch(e){}
 }
 
-async function inspectSetMode(mode){
+async function inspectSetMode(mode, confirmed){
+  // Enforce is destructive (it blocks live tool calls) — gate behind a confirm
+  // that shows how many calls would have been blocked recently.
+  if(mode==='enforce' && !confirmed){ inspectRequestEnforce(); return; }
+  inspectCancelEnforce();
   try{
     const r=await fetch('/api/inspect/mode',{method:'PUT',headers:{'content-type':'application/json'},body:JSON.stringify({mode})});
     if(!r.ok){ toast(r.status===403?'Need inspection:write to change mode':'Mode change failed','error'); return; }
@@ -7546,6 +7558,22 @@ async function inspectSetMode(mode){
     inspectRefreshMode();
     if(document.getElementById('inspect-tab-deviations').classList.contains('active')) inspectLoadDeviations();
   }catch(e){ toast('Mode change failed','error'); }
+}
+
+async function inspectRequestEnforce(){
+  let accepted=0, wouldBlock=0;
+  try{ const p=await fetch('/api/inspect/profile'); if(p.ok){ const j=await p.json(); accepted=(j.counts&&j.counts.accepted)||0; } }catch(e){}
+  try{ const d=await fetch('/api/inspect/deviations?window=24h'); if(d.ok){ const j=await d.json(); wouldBlock=j.total||0; } }catch(e){}
+  const msg=document.getElementById('inspect-enforce-msg');
+  if(accepted===0){
+    msg.innerHTML='<b>No accepted rules.</b> Enforcing now would block <b>every</b> call (nothing is allow-listed). Accept some rules first, or continue only if you really intend a default-deny.';
+  }else{
+    msg.innerHTML='Enforce will <b>block</b> any call outside the <b>'+accepted+'</b> accepted rule'+(accepted===1?'':'s')+'. In the last 24h, <b>'+wouldBlock+'</b> call'+(wouldBlock===1?'':'s')+' would have been blocked. Review them under Deviations first.';
+  }
+  document.getElementById('inspect-enforce-confirm').style.display='block';
+}
+function inspectCancelEnforce(){
+  const c=document.getElementById('inspect-enforce-confirm'); if(c) c.style.display='none';
 }
 
 async function inspectLoadDeviations(){


### PR DESCRIPTION
**Final phase** — enforce mode actually blocks tool calls outside the accepted profile.

- **`inspect/enforcer.ts`** — a `tool_pre_invoke` hook that blocks + records `blocked` for deviations **only when mode=enforce** (pass-through, no eval, in off/observe/dry-run). **Fails open** (any error → allow:true; an inspector bug must never DoS the agent's tools). A pre-invoke denial short-circuits dispatch, so the post-invoke recorder never double-records.
- **index.ts** — enforcer registered after the recorder, sharing the accepted-profile evaluator.
- **UI** — Enforce button in the mode segmented control, gated behind a **confirm-before-enforce** panel showing the accepted-rule count + how many calls would've been blocked in 24h (numbers only into innerHTML).

### Tests
- 6 enforcer unit tests (block / allow / observe+dry-run pass-through / **fail-open** / metrics).
- **Full enforce E2E** (`inspect-e2e.test.ts`, runs live in integration CI): observe→learn→accept `list_sources`→enforce → `list_services` **blocked**, `list_sources` **allowed**; CSRF-aware; **resets to observe in `finally`** so the shared CI server is never left enforcing.
- Safe enforce-confirm Playwright test (open+cancel only — never enforces globally).
- Full suite **954 pass / 0 fail**, tsc clean, 5/5 inspect Playwright specs green. Reviewer: **SHIP**.

This completes the Inspect feature (P0–P5). **Not** released — awaiting your final review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)