### PR TITLE
feat(inspect): one-click add-to-profile from a deviation

### DIFF
--- a/mcp-server/playwright/inspect.spec.mjs
+++ b/mcp-server/playwright/inspect.spec.mjs
@@ -166,6 +166,10 @@ test.describe("Inspect — Flows live graph", () => {
     await page.locator('#page-inspect .tab-btn', { hasText: "Deviations" }).click();
     await expect(page.locator("#inspect-tab-deviations")).toHaveClass(/active/);
     await expect(page.locator("#inspect-deviations")).toBeVisible();
+    // If deviations are present, each offers a one-click "Add to profile".
+    if (await page.locator("#inspect-deviations table tbody tr").count()) {
+      await expect(page.locator('#inspect-deviations button', { hasText: "Add to profile" }).first()).toBeVisible();
+    }
 
     // Restore observe so the test is idempotent against the shared demo server.
     await page.locator('#page-inspect .tab-btn', { hasText: "Profile" }).click();

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -2492,6 +2492,9 @@ async function main() {
     const argShape: Record<string, string> = {};
     if (b.argShape && typeof b.argShape === "object") {
       for (const [k, v] of Object.entries(b.argShape as Record<string, unknown>)) {
+        // Guard prototype-polluting keys from the request body (the key is
+        // remote input — js/remote-property-injection).
+        if (k === "__proto__" || k === "constructor" || k === "prototype") continue;
         if (typeof v === "string") argShape[k] = v;
       }
     }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -2481,6 +2481,28 @@ async function main() {
     res.json({ ok: true });
   });
 
+  // Deviation → rule (one click): absorb exactly this observed call shape into
+  // the accepted profile (widen the matching rule, or create a tight one).
+  app.post("/api/inspect/profile/from-deviation", need("inspection", "write"), audit("inspection", "write"), (req, res) => {
+    const b = (req.body || {}) as Record<string, unknown>;
+    const principal = typeof b.principal === "string" ? b.principal : "";
+    const tool = typeof b.tool === "string" ? b.tool : "";
+    if (!principal || !tool) { res.status(400).json({ error: "principal and tool are required" }); return; }
+    const str = (v: unknown) => (typeof v === "string" && v ? v : undefined);
+    const argShape: Record<string, string> = {};
+    if (b.argShape && typeof b.argShape === "object") {
+      for (const [k, v] of Object.entries(b.argShape as Record<string, unknown>)) {
+        if (typeof v === "string") argShape[k] = v;
+      }
+    }
+    const rule = inspectProfile.absorb({
+      principal, tool,
+      source: str(b.source), service: str(b.service), namespace: str(b.namespace),
+      argShape,
+    });
+    res.json({ rule });
+  });
+
   // Deviations: calls in the window that fell outside the accepted profile
   // (decision != allow). In dry-run these are would-block; in enforce, blocked.
   app.get("/api/inspect/deviations", need("inspection", "read"), (req, res) => {

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -2491,10 +2491,13 @@ async function main() {
     const str = (v: unknown) => (typeof v === "string" && v ? v : undefined);
     const argShape: Record<string, string> = {};
     if (b.argShape && typeof b.argShape === "object") {
+      // The arg-shape KEY is remote input. Accept only a conservative
+      // identifier charset (arg names are simple tokens) and never the
+      // prototype-polluting names — barrier for js/remote-property-injection
+      // and prototype pollution.
+      const SAFE_ARG_KEY = /^[A-Za-z0-9_.-]{1,64}$/;
       for (const [k, v] of Object.entries(b.argShape as Record<string, unknown>)) {
-        // Guard prototype-polluting keys from the request body (the key is
-        // remote input — js/remote-property-injection).
-        if (k === "__proto__" || k === "constructor" || k === "prototype") continue;
+        if (!SAFE_ARG_KEY.test(k) || k === "__proto__" || k === "constructor" || k === "prototype") continue;
         if (typeof v === "string") argShape[k] = v;
       }
     }

--- a/mcp-server/src/inspect/profile-store.test.ts
+++ b/mcp-server/src/inspect/profile-store.test.ts
@@ -54,6 +54,36 @@ describe("ProfileStore", () => {
     assert.equal(b.persisted, true);
   });
 
+  it("absorb: creates a tight accepted rule for a brand-new deviation", () => {
+    const s = new ProfileStore();
+    const r = s.absorb({ principal: "mallory", tool: "query_logs", service: "pay", argShape: { window: "<=1h" } });
+    assert.equal(r.status, "accepted");
+    assert.deepEqual(r.constraints.service, ["pay"]);
+    assert.deepEqual(r.constraints.argShape!.window, ["<=1h"]);
+    // that exact call is now allowed
+    assert.equal(s.evaluate({ principal: "mallory", tool: "query_logs", service: "pay", argShape: { window: "<=1h" } }).verdict, "allow");
+  });
+
+  it("absorb: widens an existing accepted rule (sorted union, no dupes)", () => {
+    const s = new ProfileStore();
+    s.absorb({ principal: "a", tool: "t", service: "s1", argShape: {} });
+    const r = s.absorb({ principal: "a", tool: "t", service: "s2", argShape: {} });
+    assert.deepEqual(r.constraints.service, ["s1", "s2"]);
+    // idempotent
+    const r2 = s.absorb({ principal: "a", tool: "t", service: "s2", argShape: {} });
+    assert.deepEqual(r2.constraints.service, ["s1", "s2"]);
+    assert.equal(s.list().filter((x) => x.id === ruleId("a", "t")).length, 1);
+  });
+
+  it("absorb: flips a previously-rejected/suggested rule to accepted", () => {
+    const s = new ProfileStore();
+    s.derive([obs({ principal: "a", tool: "t", service: "s1" })]); // suggested
+    s.setStatus(ruleId("a", "t"), "rejected");
+    const r = s.absorb({ principal: "a", tool: "t", service: "s9", argShape: {} });
+    assert.equal(r.status, "accepted");
+    assert.deepEqual(r.constraints.service, ["s1", "s9"]);
+  });
+
   it("a missing/invalid file starts empty, never throws", () => {
     assert.doesNotThrow(() => {
       const s = new ProfileStore({ file: "profile-store-missing.json", reader: () => "not json{", writer: () => {} });

--- a/mcp-server/src/inspect/profile-store.ts
+++ b/mcp-server/src/inspect/profile-store.ts
@@ -10,6 +10,7 @@ import type { Observation } from "./store.js";
 import {
   deriveProfile,
   evaluateCall,
+  ruleId,
   type CallSignature,
   type EvalResult,
   type ProfileRule,
@@ -23,6 +24,7 @@ export interface ProfileStoreOptions {
   /** Seams for tests. */
   reader?: (file: string) => string;
   writer?: (file: string, data: string) => void;
+  now?: () => number;
 }
 
 export class ProfileStore {
@@ -30,11 +32,13 @@ export class ProfileStore {
   private readonly file?: string;
   private readonly reader: (file: string) => string;
   private readonly writer: (file: string, data: string) => void;
+  private readonly now: () => number;
 
   constructor(opts: ProfileStoreOptions = {}) {
     this.file = opts.file;
     this.reader = opts.reader ?? ((f) => readFileSync(f, "utf8"));
     this.writer = opts.writer ?? ((f, d) => writeFileSync(f, d));
+    this.now = opts.now ?? (() => Date.now());
     if (opts.rules) this.rules = opts.rules;
     else if (this.file) this.load();
   }
@@ -104,6 +108,42 @@ export class ProfileStore {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Absorb a single (deviating) call into the profile: widen the accepted rule
+   * for (subject, tool) to include this call's resource values + arg buckets,
+   * creating a tight accepted rule if none exists. Makes exactly that observed
+   * shape allowed — the "add this deviation to the profile" one-click. Returns
+   * the upserted rule.
+   */
+  absorb(call: CallSignature): ProfileRule {
+    const id = ruleId(call.principal, call.tool);
+    const ts = new Date(this.now()).toISOString();
+    let r = this.rules.find((x) => x.id === id);
+    if (!r) {
+      r = { id, subject: call.principal, tool: call.tool, constraints: {}, status: "accepted", provenance: { learnedFrom: 1, firstSeen: ts, lastSeen: ts } };
+      this.rules.push(r);
+    } else {
+      r.status = "accepted";
+      r.provenance.lastSeen = ts;
+    }
+    const add = (arr: string[] | undefined, v: string): string[] => {
+      const a = arr ?? [];
+      if (!a.includes(v)) a.push(v);
+      a.sort();
+      return a;
+    };
+    for (const dim of ["source", "service", "namespace"] as const) {
+      const v = call[dim];
+      if (v != null) r.constraints[dim] = add(r.constraints[dim], v);
+    }
+    for (const [k, b] of Object.entries(call.argShape || {})) {
+      r.constraints.argShape = r.constraints.argShape ?? {};
+      r.constraints.argShape[k] = add(r.constraints.argShape[k], b);
+    }
+    this.persist();
+    return r;
   }
 
   evaluate(call: CallSignature): EvalResult {

--- a/mcp-server/src/inspect/signature.test.ts
+++ b/mcp-server/src/inspect/signature.test.ts
@@ -78,6 +78,17 @@ describe("deriveSignature", () => {
     assert.deepEqual(deriveSignature("x", "str"), { argShape: {} });
   });
 
+  it("drops prototype-polluting arg keys (__proto__/constructor/prototype)", () => {
+    const sig = deriveSignature("x", JSON.parse('{"__proto__":"p","constructor":"c","prototype":"q","ok":5}'));
+    const keys = Object.keys(sig.argShape);
+    assert.ok(!keys.includes("__proto__"));
+    assert.ok(!keys.includes("constructor"));
+    assert.ok(!keys.includes("prototype"));
+    assert.equal(sig.argShape.ok, "<=10");
+    // prototype not polluted
+    assert.equal(({} as Record<string, unknown>).p, undefined);
+  });
+
   it("is deterministic", () => {
     const a = deriveSignature("query_logs", { source: "s", service: "v", limit: 5, window: "5m" });
     const b = deriveSignature("query_logs", { window: "5m", limit: 5, service: "v", source: "s" });

--- a/mcp-server/src/inspect/signature.ts
+++ b/mcp-server/src/inspect/signature.ts
@@ -85,6 +85,9 @@ export function deriveSignature(_tool: string, args: unknown): Signature {
 
   for (const [k, v] of Object.entries(a)) {
     if ((RESOURCE_KEYS as readonly string[]).includes(k)) continue;
+    // Never let a prototype-polluting arg name into the shape map (keys come
+    // from arbitrary tool-call arguments — js/remote-property-injection).
+    if (k === "__proto__" || k === "constructor" || k === "prototype") continue;
     if (Array.isArray(v)) {
       sig.argShape[k] = "n=" + countBucket(v.length);
     } else if (typeof v === "number") {

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -7631,12 +7631,23 @@ async function inspectLoadDeviations(){
     const j=await r.json();
     document.getElementById('inspect-dev-stat').textContent=(j.total||0)+' in window · mode '+(j.mode||'');
     const devs=j.deviations||[];
+    window.__inspectDeviations=devs;
     if(!devs.length){ box.innerHTML='<div class="empty" style="margin:16px 0;">No deviations in this window. In <b>Observe</b> mode nothing is evaluated; switch to <b>Dry-run</b> with accepted rules to surface would-block calls.</div>'; return; }
-    box.innerHTML='<table class="dtable"><thead><tr><th>When</th><th>Identity</th><th>Tool</th><th>Backend</th><th>Why</th><th>Decision</th></tr></thead><tbody>'
-      +devs.map(d=>{ const backend=d.service||d.source||d.namespace||'—'; const dec=d.decision==='blocked'?'<span class="stchip bad">blocked</span>':'<span class="stchip warn">would-block</span>';
-        return '<tr><td class="muted t-xs">'+esc((d.ts||'').replace('T',' ').replace(/\..*/,''))+'</td><td>'+esc(d.principal)+'</td><td>'+esc(d.tool)+'</td><td>'+esc(backend)+'</td><td class="t-xs">'+esc(d.deviation||'deviation')+(d.detail?(' · '+esc(d.detail)):'')+'</td><td>'+dec+'</td></tr>'; }).join('')
+    box.innerHTML='<table class="dtable"><thead><tr><th>When</th><th>Identity</th><th>Tool</th><th>Backend</th><th>Why</th><th>Decision</th><th></th></tr></thead><tbody>'
+      +devs.map((d,i)=>{ const backend=d.service||d.source||d.namespace||'—'; const dec=d.decision==='blocked'?'<span class="stchip bad">blocked</span>':'<span class="stchip warn">would-block</span>';
+        return '<tr><td class="muted t-xs">'+esc((d.ts||'').replace('T',' ').replace(/\..*/,''))+'</td><td>'+esc(d.principal)+'</td><td>'+esc(d.tool)+'</td><td>'+esc(backend)+'</td><td class="t-xs">'+esc(d.deviation||'deviation')+(d.detail?(' · '+esc(d.detail)):'')+'</td><td>'+dec+'</td>'
+          +'<td style="text-align:right;white-space:nowrap;"><button class="btn btn-sm" onclick="inspectAddDeviation('+i+')" title="Add exactly this call shape to the accepted profile">Add to profile</button></td></tr>'; }).join('')
       +'</tbody></table>';
   }catch(e){}
+}
+
+async function inspectAddDeviation(i){
+  const d=(window.__inspectDeviations||[])[i]; if(!d) return;
+  try{
+    const r=await fetch('/api/inspect/profile/from-deviation',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({principal:d.principal,tool:d.tool,source:d.source,service:d.service,namespace:d.namespace,argShape:d.argShape||{}})});
+    if(!r.ok){ toast(r.status===403?'Need inspection:write':'Failed','error'); return; }
+    toast('Added '+d.principal+' → '+d.tool+' to profile','ok');
+  }catch(e){ toast('Failed','error'); }
 }
 
 // --- Inspect: behavior profile (learn / review) ---


### PR DESCRIPTION
Each **Deviations** row gets an **"Add to profile"** action that absorbs exactly that observed call shape into the accepted profile — widening the matching `(subject,tool)` rule (sorted union of source/service/namespace + arg buckets) or creating a tight accepted rule if none exists, so that exact call stops deviating. Beats accepting a whole derived rule when you just want to bless one variant.

- `ProfileStore.absorb(call)` (+ a `now` clock seam): flips suggested/rejected → accepted, idempotent sorted-union widening; the upserted rule makes that call `evaluate()=allow`.
- `POST /api/inspect/profile/from-deviation` (`inspection:write` + audited), validates principal+tool.
- UI button uses a trusted integer row index → looks up the full deviation client-side and POSTs JSON; toast via `textContent`. Reviewer-agent confirmed no XSS / new sink.
- 3 new absorb unit tests (create / widen / flip-status); Playwright asserts the action appears when deviations exist. tsc + suite green.

Completes the granular-accept story (drill-down → edit → deviation→rule). Not released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)