### PR TITLE
fix(agent): demo agent made zero MCP calls (broken /mcp URL replace)

### DIFF
--- a/examples/agent/src/index.ts
+++ b/examples/agent/src/index.ts
@@ -4,7 +4,12 @@ import { IncidentDeduper } from "./dedup.js";
 
 // Config from env vars
 const MCP_URL = process.env.MCP_URL || "http://mcp-server:3000/mcp";
-const SETTINGS_URL = MCP_URL.replace("/mcp", "/api/settings");
+// Derive the gateway's HTTP base from MCP_URL by stripping a trailing `/mcp`
+// path segment. Do NOT use String.replace("/mcp", …): the substring `/mcp`
+// also occurs inside `//mcp-server`, so a plain replace rewrites the host
+// (→ http://api/sources-server:3000/mcp → ENOTFOUND). Anchor to the end.
+const API_BASE = MCP_URL.replace(/\/mcp\/?$/, "");
+const SETTINGS_URL = `${API_BASE}/api/settings`;
 const OLLAMA_URL = process.env.OLLAMA_URL || "http://host.docker.internal:11434";
 const OLLAMA_MODEL = process.env.OLLAMA_MODEL || "llama3.1:8b";
 const SYSTEM_PROMPT = process.env.SYSTEM_PROMPT || `You are an SRE agent monitoring microservices infrastructure. When observability data shows anomalies or issues:
@@ -138,7 +143,7 @@ async function chatWithOllama(
 async function main() {
   log("Starting observability-mcp agent");
 
-  await waitForService(MCP_URL.replace("/mcp", "/api/sources"), "MCP Server");
+  await waitForService(`${API_BASE}/api/sources`, "MCP Server");
   await syncSettings();
   log(`Config: MCP=${MCP_URL} OLLAMA=${OLLAMA_URL} MODEL=${OLLAMA_MODEL} INTERVAL=${checkInterval}ms`);
 


### PR DESCRIPTION
## Bug

The demo SRE agent never connected to the gateway and made **zero MCP tool calls**, so the **Inspect Flows graph stayed empty** in the demo.

Root cause: 

```js
"http://mcp-server:3000/mcp".replace("/mcp", "/api/sources")
// → "http://api/sources-server:3000/mcp"   (the "/mcp" inside "//mcp-server" matched first)
// → ENOTFOUND on host "api"
```

`String.replace` with a string argument replaces the **first** occurrence — which is inside the **host** `//mcp-server`, not the path. The agent's readiness wait (`/api/sources`) and settings sync (`/api/settings`) both polled a corrupted URL forever.

## Fix

Derive the HTTP base once with an **end-anchored** strip and build `/api/*` from it:

```js
const API_BASE = MCP_URL.replace(/\/mcp\/?$/, "");
const SETTINGS_URL = `${API_BASE}/api/settings`;
// waitForService(`${API_BASE}/api/sources`, …)
```

The MCP transport still uses `MCP_URL` verbatim (`new URL(MCP_URL)`).

## Verified live

After rebuild the agent connects immediately:
```
MCP Server is ready → Connected to MCP server
MCP tools: list_sources, … (12 tools)
--- Running anomaly scan ---
```
and tool calls now surface in `/api/inspect/flows` (total > 0).

- Agent `tsc --noEmit` clean (Docker).
- Reviewer-agent: SHIP (correctness + sensitive-data; anchored regex handles `/mcp`, `/mcp/`, and non-`/mcp` no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)