### PR TITLE
feat(tenancy): active multi-tenancy requires the tenancy entitlement

### DIFF
--- a/docs/enterprise-gate.md
+++ b/docs/enterprise-gate.md
@@ -48,6 +48,7 @@ denied / refused (fail-closed):
 | `inspect-enforce` | [Inspect](inspect.md) `enforce` mode (active blocking; observe/dry-run stay free) |
 | `sso` | [SSO/OIDC](auth-oidc.md) login (`OMCP_AUTH=oidc`; basic/api-key/anonymous stay free) |
 | `scim` | [SCIM provisioning](scim-provisioning.md) (`OMCP_SCIM_TOKEN`; local users/api-keys stay free) |
+| `tenancy` | [Multi-tenant isolation](tenancy.md) (non-default tenants via OIDC tenant claim / `OMCP_KEY_TENANTS`; single-tenant stays free) |
 
 The OSS surface is whatever is left default-OFF: with no entitlement
 token, no control activates and behaviour is unchanged.

--- a/docs/tenancy.md
+++ b/docs/tenancy.md
@@ -13,6 +13,22 @@ audit entries, and catalog enrichments all scope by tenant. Cross-
 tenant data is invisible to non-admins through both the `/api/*`
 surface and the MCP tool layer.
 
+> **Active multi-tenancy is an entitled control.** The single-tenant
+> default — anonymous, basic, api-key, or OIDC without a tenant claim,
+> everyone in `default` — is open-source and bit-for-bit unchanged.
+> Configuring **non-default** tenants (an OIDC tenant claim, or
+> `OMCP_KEY_TENANTS` mapping a credential to a non-default tenant)
+> requires the `tenancy` entitlement. Without it the gateway **refuses
+> to start (fail-closed)** with a clear message — rather than silently
+> collapsing isolated tenants into one, which could merge data across
+> tenant boundaries. See [enterprise-gate.md](enterprise-gate.md).
+>
+> Note: the `google` and `microsoft-entra` OIDC profiles ship a built-in
+> tenant claim (`hd` / `tid`), so they count as actively multi-tenant even
+> with `OMCP_OIDC_TENANT_CLAIM` unset. To run single-tenant on those
+> profiles, set `OMCP_OIDC_TENANT_CLAIM=""` explicitly (or use the
+> `generic` profile).
+
 ## How identities resolve to a tenant
 
 | Identity path | Tenant comes from | Default when unset |

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -10,7 +10,7 @@ import { loadConfig, saveConfig, DEFAULT_HEALTH_THRESHOLDS, DEFAULT_SETTINGS } f
 import { ConnectorRegistry, getSupportedTypes } from "./connectors/registry.js";
 import { isTopologyProvider } from "./connectors/interface.js";
 import { defaultContext, principalContext, sessionContext, allowsTool, type RequestContext } from "./context.js";
