### PR TITLE
feat(scim): SCIM provisioning requires the scim entitlement

### DIFF
--- a/docs/enterprise-gate.md
+++ b/docs/enterprise-gate.md
@@ -47,6 +47,7 @@ denied / refused (fail-closed):
 | `audit` | the append-only audit log |
 | `inspect-enforce` | [Inspect](inspect.md) `enforce` mode (active blocking; observe/dry-run stay free) |
 | `sso` | [SSO/OIDC](auth-oidc.md) login (`OMCP_AUTH=oidc`; basic/api-key/anonymous stay free) |
+| `scim` | [SCIM provisioning](scim-provisioning.md) (`OMCP_SCIM_TOKEN`; local users/api-keys stay free) |
 
 The OSS surface is whatever is left default-OFF: with no entitlement
 token, no control activates and behaviour is unchanged.

--- a/docs/scim-provisioning.md
+++ b/docs/scim-provisioning.md
@@ -5,6 +5,14 @@ your IdP (Microsoft Entra ID, Okta) can push directory state
 directly into the gateway — no manual `OMCP_API_KEYS` rotation, no
 per-user `OMCP_USERS_FILE` editing.
 
+> **SCIM provisioning is an entitled control.** It is OFF by default
+> (no `OMCP_SCIM_TOKEN`), so the open-source surface is unchanged — local
+> `OMCP_USERS_FILE` and `OMCP_API_KEYS` auth stay free. Pushing directory
+> state from an IdP over SCIM requires the `scim` entitlement; with
+> `OMCP_SCIM_TOKEN` set but no valid entitlement the gateway keeps running
+> but **refuses to mount `/scim/v2/*` (fail-closed)** and logs the reason.
+> See [enterprise-gate.md](enterprise-gate.md).
+
 ## Enable
 
 ```bash

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1535,6 +1535,11 @@ async function main() {
   // Inspect ENFORCE (active blocking) is an entitled control; observe/dry-run
   // are free (OSS). Resolve the entitlement once at boot.
   const inspectEnforceAllowed = await inspectEnforceEntitled();
+  // SCIM provisioning is likewise an entitled control. OFF by default (no
+  // OMCP_SCIM_TOKEN) so the OSS surface is unchanged; resolve the entitlement
+  // once here so both /api/info and the route-mount block agree.
+  const scimConfigured = !!process.env.OMCP_SCIM_TOKEN?.trim();
+  const scimEntitled = scimConfigured && (await featureEntitled("scim"));
   let inspectBootMode = bootMode(process.env.OMCP_INSPECT);
   if (inspectBootMode === "enforce" && !inspectEnforceAllowed) {
     console.warn("[inspect] OMCP_INSPECT=enforce requires an entitlement (inspect-enforce); running in dry-run.");
@@ -1925,7 +1930,8 @@ async function main() {
           .getAll()
           .filter((c) => typeof c.queryTraces === "function").length,
         pluginsVerified: !/^(0|false|no|off)$/i.test(process.env.VERIFY_PLUGINS ?? "true"),
-        scimEnabled: !!process.env.OMCP_SCIM_TOKEN,
+        scimEnabled: scimEntitled,
+        scimConfigured,
         federationUpstreams: (process.env.OMCP_FEDERATION_UPSTREAMS ?? "")
           .split(",").map((s) => s.trim()).filter(Boolean).length,
       },
@@ -2841,7 +2847,20 @@ async function main() {
   // multi-replica deployments stay coherent (Q6); the redis client is
   // built from OMCP_SCIM_REDIS_URL here, mirroring the session store.
   const scimToken = process.env.OMCP_SCIM_TOKEN?.trim();
-  if (scimToken) {
+  // SCIM provisioning is an entitled control (entitlement resolved at boot as
+  // `scimEntitled`). OFF by default (no OMCP_SCIM_TOKEN) → OSS surface
+  // unchanged. Configured without the `scim` entitlement → fail closed: the
+  // /scim/v2/* routes are NOT mounted and the dashboard store stays empty, so
+  // no unentitled provisioning can happen — and the gateway keeps running (a
+  // missing IdP integration must not take the whole server down).
+  if (scimToken && !scimEntitled) {
+    console.error(
+      "[scim] OMCP_SCIM_TOKEN is set but SCIM provisioning requires an entitlement " +
+        "(scim feature) — refusing to mount /scim/v2/* (fail-closed). " +
+        "Unset OMCP_SCIM_TOKEN to silence this, or provision an entitlement.",
+    );
+  }
+  if (scimToken && scimEntitled) {
     try {
       const scimBackend = (process.env.OMCP_SCIM_BACKEND?.trim() || "file") as "file" | "redis";
       let scimRedis: import("./scim/redis-store.js").RedisLike | undefined;


### PR DESCRIPTION
## What

`OMCP_SCIM_TOKEN` now gates on a valid `scim` entitlement, making SCIM provisioning an entitled control while keeping the open-source identity surface free and unchanged.

| Identity source | Entitlement |
|-----------------|-------------|
| local users (`OMCP_USERS_FILE`) | free |
| api-keys (`OMCP_API_KEYS`) | free |
| **SCIM provisioning** (`OMCP_SCIM_TOKEN`) | **requires `scim`** |

## Behavior

- **OFF by default:** no `OMCP_SCIM_TOKEN` → SCIM never activates, OSS surface unchanged.
- **Fail-closed:** `OMCP_SCIM_TOKEN` set without the `scim` entitlement → `/scim/v2/*` is **not mounted**, the provisioning store stays unset, and the gateway logs a clear error and **keeps running**. A missing IdP integration must not take the whole server down — this intentionally differs from OIDC, which exits.
- `/api/provisioning` returns its graceful empty note when SCIM isn't mounted (`projectProvisioning(null)`).

## Posture flag

`/api/info`: `scimEnabled` now means *active* (token present **and** entitled); a new `scimConfigured` field preserves the "token present" signal so dashboards can distinguish "configured but not entitled".

## Tests

- Reuses the `featureEntitled("scim")` seam from E2; default-OFF returns false (covered by the existing gate unit test).
- Full suite green: 970 pass / 0 fail, tsc clean.
- Reviewer-agent gate: SHIP (quality + sensitive-data; gate verified airtight — single `provisioningStore` assignment, no TDZ).

🤖 Generated with [Claude Code](https://claude.com/claude-code)