### PR TITLE
fix(connectors): show descriptions for builtin connectors

### DIFF
--- a/mcp-server/src/connectors/loader.test.ts
+++ b/mcp-server/src/connectors/loader.test.ts
@@ -80,3 +80,15 @@ test("PluginLoader.load(): with verify on + no trust root → builtins still loa
     assert.ok(names.includes("kubernetes"), "kubernetes builtin must remain available");
   });
 });
+
+test("PluginLoader.load(): builtins carry manifest metadata (description shows in Installed Connectors)", async () => {
+  const loader = new PluginLoader({ pluginsDir: tmp() });
+  await loader.load();
+  for (const name of ["prometheus", "loki", "kubernetes"]) {
+    const c = loader.get(name);
+    assert.ok(c, `${name} builtin present`);
+    assert.ok(c!.manifest, `${name} builtin has a manifest`);
+    assert.ok((c!.manifest!.description || "").length > 10, `${name} builtin has a non-empty description`);
+    assert.equal(c!.manifest!.name, name);
+  }
+});

--- a/mcp-server/src/connectors/loader.ts
+++ b/mcp-server/src/connectors/loader.ts
@@ -136,19 +136,52 @@ export class PluginLoader {
   }
 
   private loadBuiltins(): void {
+    // Builtins carry inline manifest metadata so the Installed Connectors UI
+    // shows a name/description/version like filesystem plugins do (without it,
+    // describeInstalled() falls back to an empty description). Mirrors
+    // plugins/<name>/manifest.json — keep the description text in sync.
     this.register({
       name: "prometheus",
       source: "builtin",
+      manifest: {
+        schemaVersion: 1,
+        name: "prometheus",
+        displayName: "Prometheus",
+        version: "1.0.0",
+        description:
+          "PromQL-based metrics backend with prom-client default scrape support and dynamic service-label resolution.",
+        signalTypes: ["metrics"],
+        capabilities: { queryMetrics: true, listServices: true, listAvailableMetrics: true },
+      },
       factory: () => new PrometheusConnector(),
     });
     this.register({
       name: "loki",
       source: "builtin",
+      manifest: {
+        schemaVersion: 1,
+        name: "loki",
+        displayName: "Loki",
+        version: "1.0.0",
+        description:
+          "LogQL-based log backend with dynamic service-label discovery (service_name / service / job / app / container).",
+        signalTypes: ["logs"],
+        capabilities: { queryLogs: true, listServices: true },
+      },
       factory: () => new LokiConnector(),
     });
     this.register({
       name: "kubernetes",
       source: "builtin",
+      manifest: {
+        schemaVersion: 1,
+        name: "kubernetes",
+        displayName: "Kubernetes",
+        version: "0.1.0",
+        description:
+          "Watches a Kubernetes cluster (in-cluster or via kubeconfig) and exposes pods, nodes, deployments, replicasets and namespaces as an infrastructure topology graph. Edges: RUNS_ON (pod→node), OWNED_BY (pod→rs→deployment), IN_NAMESPACE.",
+        signalTypes: ["topology"],
+      },
       factory: () => new KubernetesConnector(),
     });
   }


### PR DESCRIPTION
In **Installed Connectors**, only `datadog` showed a description — `prometheus` / `loki` / `kubernetes` showed none.

**Cause:** the builtins load via `loadBuiltins()` with no `manifest`, so `describeInstalled()` falls back to `""` (datadog loads from a filesystem manifest that carries a description).

**Fix:** attach inline manifest metadata (displayName / version / description / signalTypes) to each builtin registration, mirroring `plugins/<name>/manifest.json`. New loader test asserts the builtins now carry a non-empty description. tsc + connector tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)