### PR TITLE
feat(ui): governance overview + per-tab clarifying subtitles

### DIFF
--- a/mcp-server/playwright/Dockerfile
+++ b/mcp-server/playwright/Dockerfile
@@ -19,6 +19,7 @@ COPY tables-filters-density.spec.mjs ./tables-filters-density.spec.mjs
 COPY topology.spec.mjs ./topology.spec.mjs
 COPY rail.spec.mjs ./rail.spec.mjs
 COPY inspect.spec.mjs ./inspect.spec.mjs
+COPY governance.spec.mjs ./governance.spec.mjs
 
 # When run with --network=host (Linux) OMCP_UI_BASE defaults to localhost.
 # In a compose network pass OMCP_UI_BASE=http://mcp-server:3000 explicitly.

--- a/mcp-server/playwright/governance.spec.mjs
+++ b/mcp-server/playwright/governance.spec.mjs
@@ -1,0 +1,36 @@
+import { test, expect } from "@playwright/test";
+
+const BASE = process.env.OMCP_UI_BASE || "http://localhost:3000";
+
+test.describe("Governance IA — overview + clarifying subtitles", () => {
+  test("Access Control shows the governance overview flow", async ({ page }) => {
+    const errors = [];
+    page.on("console", (m) => { if (m.type() === "error") errors.push(m.text()); });
+    page.on("pageerror", (e) => errors.push(String(e)));
+
+    await page.goto(BASE, { waitUntil: "networkidle" });
+    await page.locator('[data-page="access"]').click();
+    await expect(page.locator("#page-access")).toHaveClass(/active/);
+
+    const overview = page.locator("#page-access .gov-overview");
+    await expect(overview).toBeVisible();
+    // The four layered steps in order.
+    for (const step of ["Access Control", "Products", "Policies", "Inspect"]) {
+      await expect(overview.locator(".gov-step b", { hasText: step })).toBeVisible();
+    }
+    await expect(errors, `console errors: ${errors.join("\n")}`).toEqual([]);
+  });
+
+  test("each governance tab carries a clarifying subtitle", async ({ page }) => {
+    await page.goto(BASE, { waitUntil: "networkidle" });
+    for (const [pageId, needle] of [
+      ["access", /Authentication/i],
+      ["policies", /allowed/i],
+      ["inspect", /normal/i],
+      ["audit", /tamper-evident/i],
+    ]) {
+      await page.locator(`[data-page="${pageId}"]`).click();
+      await expect(page.locator(`#page-${pageId} .gov-sub`).first()).toContainText(needle);
+    }
+  });
+});

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -1419,6 +1419,16 @@
     .inspect-kv dt { color: var(--text-dim); }
     .inspect-kv dd { margin: 0; color: var(--text); font-family: var(--font-mono, monospace); }
 
+    /* ===== Governance — clarifying subtitles + overview flow ===== */
+    .gov-sub { font-size: var(--fs-sm); color: var(--text-muted); margin-top: 4px; max-width: 70ch; line-height: 1.5; }
+    .gov-sub em { color: var(--text); font-style: normal; font-weight: 600; }
+    .gov-overview { background: var(--surface); }
+    .gov-flow { display: flex; flex-wrap: wrap; align-items: stretch; gap: 6px; }
+    .gov-step { display: flex; flex-direction: column; gap: 2px; padding: 8px 12px; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius-sm); min-width: 120px; }
+    .gov-step b { font-size: var(--fs-md); color: var(--text); }
+    .gov-step small { font-size: var(--fs-xs); color: var(--text-muted); }
+    .gov-arrow { align-self: center; color: var(--text-dim); font-size: var(--fs-lg); }
+
     /* ===== Playground (Q13) — restrained, monochrome ===== */
     .pg-seg { display:inline-flex; gap:0; border:1px solid var(--border); border-radius:6px; overflow:hidden; }
     .pg-seg button { border:none; background:transparent; color:var(--text-2,var(--text)); font:inherit; font-size:12px; padding:3px 11px; cursor:pointer; }
@@ -1819,6 +1829,7 @@
         <div class="ph-left">
           <div class="breadcrumb">Console / Governance / <b>Inspect</b></div>
           <h1>Inspect — agent activity</h1>