-import { parseKeyTenants } from "./tenancy/context.js";
+import { parseKeyTenants, isMultiTenantConfigured } from "./tenancy/context.js";
 import {
   enforceEntitledAccess,
   enterpriseGateStatus,
@@ -1144,6 +1144,9 @@ async function main() {
   let usersStore: LocalUsersFile | null = null;
   let secretEphemeral = false;
   let oidcRuntime: ReturnType<typeof buildOidcRuntime> | undefined;
+  // Captured so the multi-tenancy entitlement gate below can tell whether
+  // OIDC is configured to read a tenant claim (non-empty → tenant'd logins).
+  let oidcTenantClaim = "";
   if (requestedAuthMode === "basic") {
     const usersPath = process.env.OMCP_USERS_FILE;
     if (!usersPath) {
@@ -1200,11 +1203,38 @@ async function main() {
       sessionCfg = { secret };
       authMode = "oidc";
       oidcRuntime = buildOidcRuntime(r.config);
+      oidcTenantClaim = r.config.tenantClaim ?? "";
       console.log(`[auth] OIDC mode active — issuer=${r.config.issuer} clientId=${r.config.clientId} rolesClaim=${r.config.rolesClaim} mappedRoles=${Object.keys(r.config.roleMap).length}`);
     }
   } else if (requestedAuthMode !== "anonymous") {
     authMisconfig(`unknown OMCP_AUTH=${requestedAuthMode}`);
   }
+
+  // Multi-tenancy is an entitled control. The gateway is ALWAYS tenant-scoped,
+  // but every principal lands in DEFAULT_TENANT unless the operator actively
+  // maps identities to NON-default tenants — so the single-tenant default (the
+  // OSS path: anonymous, basic, api-key, or OIDC without a tenant claim) is
+  // free and bit-for-bit unchanged. It becomes "actively multi-tenant" only
+  // when an OIDC tenant claim is configured, or OMCP_KEY_TENANTS maps a
+  // credential to a non-default tenant. That configuration requires the
+  // `tenancy` entitlement; without it we fail closed and refuse to start,
+  // rather than silently collapsing isolated tenants into one (which could
+  // merge data across tenant boundaries). Single-tenant deployments never hit
+  // this branch.
+  const tenancyConfigured = isMultiTenantConfigured(oidcTenantClaim, process.env.OMCP_KEY_TENANTS);
+  if (tenancyConfigured && !(await featureEntitled("tenancy"))) {
+    const which = oidcTenantClaim
+      ? `an OIDC tenant claim (${oidcTenantClaim})`
+      : "OMCP_KEY_TENANTS with non-default tenants";
+    console.error(
+      `[tenancy] ${which} configures multi-tenant isolation, which requires an ` +
+        "entitlement (tenancy feature) — refusing to start (fail-closed). " +
+        "For the open-source single-tenant setup, omit OMCP_OIDC_TENANT_CLAIM and " +
+        "keep OMCP_KEY_TENANTS at the default tenant.",
+    );
+    process.exit(1);
+  }
+
   // Session revocation blocklist (Q17). Only meaningful when sessions
   // exist (basic / oidc); anonymous mode leaves it undefined so the
   // middleware check is a pure no-op. OMCP_AUTH_REVOCATION_FILE persists
@@ -1932,6 +1962,10 @@ async function main() {
         pluginsVerified: !/^(0|false|no|off)$/i.test(process.env.VERIFY_PLUGINS ?? "true"),
         scimEnabled: scimEntitled,
         scimConfigured,
+        // Active multi-tenancy (non-default tenants configured). When true the
+        // server is running, so the `tenancy` entitlement is necessarily
+        // present — an unentitled multi-tenant config fails closed at boot.
+        multiTenant: tenancyConfigured,
         federationUpstreams: (process.env.OMCP_FEDERATION_UPSTREAMS ?? "")
           .split(",").map((s) => s.trim()).filter(Boolean).length,
       },

--- a/mcp-server/src/tenancy/context.test.ts
+++ b/mcp-server/src/tenancy/context.test.ts
@@ -7,6 +7,7 @@ import {
   normaliseTenant,
   tenantFromClaim,
   parseKeyTenants,
+  isMultiTenantConfigured,
 } from "./context.js";
 
 test("normaliseTenant — happy paths", () => {
@@ -88,4 +89,23 @@ test("parseKeyTenants — malformed entries skipped, doesn't crash", () => {
 test("parseKeyTenants — undefined / empty returns empty map", () => {
   assert.equal(parseKeyTenants(undefined).size, 0);
   assert.equal(parseKeyTenants("").size, 0);
+});
+
+test("isMultiTenantConfigured — single-tenant default is false (OSS path stays free)", () => {
+  // No OIDC tenant claim, no key-tenant mapping → single-tenant.
+  assert.equal(isMultiTenantConfigured(undefined, undefined), false);
+  assert.equal(isMultiTenantConfigured("", ""), false);
+  // Mappings that only ever resolve to `default` are NOT multi-tenant.
+  assert.equal(isMultiTenantConfigured("", "agent=default;ci=default"), false);
+  // Invalid tenant strings normalise to `default`, so they don't trip it.
+  assert.equal(isMultiTenantConfigured("", "agent=!!!bad!!!"), false);
+});
+
+test("isMultiTenantConfigured — true once a non-default tenant is configured", () => {
+  // An OIDC tenant claim alone activates multi-tenancy.
+  assert.equal(isMultiTenantConfigured("tid", undefined), true);
+  assert.equal(isMultiTenantConfigured("  tenant  ", undefined), true);
+  // A non-default key→tenant mapping activates it.
+  assert.equal(isMultiTenantConfigured("", "agent=acme"), true);
+  assert.equal(isMultiTenantConfigured("", "agent=default;ci=bigco"), true);
 });

--- a/mcp-server/src/tenancy/context.ts
+++ b/mcp-server/src/tenancy/context.ts
@@ -90,3 +90,20 @@ export function parseKeyTenants(raw: string | undefined): Map<string, string> {
   }
   return out;
 }
+
+/** Is the deployment ACTIVELY multi-tenant — i.e. configured to place any
+ *  identity in a NON-default tenant? True when an OIDC tenant claim is set,
+ *  or OMCP_KEY_TENANTS maps a credential to a tenant other than `default`.
+ *  The single-tenant default (no claim, no non-default key mapping) returns
+ *  false, so the open-source path stays free. This is the predicate the boot
+ *  sequence uses to decide whether the `tenancy` entitlement is required. */
+export function isMultiTenantConfigured(
+  oidcTenantClaim: string | undefined,
+  keyTenantsEnv: string | undefined,
+): boolean {
+  if (oidcTenantClaim && oidcTenantClaim.trim().length > 0) return true;
+  for (const t of parseKeyTenants(keyTenantsEnv).values()) {
+    if (t && t !== DEFAULT_TENANT) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## What

Active multi-tenancy now gates on a valid `tenancy` entitlement, completing the entitlement model (alongside `inspect-enforce`, `sso`, `scim`).

The gateway is *always* tenant-scoped, but every principal lands in the `default` tenant unless an operator actively maps identities to non-default tenants. The single-tenant default stays free and bit-for-bit unchanged.

| Tenancy state | Entitlement |
|---------------|-------------|
| single-tenant (anonymous / basic / api-key / OIDC without a tenant claim) | free |
| **active multi-tenancy** (OIDC tenant claim, or `OMCP_KEY_TENANTS` → non-default tenant) | **requires `tenancy`** |

## Behavior

- **Fail-closed:** active multi-tenancy without the `tenancy` entitlement → the gateway **refuses to start** with a clear message. A hard exit (not a silent downgrade) is intentional: silently collapsing isolated tenants into `default` could merge data across tenant boundaries.
- **Single-tenant unaffected:** no tenant claim and no non-default `OMCP_KEY_TENANTS` mapping → never hits the gate.
- Detection is a pure, unit-tested predicate `isMultiTenantConfigured()` (invalid tenant strings normalize to `default`, so garbage can't trip the gate).
- `/api/info` gains a `multiTenant` posture flag.

## Note for Entra/Google profiles

The `google` / `microsoft-entra` OIDC profiles ship a built-in tenant claim (`hd` / `tid`), so they count as actively multi-tenant by nature. Documented in `tenancy.md`: to run single-tenant on those profiles, set `OMCP_OIDC_TENANT_CLAIM=""` (or use the `generic` profile).

## Tests

- New unit tests for `isMultiTenantConfigured` (single-tenant false incl. all-default mappings & invalid strings; true for claim or non-default mapping).
- Full suite green: 972 pass / 0 fail, tsc clean.
- Reviewer-agent gate: SHIP (quality + sensitive-data; detection verified airtight, `process.exit` placement clean, no consumer break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)