### PR TITLE
feat(inspect): enforce becomes an entitled control (observe/dry-run stay free)

### DIFF
--- a/docs/inspect.md
+++ b/docs/inspect.md
@@ -41,7 +41,13 @@ changed at runtime from the UI or `PUT /api/inspect/mode`.
 | `off` | – | – | – | disable entirely |
 | `observe` | ✅ | – | – | learn what normal looks like (default, zero risk) |
 | `dryrun` | ✅ | ✅ (logs "would block") | – | prove a profile against live traffic before enforcing |
-| `enforce` | ✅ | ✅ | ✅ | block calls outside the accepted profile |
+| `enforce` | ✅ | ✅ | ✅ | block calls outside the accepted profile **(entitled feature)** |
+
+`observe` and `dry-run` — the live Flows graph, learning a profile, and seeing
+would-block deviations — are free. **`enforce` (active blocking) requires an
+entitlement** (the `inspect-enforce` feature); without it the mode switch is
+refused and the gateway keeps running in dry-run. Visibility is free;
+enforcement is the licensed control.
 
 `observe` is the default and is **completely read-only** — it adds no decision
 to the call path, only a non-blocking recorder. `enforce` is the only mode that

--- a/mcp-server/src/conformance/inspect-e2e.test.ts
+++ b/mcp-server/src/conformance/inspect-e2e.test.ts
@@ -81,7 +81,7 @@ test("/api/inspect/mode reports a recording mode", opts, async () => {
   assert.ok(["off", "observe", "dryrun", "enforce"].includes(m.mode));
 });
 