+          <div class="gov-sub">Whether a call is <em>normal</em> vs. the learned baseline for that identity — behavioral guardrails. Distinct from <b>Policies</b> (allowed at all).</div>
         </div>
         <div class="ph-actions">
           <span id="inspect-mode-chip" class="stchip" title="Current inspection mode">…</span>
@@ -2044,8 +2055,19 @@
         <div class="ph-left">
           <div class="breadcrumb">Console / Governance / <b>Access Control</b></div>
           <h1>Access Control</h1>
+          <div class="gov-sub">Who can sign in and which role they hold — identities, SSO/OIDC, sessions. <em>Authentication.</em></div>
         </div>
         <div class="ph-actions"><button class="btn btn-primary btn-sm" onclick="entEditNew('rbac')">+ New role</button><button class="btn btn-sm" id="ent-rbac-editbtn" onclick="entEditOpen('rbac')">Edit policy</button></div>
+      </div>
+      <div class="card gov-overview">
+        <div class="card-header"><h2>How governance fits together</h2></div>
+        <div class="gov-flow">
+          <span class="gov-step"><b>Access Control</b><small>who you are</small></span><span class="gov-arrow">→</span>
+          <span class="gov-step"><b>Products</b><small>what you're offered</small></span><span class="gov-arrow">→</span>
+          <span class="gov-step"><b>Policies</b><small>what you're allowed</small></span><span class="gov-arrow">→</span>
+          <span class="gov-step"><b>Inspect</b><small>is it normal</small></span>
+        </div>
+        <div class="muted t-xs" style="margin-top:8px;">Each layer answers a different question. <b>Catalog</b> runs alongside, adding resource context (owners, criticality). <b>Audit Log</b> records every change. <b>Policies</b> = allowed at all (static); <b>Inspect</b> = normal vs. the learned baseline (behavioral).</div>
       </div>
       <div class="card">
         <div class="card-header"><h2>Roles &amp; bindings
@@ -2209,6 +2231,7 @@ curl -X PUT http://localhost:3000/api/enterprise/policy \
               onclick="infoPop(this)">?</button>
           </h1>
           <p class="ph-sub">Curated, governed tool bundles you expose to an agent or credential.</p>
+          <div class="gov-sub">Which tools a credential is <em>offered</em> (packaging). Distinct from <b>Policies</b>, which decide what's <em>permitted</em>.</div>
         </div>
       </div>
 
@@ -2304,6 +2327,7 @@ curl -X PUT http://localhost:3000/api/enterprise/catalog \
         <div class="ph-left">
           <div class="breadcrumb">Console / Governance / <b>Policies</b></div>
           <h1>Policies</h1>
+          <div class="gov-sub">What a role is <em>allowed</em> to call at all — coarse RBAC (resource × action). Distinct from <b>Inspect</b>, which judges whether a call is <em>normal</em>.</div>
         </div>
         <div class="ph-actions"><span id="pol-engine" class="badge"></span></div>
       </div>
@@ -2534,6 +2558,7 @@ curl -X PUT http://localhost:3000/api/enterprise/catalog \
         <div class="ph-left">
           <div class="breadcrumb">Console / Governance / <b>Audit Log</b></div>
           <h1>Audit Log</h1>
+          <div class="gov-sub">An append-only, tamper-evident record of every mutating action — who did what, when.</div>
         </div>
         <div class="ph-actions"><span id="ent-chain"></span></div>
       </div>


### PR DESCRIPTION
The governance features (Access Control, Products, Policies, Inspect, Audit, Catalog) answer different questions but read as overlapping. This clarifies the information architecture without merging anything.

- A compact **"How governance fits together"** overview on the Access Control page: the layered flow **Identity → Offer (Products) → Permission (Policies) → Behavior (Inspect)**, with **Catalog** as resource context and **Audit** recording changes.
- A one-line **clarifier subtitle** under each governance tab header — notably **Policies** = *allowed at all* (static) vs **Inspect** = *normal vs. the learned baseline* (behavioral); **Products** = *offered* vs **Policies** = *permitted*.

Static markup + CSS only (no interpolation → no XSS surface). New Playwright `governance.spec.mjs` (wired into the ui-smoke Dockerfile) asserts the overview flow + the per-tab subtitles; verified green against the live demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)