### PR TITLE
feat(inspect): finer query signatures (PromQL/LogQL fingerprint)

### DIFF
--- a/mcp-server/src/inspect/recorder.test.ts
+++ b/mcp-server/src/inspect/recorder.test.ts
@@ -48,7 +48,7 @@ describe("createInspectRecorder", () => {
     assert.equal(o.source, "prom-eu");
     assert.equal(o.service, "pay");
     assert.equal(o.argShape.window, "<=1h");
-    assert.equal(o.argShape.query, "present"); // literal never stored
+    assert.match(o.argShape.query, /m:x/); // fingerprint, literal never stored
     assert.equal(o.decision, "allow");
     assert.equal(o.outcome, "ok");
   });

--- a/mcp-server/src/inspect/signature.test.ts
+++ b/mcp-server/src/inspect/signature.test.ts
@@ -6,6 +6,7 @@ import {
   durationToSeconds,
   durationBucket,
   numBucket,
+  queryFingerprint,
 } from "./signature.js";
 
 describe("buckets", () => {
@@ -48,6 +49,63 @@ describe("buckets", () => {
   });
 });
 
+describe("queryFingerprint", () => {
+  it("blank → empty", () => {
+    assert.equal(queryFingerprint(""), "empty");
+    assert.equal(queryFingerprint("   "), "empty");
+  });
+  it("extracts func + metric + label from a PromQL rate query", () => {
+    const fp = queryFingerprint('rate(http_requests_total{job="api"}[5m])');
+    assert.match(fp, /f:rate/);
+    assert.match(fp, /m:http_requests_total/);
+    assert.match(fp, /l:job/);
+    // the range fragment "m" and the quoted value "api" are NOT metrics
+    assert.ok(!/[, ]m[, ]|m:.*\bm\b/.test(fp.replace("http_requests_total", "")));
+    assert.ok(!fp.includes("api"));
+  });
+  it("treats by()-grouping labels as labels, not metrics", () => {
+    const fp = queryFingerprint("sum by (instance) (up)");
+    assert.match(fp, /f:sum/);
+    assert.match(fp, /m:up/);
+    assert.match(fp, /l:instance/);
+  });
+  it("LogQL stream selector → label keys", () => {
+    const fp = queryFingerprint('{service_name="payment", level="error"} |= "boom"');
+    assert.match(fp, /l:level,service_name/);
+    assert.ok(!fp.includes("payment") && !fp.includes("boom"));
+  });
+  it("is deterministic + sorted + capped", () => {
+    const a = queryFingerprint('sum(rate(a_total[1m])) + avg(b_total)');
+    const b = queryFingerprint('avg(b_total) + sum(rate(a_total[1m]))');
+    assert.equal(a, b);
+    assert.match(a, /f:avg,rate,sum/);
+    assert.match(a, /m:a_total,b_total/);
+  });
+  it("is fast on a huge attacker-supplied query (no ReDoS)", () => {
+    const t0 = Date.now();
+    queryFingerprint("a".repeat(100000));
+    queryFingerprint("(".repeat(50000));
+    queryFingerprint("rate(".repeat(20000));
+    assert.ok(Date.now() - t0 < 100, "fingerprint stays linear/bounded on large input");
+  });
+  it("non-query free text with no structure → present", () => {
+    assert.equal(queryFingerprint("just some words"), "m:just,some,words"); // bare idents count as metrics
+    assert.equal(queryFingerprint("!!!"), "present");
+  });
+});
+
+describe("deriveSignature query fingerprinting", () => {
+  it("query/expr keys get a fingerprint, not 'present'", () => {
+    const sig = deriveSignature("query_metrics", { service: "pay", query: 'rate(http_requests_total[5m])' });
+    assert.match(sig.argShape.query, /m:http_requests_total/);
+    assert.match(sig.argShape.query, /f:rate/);
+  });
+  it("non-query free text still collapses to 'present'", () => {
+    const sig = deriveSignature("x", { note: "hello world" });
+    assert.equal(sig.argShape.note, "present");
+  });
+});
+
 describe("deriveSignature", () => {
   it("lifts source/service/namespace as real resource dimensions", () => {
     const sig = deriveSignature("query_logs", { source: "prom-eu", service: "payment", namespace: "omcp" });
@@ -62,9 +120,10 @@ describe("deriveSignature", () => {
     assert.ok(!("source" in sig));
   });
 
-  it("buckets duration-shaped keys, collapses free text to 'present'", () => {
+  it("buckets duration-shaped keys, fingerprints queries (literal never kept)", () => {
     const sig = deriveSignature("query_metrics", { query: "rate(http_requests_total[5m])", window: "1h", limit: 500 });
-    assert.equal(sig.argShape.query, "present"); // literal never persisted
+    assert.match(sig.argShape.query, /m:http_requests_total/); // structural, not the literal
+    assert.ok(!sig.argShape.query.includes("[5m]"));
     assert.equal(sig.argShape.window, "<=1h");
     assert.equal(sig.argShape.limit, "<=1000");
   });

--- a/mcp-server/src/inspect/signature.ts
+++ b/mcp-server/src/inspect/signature.ts
@@ -69,6 +69,77 @@ export function numBucket(n: number): string {
 /** Keys whose string value should be treated as a duration when parseable. */
 const DURATION_KEY = /window|range|lookback|step|interval|since|duration|period|timeout/i;
 
+/** Arg keys carrying a PromQL/LogQL expression — fingerprinted, not kept literal. */
+const QUERY_KEY = /^(query|expr|promql|logql)$/i;
+
+const PROMQL_KEYWORDS = new Set([
+  "by", "without", "on", "ignoring", "group_left", "group_right", "offset",
+  "bool", "and", "or", "unless", "keep_metric_names", "start", "end", "inf", "nan",
+]);
+
+// Aggregation operators can appear as `sum by (x) (expr)` — i.e. NOT immediately
+// before "(" — so they need recognising by name, not just by a trailing paren.
+const PROMQL_AGG = new Set([
+  "sum", "min", "max", "avg", "group", "stddev", "stdvar",
+  "count", "count_values", "bottomk", "topk", "quantile",
+]);
+
+/**
+ * Structural fingerprint of a PromQL/LogQL query — a deterministic, bounded
+ * signal of *which* metric(s), function(s) and label key(s) it touches, WITHOUT
+ * keeping the literal query. Lets a profile rule distinguish "query_metrics on
+ * metric X" from "...on metric Y". Heuristic (not a full parser) but stable.
+ * Returns "present" when nothing structural is extractable, "empty" for blank.
+ */
+export function queryFingerprint(q: string): string {
+  if (!q || !q.trim()) return "empty";
+  // Bound the input first — query args are attacker-controlled and run on the
+  // recorder/enforcer hot path; a huge string must not cost real CPU. 4 KB is
+  // ample for a structural signal; truncation stays deterministic.
+  const capped = q.length > 4096 ? q.slice(0, 4096) : q;
+  // Drop string literals so label values / quoted text never look like metrics.
+  const s = capped.replace(/"[^"]*"|'[^']*'|`[^`]*`/g, '""');
+  const funcs = new Set<string>();
+  const labels = new Set<string>();
+  const metrics = new Set<string>();
+  const exclude = new Set<string>();
+
+  // Functions: an identifier immediately followed by "(" (excluding keywords
+  // like `by(`), plus any aggregation operator by name (e.g. `sum by (x)`).
+  for (const m of s.matchAll(/([A-Za-z_]\w{0,127})\s*\(/g)) {
+    if (!PROMQL_KEYWORDS.has(m[1].toLowerCase())) funcs.add(m[1]);
+  }
+  for (const m of s.matchAll(/[A-Za-z_]\w*/g)) {
+    if (PROMQL_AGG.has(m[0].toLowerCase())) funcs.add(m[0]);
+  }
+  // Grouping labels: by/without/on/ignoring/group_* ( … ) — not metrics.
+  for (const m of s.matchAll(/\b(?:by|without|on|ignoring|group_left|group_right)\s*\(([^)]*)\)/gi)) {
+    for (const id of m[1].match(/[A-Za-z_]\w*/g) ?? []) { labels.add(id); exclude.add(id); }
+  }
+  // Selector label keys: inside { … } before = / != / =~ / !~.
+  for (const br of s.matchAll(/\{([^}]*)\}/g)) {
+    for (const m of br[1].matchAll(/([A-Za-z_]\w*)\s*(?:=~|!~|=|!=)/g)) { labels.add(m[1]); exclude.add(m[1]); }
+  }
+  // Metrics: identifiers (PromQL allows ':') that aren't funcs/keywords/labels,
+  // not a range-duration fragment ([5m] → "m", preceded by a digit).
+  for (const m of s.matchAll(/([A-Za-z_:][\w:]*)/g)) {
+    const idx = m.index ?? 0;
+    const id = m[1];
+    const prev = idx > 0 ? s[idx - 1] : "";
+    if (/\d/.test(prev)) continue;
+    const nxt = (s.slice(idx + id.length).match(/^\s*(.)/) ?? [])[1] ?? "";
+    if (nxt === "(") continue;
+    if (funcs.has(id) || exclude.has(id) || PROMQL_KEYWORDS.has(id.toLowerCase())) continue;
+    metrics.add(id);
+  }
+  const cap = (set: Set<string>): string => [...set].sort().slice(0, 8).join(",");
+  const parts: string[] = [];
+  if (funcs.size) parts.push("f:" + cap(funcs));
+  if (metrics.size) parts.push("m:" + cap(metrics));
+  if (labels.size) parts.push("l:" + cap(labels));
+  return parts.length ? parts.join(" ") : "present";
+}
+
 /**
  * Derive a Signature from a tool name + its (redacted) arguments.
  * Deterministic and pure — same input always yields the same signature.
@@ -97,9 +168,13 @@ export function deriveSignature(_tool: string, args: unknown): Signature {
     } else if (typeof v === "string") {
       if (DURATION_KEY.test(k) && durationToSeconds(v) !== null) {
         sig.argShape[k] = durationBucket(v);
+      } else if (QUERY_KEY.test(k)) {
+        // Query args get a structural fingerprint (which metric/func/labels),
+        // not the literal — lets rules distinguish queries by shape.
+        sig.argShape[k] = queryFingerprint(v);
       } else {
-        // Free-text values (queries, ids, names) collapse to "present" — we
-        // never persist the literal.
+        // Other free-text values (ids, names) collapse to "present" — never
+        // the literal.
         sig.argShape[k] = v.trim() ? "present" : "empty";
       }
     } else if (v && typeof v === "object") {


### PR DESCRIPTION
Query args (`query`/`expr`/`promql`/`logql`) were collapsed to `"present"`. Now `queryFingerprint` derives a **structural fingerprint** — functions, metric name(s), label keys — so a profile rule can distinguish *"query_metrics on metric X"* from *"…on Y"*, and the G1 drill-down / G2 editor show which metric/labels a call touched.

- **Privacy:** the literal query is never persisted — string literals (label values, quoted text) are stripped before extraction; numbers/durations aren't emitted as metrics. (Reviewer verified `{job="secret"}`→`l:job`, no value leak.)
- **Correctness:** aggregation operators classified as funcs even as `sum by (x)(expr)`; `by()/without()` grouping labels treated as labels; `[5m]` range fragments not emitted; deterministic — sorted, deduped, capped at 8 per part; prototype-key guard retained.
- **Security:** reviewer caught a **ReDoS** in the func regex (O(n²) on long word runs, attacker-controlled query on the recorder/enforcer hot path). Fixed: input capped at 4 KB + bounded identifier quantifier + a perf regression test (100k-char input < 100ms).
- 9 new fingerprint unit tests; full suite **967 pass / 0 fail**.

Backward-compat: new observations store a fingerprint where old stored `"present"` — fine since Inspect is unreleased. Completes the granularity series. Not released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)