-test("enforce: an out-of-profile tool call is blocked end-to-end", opts, async () => {
+test("enforce is gated by entitlement; observe/dry-run are free", opts, async () => {
   // CSRF double-submit: grab the issued token, echo it on every mutation.
   const probe = await fetch(`${base}/api/inspect/mode`);
   const sc = probe.headers.get("set-cookie") || "";
@@ -90,41 +90,29 @@ test("enforce: an out-of-profile tool call is blocked end-to-end", opts, async (
   const write = (path: string, method: string, body: unknown) =>
     fetch(`${base}${path}`, { method, headers: { "content-type": "application/json", ...csrf }, body: JSON.stringify(body) });
 
-  // MCP session + an observed list_sources call (gives us a rule to accept).
-  const init = await rpc("initialize", { protocolVersion: "2025-11-25", capabilities: {}, clientInfo: { name: "inspect-e2e", version: "0" } });
-  const session = init.session!;
-  await fetch(URL_ENV!, { method: "POST", headers: { "content-type": "application/json", accept: "application/json, text/event-stream", "mcp-session-id": session }, body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized", params: {} }) });
-  await rpc("tools/call", { name: "list_sources", arguments: {} }, session);
-  await new Promise((r) => setTimeout(r, 250));
+  const modeBody = (await probe.json()) as { enforceEntitled?: boolean };
+
+  // Dry-run is always available (OSS).
+  const dry = await write("/api/inspect/mode", "PUT", { mode: "dryrun" });
+  assert.equal(dry.status, 200, "dry-run is free");
 
   try {
-    // Learn, then accept ONLY the list_sources rule — so list_sources is
-    // allow-listed but every other tool deviates, regardless of demo traffic.
-    await write("/api/inspect/profile/derive?window=24h", "POST", {});
-    const prof = (await (await fetch(`${base}/api/inspect/profile`)).json()) as { rules: Array<{ id: string; tool: string; status: string }> };
-    const lsRule = prof.rules.find((r) => r.tool === "list_sources");
-    assert.ok(lsRule, "a list_sources rule was derived");
-    const acc = await write(`/api/inspect/profile/rules/${encodeURIComponent(lsRule!.id)}`, "PATCH", { status: "accepted" });
-    assert.equal(acc.status, 200, "rule accepted (CSRF + inspection:write OK)");
-
-    // Switch to enforce.
-    const setRes = await write("/api/inspect/mode", "PUT", { mode: "enforce" });
-    assert.equal(setRes.status, 200, "mode set to enforce");
-
-    // list_sources is within the accepted rule → NOT blocked.
-    const okCall = await rpc("tools/call", { name: "list_sources", arguments: {} }, session);
-    assert.doesNotMatch(okCall.text, /Blocked by the inspection profile/, "accepted tool allowed under enforce");
-
-    // list_services has no accepted rule → blocked by the enforcer.
-    const blocked = await rpc("tools/call", { name: "list_services", arguments: {} }, session);
-    assert.match(blocked.text, /Blocked by the inspection profile/, "out-of-profile tool blocked under enforce");
-
-    // The block is recorded as a deviation.
-    await new Promise((r) => setTimeout(r, 200));
-    const devs = (await (await fetch(`${base}/api/inspect/deviations?window=1h`)).json()) as { deviations: Array<{ tool: string; decision: string }> };
-    assert.ok(devs.deviations.some((d) => d.tool === "list_services" && d.decision === "blocked"), "blocked deviation recorded");
+    const enf = await write("/api/inspect/mode", "PUT", { mode: "enforce" });
+    if (modeBody.enforceEntitled) {
+      // Licensed: enforce switches on and blocks out-of-profile calls.
+      assert.equal(enf.status, 200, "enforce accepted when entitled");
+      const init = await rpc("initialize", { protocolVersion: "2025-11-25", capabilities: {}, clientInfo: { name: "inspect-e2e", version: "0" } });
+      const session = init.session!;
+      await fetch(URL_ENV!, { method: "POST", headers: { "content-type": "application/json", accept: "application/json, text/event-stream", "mcp-session-id": session }, body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized", params: {} }) });
+      const blocked = await rpc("tools/call", { name: "list_services", arguments: {} }, session);
+      assert.match(blocked.text, /Blocked by the inspection profile|inspection profile/, "out-of-profile call blocked when entitled");
+    } else {
+      // OSS default: enforce is refused with a clear entitlement error.
+      assert.equal(enf.status, 403, "enforce refused without entitlement");
+      const body = (await enf.json()) as { code?: string };
+      assert.equal(body.code, "OMCP_ENTITLEMENT_REQUIRED");
+    }
   } finally {
-    // ALWAYS restore observe so we never leave the shared demo server enforcing.
     await write("/api/inspect/mode", "PUT", { mode: "observe" }).catch(() => {});
   }
 });

--- a/mcp-server/src/enterprise-gate.ts
+++ b/mcp-server/src/enterprise-gate.ts
@@ -62,6 +62,7 @@ type GateState =
       mode: "active";
       claims: Record<string, unknown>;
       accessControl: boolean;
+      inspectEnforce: boolean;
       enforceRbac?: (policy: unknown, ctx: unknown, req: unknown) => unknown;
       enforceCatalog?: (catalog: unknown, ctx: unknown, req: unknown) => unknown;
       rbacPolicy?: unknown;
@@ -149,6 +150,7 @@ async function buildGate(): Promise<GateState> {
     mode: "active",
     claims,
     accessControl: has("access-control"),
+    inspectEnforce: has("inspect-enforce"),
   };
 
   // Audit (best-effort; only if entitled and the module loads). The log
@@ -179,6 +181,18 @@ async function buildGate(): Promise<GateState> {
 /** Reset memoised state (tests only). */
 export function _resetEnterpriseGate(): void {
   gatePromise = null;
+}
+
+/**
+ * Is the Inspect ENFORCE control entitled? Inspect observe/dry-run are free
+ * (OSS); only blocking enforcement requires the "inspect-enforce" feature on a
+ * valid entitlement token. Default-OFF (no token) → false, so OSS deployments
+ * keep observe/dry-run and simply can't switch to blocking enforce.
+ */
+export async function inspectEnforceEntitled(): Promise<boolean> {
+  if (!gatePromise) gatePromise = buildGate();
+  const g = await gatePromise;
+  return g.mode === "active" && g.inspectEnforce === true;
 }
 
 /** Gate mode — for diagnostics (/api/info). */

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -21,6 +21,7 @@ import {
   authorizeAdmin,
   updateRbacPolicy,
   updateCatalog,
+  inspectEnforceEntitled,
 } from "./enterprise-gate.js";
 import {
   loadCredentials,
@@ -1519,7 +1520,15 @@ async function main() {
   // off/dryrun/enforce at boot, and the API can switch it at runtime. Profile
   // evaluation (dry-run/enforce) is wired in a later phase.
   const inspectStore = new InspectStore({ file: process.env.OMCP_INSPECT_FILE?.trim() || undefined });
-  const inspectMode = new ModeController(bootMode(process.env.OMCP_INSPECT));
+  // Inspect ENFORCE (active blocking) is an entitled control; observe/dry-run
+  // are free (OSS). Resolve the entitlement once at boot.
+  const inspectEnforceAllowed = await inspectEnforceEntitled();
+  let inspectBootMode = bootMode(process.env.OMCP_INSPECT);
+  if (inspectBootMode === "enforce" && !inspectEnforceAllowed) {
+    console.warn("[inspect] OMCP_INSPECT=enforce requires an entitlement (inspect-enforce); running in dry-run.");
+    inspectBootMode = "dryrun";
+  }
+  const inspectMode = new ModeController(inspectBootMode);
   // Behavior profile (the learned ruleset). Accepted rules drive the
   // evaluator: in dry-run the recorder records a `would-block` deviation for
   // calls outside the profile (never blocks — enforce blocking is a later
@@ -1536,6 +1545,9 @@ async function main() {
   hookRegistry.register(
     createInspectEnforcer(inspectStore, inspectMode, inspectProfile, {
       onEvent: (e) => recordInspectEvent(e.tool, e.outcome, e.decision),
+      // Belt-and-suspenders: never block without the enforce entitlement, even
+      // if the mode were somehow set to enforce.
+      enforceAllowed: () => inspectEnforceAllowed,
     }),
   );
   if (inspectMode.get() !== "observe") {
@@ -2379,11 +2391,23 @@ async function main() {
       blocking: inspectMode.blocking,
       size: inspectStore.size,
       persisted: inspectStore.persisted,
+      // observe/dry-run are free; enforce (active blocking) is an entitled
+      // control. The UI uses this to lock the Enforce option when unlicensed.
+      enforceEntitled: inspectEnforceAllowed,
     });
   });
 
   app.put("/api/inspect/mode", need("inspection", "write"), audit("inspection", "write"), (req, res) => {
     const body = req.body as { mode?: unknown } | undefined;
+    // Enforce (active blocking) requires the inspect-enforce entitlement;
+    // observe/dry-run are always available. Refuse the switch otherwise.
+    if (typeof body?.mode === "string" && body.mode.trim().toLowerCase() === "enforce" && !inspectEnforceAllowed) {
+      res.status(403).json({
+        error: "Enforce mode requires an entitlement (inspect-enforce). Observe and dry-run are available without a license.",
+        code: "OMCP_ENTITLEMENT_REQUIRED",
+      });
+      return;
+    }
     try {
       const m = inspectMode.set(body?.mode);
       res.json({ mode: m });

--- a/mcp-server/src/inspect/enforcer.test.ts
+++ b/mcp-server/src/inspect/enforcer.test.ts
@@ -53,6 +53,20 @@ describe("createInspectEnforcer", () => {
     }
   });
 
+  it("never blocks when the enforce entitlement is absent (enforceAllowed=false)", async () => {
+    const store = new InspectStore();
+    const reg = createInspectEnforcer(store, new ModeController("enforce"), denyEval, { enforceAllowed: () => false });
+    const r = await reg.handler(ctx(), { args: { service: "novel" } });
+    assert.deepEqual(r, { allow: true }, "unlicensed enforce must not block");
+    assert.equal(store.size, 0, "nothing recorded as blocked when unlicensed");
+  });
+
+  it("blocks when the enforce entitlement is present (enforceAllowed=true)", async () => {
+    const reg = createInspectEnforcer(new InspectStore(), new ModeController("enforce"), denyEval, { enforceAllowed: () => true });
+    const r = await reg.handler(ctx(), { args: {} });
+    assert.equal(r.allow, false);
+  });
+
   it("fails OPEN — an evaluator that throws never blocks the call", async () => {
     const store = new InspectStore();
     const boom = { evaluate: () => { throw new Error("inspector bug"); } };

--- a/mcp-server/src/inspect/enforcer.ts
+++ b/mcp-server/src/inspect/enforcer.ts
@@ -19,6 +19,9 @@ import { authKind, type ProfileEvaluator } from "./recorder.js";
 
 export interface EnforcerOptions {
   onEvent?: (e: { tool: string; outcome: "ok" | "error"; decision: "blocked" }) => void;
+  /** Entitlement gate — when it returns false, the enforcer never blocks (enforce
+   *  is an entitled control; observe/dry-run are free). Defaults to allowed. */
+  enforceAllowed?: () => boolean;
 }
 
 /**
@@ -34,6 +37,8 @@ export function createInspectEnforcer(
   const handler = (ctx: HookContext, payload: HookPayload): HookResult => {
     try {
       if (!mode.blocking) return { allow: true };
+      // Enforce blocking is an entitled control; without it, pass through.
+      if (opts.enforceAllowed && !opts.enforceAllowed()) return { allow: true };
       const red = redactValue((payload as { args?: unknown }).args);
       const sig = deriveSignature(ctx.target, red.value);
       const ev = evaluator.evaluate({

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -1439,6 +1439,7 @@
     .pg-seg button { border:none; background:transparent; color:var(--text-2,var(--text)); font:inherit; font-size:12px; padding:3px 11px; cursor:pointer; }
     .pg-seg button + button { border-left:1px solid var(--border); }
     .pg-seg button.active { background:var(--surface-3); color:var(--text); font-weight:600; }
+    .pg-seg button.locked { color:var(--text-dim); }
     /* JSON: two tones only — keys at full strength, scalars muted. */
     .pg-json { white-space:pre-wrap; font-family:var(--mono); font-size:12px; background:var(--bg); padding:12px; border:1px solid var(--border); border-radius:4px; max-height:540px; overflow:auto; margin:0; color:var(--text-3,#8a93a5); }
     .pg-json .k { color:var(--text); }
@@ -1909,7 +1910,7 @@
           <div id="inspect-enforce-confirm" style="display:none; margin-top:10px; padding:10px 12px; border:1px solid var(--danger); background:var(--danger-soft); border-radius:6px;">
             <div id="inspect-enforce-msg" style="margin-bottom:8px; font-size:var(--fs-sm);"></div>
             <div style="display:flex; gap:8px;">
-              <button class="btn btn-sm btn-danger" onclick="inspectSetMode('enforce', true)">Enforce — block deviations</button>
+              <button class="btn btn-sm btn-danger" id="inspect-enforce-go" onclick="inspectSetMode('enforce', true)">Enforce — block deviations</button>
               <button class="btn btn-sm" onclick="inspectCancelEnforce()">Cancel</button>
             </div>
           </div>
@@ -7598,7 +7599,7 @@ async function inspectSetMode(mode, confirmed){
   inspectCancelEnforce();
   try{
     const r=await fetch('/api/inspect/mode',{method:'PUT',headers:{'content-type':'application/json'},body:JSON.stringify({mode})});
-    if(!r.ok){ toast(r.status===403?'Need inspection:write to change mode':'Mode change failed','error'); return; }
+    if(!r.ok){ let msg='Mode change failed'; try{ const e=await r.json(); if(e&&e.error) msg=e.error; }catch(_){} toast(msg,'error'); return; }
     const j=await r.json();
     toast('Inspection mode: '+(j.mode||mode),'ok');
     inspectRefreshMode();
@@ -7607,10 +7608,20 @@ async function inspectSetMode(mode, confirmed){
 }
 
 async function inspectRequestEnforce(){
+  const msg=document.getElementById('inspect-enforce-msg');
+  const go=document.getElementById('inspect-enforce-go');
+  // Enforce (active blocking) is an entitled control — show an Enterprise
+  // notice instead of the confirm action when unlicensed.
+  if(window.__inspectEnforceEntitled===false){
+    msg.innerHTML='🔒 <b>Enforce is an Enterprise feature.</b> Blocking out-of-profile calls requires an entitlement (inspect-enforce). <b>Observe</b> and <b>Dry-run</b> — including the live graph, learning, and would-block deviations — are available without a license.';
+    if(go) go.style.display='none';
+    document.getElementById('inspect-enforce-confirm').style.display='block';
+    return;
+  }
+  if(go) go.style.display='';
   let accepted=0, wouldBlock=0;
   try{ const p=await fetch('/api/inspect/profile'); if(p.ok){ const j=await p.json(); accepted=(j.counts&&j.counts.accepted)||0; } }catch(e){}
   try{ const d=await fetch('/api/inspect/deviations?window=24h'); if(d.ok){ const j=await d.json(); wouldBlock=j.total||0; } }catch(e){}
-  const msg=document.getElementById('inspect-enforce-msg');
   if(accepted===0){
     msg.innerHTML='<b>No accepted rules.</b> Enforcing now would block <b>every</b> call (nothing is allow-listed). Accept some rules first, or continue only if you really intend a default-deny.';
   }else{
@@ -7820,6 +7831,15 @@ function updateInspectModeChip(m){
   if(seg) seg.querySelectorAll('button[data-mode]').forEach(b=>b.classList.toggle('active', b.getAttribute('data-mode')===mode));
   const desc=document.getElementById('inspect-mode-desc');
   if(desc) desc.textContent=(typeof INSPECT_MODE_DESC!=='undefined'&&INSPECT_MODE_DESC[mode])||'';
+  // Enforce is an entitled control — lock the segment when unlicensed.
+  window.__inspectEnforceEntitled = (m.enforceEntitled !== false);
+  const enf=seg&&seg.querySelector('button[data-mode="enforce"]');
+  if(enf){
+    const locked=m.enforceEntitled===false;
+    enf.classList.toggle('locked', locked);
+    enf.textContent=locked?'Enforce 🔒':'Enforce';
+    enf.title=locked?'Enforce (active blocking) is an Enterprise feature — requires an entitlement':'';
+  }
 }
 
 function showInspectGraphMessage(msg){


### PR DESCRIPTION
Inspect's **active blocking (enforce)** is now an entitled/Enterprise control. The **live Flows graph, profile learning, and dry-run would-block deviations stay free (OSS)** — only blocking requires the `inspect-enforce` entitlement.

- **enterprise-gate.ts**: `inspectEnforceEntitled()` — true only when the gate is active AND the token carries `inspect-enforce`; **default-OFF / no token → false, never throws** (safe when the `enterprise/` modules are absent from the published build).
- **index.ts**: entitlement resolved once at boot; `OMCP_INSPECT=enforce` downgrades to dry-run when unlicensed; `PUT /api/inspect/mode` refuses enforce with **403 `OMCP_ENTITLEMENT_REQUIRED`**; GET exposes `enforceEntitled`. Three layers (boot downgrade · PUT 403 · enforcer guard) — no path blocks unlicensed.
- **UI**: Enforce segment **locks** (🔒, Enterprise tooltip) + the confirm panel shows an Enterprise notice; mode errors surface via toast.
- **Backward-compat**: default/unconfigured behavior unchanged; observe/dry-run fully functional. Reviewer-agent confirmed no OSS breakage, 3-layer gate, no XSS.
- **Tests**: enforcer entitlement unit tests; live E2E asserts the gate (enforce→403 unlicensed, dry-run free; blocks when entitled); 970-test suite green; inspect Playwright 7/7.

First of the licensing slices (E2 SSO/OIDC, E3 SCIM, E4 tenancy to follow). Not released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)