### PR TITLE
feat(auth): SSO/OIDC requires the sso entitlement

### DIFF
--- a/docs/auth-oidc.md
+++ b/docs/auth-oidc.md
@@ -6,6 +6,15 @@ own the user database. Sign-in becomes a single "Sign in with SSO"
 button; the OMCP server only sees identity claims after the IdP has
 verified the user.
 
+> **SSO/OIDC is an entitled control.** The open-source surface —
+> anonymous, [basic (local users)](auth-basic.md), and API-key auth —
+> stays free and unchanged. Delegating identity to an external IdP
+> requires the `sso` entitlement; with `OMCP_AUTH=oidc` set but no valid
+> entitlement, the server refuses to start with a clear message (or, with
+> `OMCP_AUTH_ALLOW_FALLBACK=true`, logs the reason and falls back to
+> anonymous). A deployment that never sets `OMCP_AUTH=oidc` is never
+> affected. See [enterprise-gate.md](enterprise-gate.md).
+
 This page documents the operator-side setup. The two adjacent docs
 that frame it:
 

--- a/docs/enterprise-gate.md
+++ b/docs/enterprise-gate.md
@@ -37,9 +37,19 @@ principal). The local `/api/*` management UI is unchanged.
 | `OMCP_CATALOG` | Path to a product-catalog JSON (enables the catalog) |
 | `OMCP_AUDIT_FILE` | Optional path; appends one JSON line per access decision |
 
-Feature gating: the token's `features` must include `access-control`
-for RBAC/catalog enforcement and `audit` for the audit log. A policy
-configured without the matching feature is denied (fail-closed).
+Feature gating: the token's `features` must include the matching claim
+for each entitled control. A control configured without its feature is
+denied / refused (fail-closed):
+
+| Feature | Gates |
+|---------|-------|
+| `access-control` | RBAC + product-catalog enforcement |
+| `audit` | the append-only audit log |
+| `inspect-enforce` | [Inspect](inspect.md) `enforce` mode (active blocking; observe/dry-run stay free) |
+| `sso` | [SSO/OIDC](auth-oidc.md) login (`OMCP_AUTH=oidc`; basic/api-key/anonymous stay free) |
+
+The OSS surface is whatever is left default-OFF: with no entitlement
+token, no control activates and behaviour is unchanged.
 
 ## Quickstart
 

--- a/mcp-server/src/enterprise-gate.test.ts
+++ b/mcp-server/src/enterprise-gate.test.ts
@@ -14,6 +14,8 @@ import {
   validatePolicyShape,
   validateCatalogShape,
   authorizeAdmin,
+  featureEntitled,
+  inspectEnforceEntitled,
   _resetEnterpriseGate,
 } from "./enterprise-gate.js";
 
@@ -73,6 +75,17 @@ describe("enterprise-gate — OFF (no opt-in, published-artifact state)", () => 
     ]) {
       await assert.doesNotReject(enforceEntitledAccess(defaultContext(), { tool }));
     }
