### PR TITLE
fix(hub): publish .nojekyll so the connector hub catalog is reachable

### DIFF
--- a/.github/workflows/hub-pages.yml
+++ b/.github/workflows/hub-pages.yml
@@ -65,10 +65,15 @@ jobs:
           rm -rf "$tmp/hub"
           mkdir -p "$tmp/hub"
           cp -r /tmp/site/. "$tmp/hub/"
+          # GitHub Pages runs Jekyll by default, which drops this static
+          # /hub/ subtree (files exist on the branch but 404 live). A root
+          # .nojekyll makes Pages serve the branch verbatim so
+          # /hub/index.json + /hub/catalog/*.json resolve. Idempotent.
+          touch "$tmp/.nojekyll"
           cd "$tmp"
-          git add hub
+          git add hub .nojekyll
           if git diff --cached --quiet; then
-            echo "hub/ unchanged — nothing to publish."
+            echo "hub/ + .nojekyll unchanged — nothing to publish."
             exit 0
           fi
           git commit -m "chore(hub): publish connector hub site [skip ci]"


### PR DESCRIPTION
**Symptom:** `Hub catalog unreachable … hub catalog HTTP 404 from https://thotischner.github.io/observability-mcp/hub/index.json`.

**Root cause:** the files **do** exist on the `gh-pages` branch (`hub/index.json`, `hub/index.html`, `hub/catalog/*.json` — confirmed via `git ls-tree`), but **GitHub Pages runs Jekyll by default** and drops the static `/hub/` subtree, so it 404s live. The chart-releaser's root `index.yaml` still serves (Jekyll passes it through), which is why Helm kept working while the hub didn't.

**Fix:** the `hub-pages` publish step now writes a root **`.nojekyll`**, making Pages serve the branch verbatim → `/hub/index.json` + `/hub/catalog/*.json` resolve. Idempotent. Merging this re-triggers the workflow (it watches its own path), which republishes with `.nojekyll`.

No app change needed — the default `HUB_CATALOG_URL` already points at the correct path; the UI's "set HUB_CATALOG_URL for a mirror" degradation stays as a fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)