### PR TITLE
fix(hub): serve the connector catalog from the Pages site (docs build)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -79,6 +79,16 @@ jobs:
               cp -n "$f" site/
               echo "  preserved $(basename "$f")"
             done
+            # The connector hub catalog lives on gh-pages under hub/ (published
+            # by hub-pages.yml). Pages serves from THIS main-built site, not the
+            # gh-pages branch, so mirror hub/ in too — otherwise
+            # /hub/index.json + /hub/catalog/*.json 404 even though they exist
+            # on the branch. This is the path the in-app connector hub fetches.
+            if [ -d /tmp/ghpages/hub ]; then
+              mkdir -p site/hub
+              cp -r /tmp/ghpages/hub/. site/hub/
+              echo "  preserved hub/ connector catalog"
+            fi
             git worktree remove --force /tmp/ghpages || true
             echo "::notice::Helm repo files preserved alongside docs site"
           else


### PR DESCRIPTION
**Symptom:** `Hub catalog unreachable … 404 from …/hub/index.json`.

**Real root cause:** GitHub Pages is built from **`main` by `docs.yml`** (MkDocs, plus a step that merges the gh-pages Helm artifacts — `index.yaml`, `*.tgz` — into `site/`). It is **not** served from the `gh-pages` branch. So the `hub/` subtree that `hub-pages.yml` publishes to gh-pages was never copied into the served site → 404. (`/index.yaml` works precisely because docs.yml copies it in; and the earlier root `.nojekyll` on gh-pages had no effect since gh-pages isn't the Pages source.)

**Fix:** in the same merge step, mirror the gh-pages `hub/` subtree into `site/hub/`, so `/hub/index.json` + `/hub/catalog/*.json` resolve. Merging this re-runs `docs.yml` (it watches its own path) and rebuilds Pages with the catalog. No app change — the default `HUB_CATALOG_URL` already points at this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)