+  });
+
+  it("featureEntitled is false for every feature when OFF (OSS default)", async () => {
+    clearEnv();
+    // Default-OFF means no entitled feature is active — SSO/SCIM/tenancy/
+    // inspect-enforce all stay locked, so the OSS surface is unchanged and
+    // a feature only ever gates when the operator has actively licensed it.
+    for (const feature of ["sso", "scim", "tenancy", "inspect-enforce", "anything"]) {
+      assert.equal(await featureEntitled(feature), false, `feature ${feature} must be locked when OFF`);
+    }
+    assert.equal(await inspectEnforceEntitled(), false, "inspectEnforceEntitled mirrors featureEntitled");
   });
 
   it("gate state is memoised across calls", async () => {

--- a/mcp-server/src/enterprise-gate.ts
+++ b/mcp-server/src/enterprise-gate.ts
@@ -63,6 +63,7 @@ type GateState =
       claims: Record<string, unknown>;
       accessControl: boolean;
       inspectEnforce: boolean;
+      hasFeature: (feature: string) => boolean;
       enforceRbac?: (policy: unknown, ctx: unknown, req: unknown) => unknown;
       enforceCatalog?: (catalog: unknown, ctx: unknown, req: unknown) => unknown;
       rbacPolicy?: unknown;
@@ -151,6 +152,7 @@ async function buildGate(): Promise<GateState> {
     claims,
     accessControl: has("access-control"),
     inspectEnforce: has("inspect-enforce"),
+    hasFeature: has,
   };
 
   // Audit (best-effort; only if entitled and the module loads). The log
@@ -190,9 +192,20 @@ export function _resetEnterpriseGate(): void {
  * keep observe/dry-run and simply can't switch to blocking enforce.
  */
 export async function inspectEnforceEntitled(): Promise<boolean> {
+  return featureEntitled("inspect-enforce");
+}
+
+/**
+ * Is a named entitlement feature active? True only with a valid entitlement
+ * token that carries the feature. Default-OFF (no token / enterprise modules
+ * absent) → false, never throws — so OSS deployments keep their free surface
+ * and a feature is only gated when the operator has actively configured it.
+ * Used to license SSO/OIDC ("sso"), SCIM ("scim"), multi-tenancy ("tenancy").
+ */
+export async function featureEntitled(feature: string): Promise<boolean> {
   if (!gatePromise) gatePromise = buildGate();
   const g = await gatePromise;
-  return g.mode === "active" && g.inspectEnforce === true;
+  return g.mode === "active" && g.hasFeature(feature);
 }
 
 /** Gate mode — for diagnostics (/api/info). */

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -22,6 +22,7 @@ import {
   updateRbacPolicy,
   updateCatalog,
   inspectEnforceEntitled,
+  featureEntitled,
 } from "./enterprise-gate.js";
 import {
   loadCredentials,
@@ -1171,8 +1172,19 @@ async function main() {
       }
     }
   } else if (requestedAuthMode === "oidc") {
+    // SSO/OIDC is an entitled control. The OSS surface — anonymous, basic
+    // (local users), and API-key auth — stays free and unchanged; only
+    // delegating identity to an external IdP requires the `sso` entitlement.
+    // Fail-closed when actively requested without it (respects the same
+    // OMCP_AUTH_ALLOW_FALLBACK escape hatch as every other auth misconfig);
+    // a deployment that never sets OMCP_AUTH=oidc is never affected.
     const r = resolveOidcConfig(process.env);
-    if (r.error || !r.config) {
+    if (!(await featureEntitled("sso"))) {
+      authMisconfig(
+        "OMCP_AUTH=oidc (SSO) requires an entitlement (sso feature). " +
+          "Use OMCP_AUTH=basic or api-key for the open-source single-sign-on-free setup",
+      );
+    } else if (r.error || !r.config) {
       authMisconfig(r.error ?? "OIDC misconfigured");
     } else {
       let secret = process.env.OMCP_SESSION_SECRET;


### PR DESCRIPTION
## What

`OMCP_AUTH=oidc` now gates on a valid `sso` entitlement, making SSO/OIDC an entitled control while keeping the open-source auth surface free and unchanged.

| Auth mode | Entitlement |
|-----------|-------------|
| anonymous (default) | free |
| basic (local users file) | free |
| api-key | free |
| **oidc / SSO** | **requires `sso`** |

## Behavior

- **Fail-closed:** `OMCP_AUTH=oidc` without the `sso` entitlement → server refuses to start with a clear message, mirroring the existing `authMisconfig()` contract used by basic mode. `OMCP_AUTH_ALLOW_FALLBACK=true` downgrades to anonymous instead.
- **Unaffected by default:** a deployment that never sets `OMCP_AUTH=oidc` never calls the gate. Default is `anonymous`.
- **Default-OFF safe:** with no entitlement token (the published-artifact state), `featureEntitled()` returns `false` and never throws.

## Refactor

Generalizes the entitlement gate: `enterprise-gate` now exposes `featureEntitled(name)`; `inspectEnforceEntitled()` delegates to it (behavior byte-identical). This is the seam SCIM (E3) and multi-tenancy (E4) will reuse.

## Tests

- New unit test pins default-OFF: every feature (`sso`/`scim`/`tenancy`/`inspect-enforce`/`anything`) locked, `inspectEnforceEntitled` mirror.
- Full suite green: 970 pass / 0 fail, tsc clean.
- Reviewer-agent gate: SHIP (quality + sensitive-data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)