### PR TITLE
feat(ui): consistent lock-badge optic for entitled features

### DIFF
--- a/mcp-server/playwright/Dockerfile
+++ b/mcp-server/playwright/Dockerfile
@@ -20,6 +20,7 @@ COPY topology.spec.mjs ./topology.spec.mjs
 COPY rail.spec.mjs ./rail.spec.mjs
 COPY inspect.spec.mjs ./inspect.spec.mjs
 COPY governance.spec.mjs ./governance.spec.mjs
+COPY entitlement-locks.spec.mjs ./entitlement-locks.spec.mjs
 
 # When run with --network=host (Linux) OMCP_UI_BASE defaults to localhost.
 # In a compose network pass OMCP_UI_BASE=http://mcp-server:3000 explicitly.

--- a/mcp-server/playwright/entitlement-locks.spec.mjs
+++ b/mcp-server/playwright/entitlement-locks.spec.mjs
@@ -1,0 +1,50 @@
+import { test, expect } from "@playwright/test";
+
+const BASE = process.env.OMCP_UI_BASE || "http://localhost:3000";
+
+// The OSS demo has no entitlement token, so /api/info.governance.entitlements
+// is all-false and every enterprise feature must read as "visible but locked":
+// a 🔒 badge on the nav item and an explanatory banner on the page.
+test.describe("Entitlement lock optic (OSS default — everything locked)", () => {
+  test("nav-rail shows a lock badge on each entitled feature", async ({ page }) => {
+    const errors = [];
+    page.on("console", (m) => { if (m.type() === "error") errors.push(m.text()); });
+    page.on("pageerror", (e) => errors.push(String(e)));
+
+    await page.goto(BASE, { waitUntil: "networkidle" });
+
+    for (const pageId of ["products", "access", "policies", "audit"]) {
+      const btn = page.locator(`.nav-btn[data-page="${pageId}"]`);
+      await expect(btn).toHaveClass(/ent-locked/);
+      await expect(btn.locator(".ent-lock")).toBeVisible();
+    }
+    await expect(errors, `console errors: ${errors.join("\n")}`).toEqual([]);
+  });
+
+  test("each entitled page shows its Enterprise lock banner naming the feature", async ({ page }) => {
+    await page.goto(BASE, { waitUntil: "networkidle" });
+    for (const [pageId, feature] of [
+      ["access", "access-control"],
+      ["products", "access-control"],
+      ["policies", "access-control"],
+      ["audit", "audit"],
+    ]) {
+      await page.locator(`.nav-btn[data-page="${pageId}"]`).click();
+      const banner = page.locator(`#page-${pageId} .ent-banner[data-ent-feature="${feature}"]`);
+      await expect(banner).toBeVisible();
+      await expect(banner).toContainText(/Enterprise feature/i);
+      await expect(banner.locator("code", { hasText: feature })).toBeVisible();
+    }
+  });
+
+  test("Provisioning sub-tab carries a SCIM lock badge + banner", async ({ page }) => {
+    await page.goto(BASE, { waitUntil: "networkidle" });
+    await page.locator('.nav-btn[data-page="policies"]').click();
+    const provTab = page.locator('.pol-subtab[data-pol-tab="provisioning"]');
+    await expect(provTab.locator(".ent-lock")).toBeVisible();
+    await provTab.click();
+    const banner = page.locator('#pol-pane-provisioning .ent-banner[data-ent-feature="scim"]');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText(/scim/i);
+  });
+});

--- a/mcp-server/src/enterprise-gate.test.ts
+++ b/mcp-server/src/enterprise-gate.test.ts
@@ -16,6 +16,8 @@ import {
   authorizeAdmin,
   featureEntitled,
   inspectEnforceEntitled,
+  entitledFeatures,
+  ENTITLEABLE_FEATURES,
   _resetEnterpriseGate,
 } from "./enterprise-gate.js";
 
@@ -86,6 +88,17 @@ describe("enterprise-gate — OFF (no opt-in, published-artifact state)", () => 
       assert.equal(await featureEntitled(feature), false, `feature ${feature} must be locked when OFF`);
     }
     assert.equal(await inspectEnforceEntitled(), false, "inspectEnforceEntitled mirrors featureEntitled");
+  });
+
+  it("entitledFeatures returns the full vocabulary, all false when OFF", async () => {
+    clearEnv();
+    const map = await entitledFeatures();
+    // Every known feature is present as a key (so the UI can render a badge
+    // for each) and false on the OSS default.
+    for (const f of ENTITLEABLE_FEATURES) {
+      assert.equal(map[f], false, `feature ${f} must be false when OFF`);
+    }
+    assert.deepEqual(Object.keys(map).sort(), [...ENTITLEABLE_FEATURES].sort());
   });
 
   it("gate state is memoised across calls", async () => {

--- a/mcp-server/src/enterprise-gate.ts
+++ b/mcp-server/src/enterprise-gate.ts
@@ -208,6 +208,33 @@ export async function featureEntitled(feature: string): Promise<boolean> {
   return g.mode === "active" && g.hasFeature(feature);
 }
 
+/** Every entitlement feature the product knows about — the closed vocabulary
+ *  the UI renders lock badges for. Keep in sync with the gates in index.ts. */
+export const ENTITLEABLE_FEATURES = [
+  "access-control",
+  "audit",
+  "inspect-enforce",
+  "sso",
+  "scim",
+  "tenancy",
+] as const;
+
+/**
+ * Resolve every known feature to whether it is currently entitled — one flat
+ * map for the UI to drive a consistent lock optic. Default-OFF (no token /
+ * enterprise modules absent) → all false; never throws. This is purely
+ * informational (visibility is free); the real enforcement lives in each
+ * feature's own gate.
+ */
+export async function entitledFeatures(): Promise<Record<string, boolean>> {
+  if (!gatePromise) gatePromise = buildGate();
+  const g = await gatePromise;
+  const active = g.mode === "active";
+  const out: Record<string, boolean> = {};
+  for (const f of ENTITLEABLE_FEATURES) out[f] = active && g.hasFeature(f);
+  return out;
+}
+
 /** Gate mode — for diagnostics (/api/info). */
 export async function enterpriseGateStatus(): Promise<{
   active: boolean;

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -23,6 +23,7 @@ import {
   updateCatalog,
   inspectEnforceEntitled,
   featureEntitled,
+  entitledFeatures,
 } from "./enterprise-gate.js";
 import {
   loadCredentials,
@@ -1570,6 +1571,10 @@ async function main() {
   // once here so both /api/info and the route-mount block agree.
   const scimConfigured = !!process.env.OMCP_SCIM_TOKEN?.trim();
   const scimEntitled = scimConfigured && (await featureEntitled("scim"));
+  // One flat map of every entitled feature → bool, surfaced on /api/info so
+  // the UI can render a consistent lock optic. Resolved once at boot (the
+  // entitlement token is read at startup and never changes at runtime).
+  const entitlements = await entitledFeatures();
   let inspectBootMode = bootMode(process.env.OMCP_INSPECT);
   if (inspectBootMode === "enforce" && !inspectEnforceAllowed) {
     console.warn("[inspect] OMCP_INSPECT=enforce requires an entitlement (inspect-enforce); running in dry-run.");
@@ -1966,6 +1971,10 @@ async function main() {
         // server is running, so the `tenancy` entitlement is necessarily
         // present — an unentitled multi-tenant config fails closed at boot.
         multiTenant: tenancyConfigured,
+        // Per-feature entitlement map ({ "access-control": bool, audit, sso,
+        // scim, tenancy, "inspect-enforce" }) so the UI shows a lock badge on
+        // every entitled feature. All false on the OSS default (no token).
+        entitlements,
         federationUpstreams: (process.env.OMCP_FEDERATION_UPSTREAMS ?? "")
           .split(",").map((s) => s.trim()).filter(Boolean).length,
       },

--- a/mcp-server/src/ui/index.html
+++ b/mcp-server/src/ui/index.html
@@ -1440,6 +1440,18 @@
     .pg-seg button + button { border-left:1px solid var(--border); }
     .pg-seg button.active { background:var(--surface-3); color:var(--text); font-weight:600; }
     .pg-seg button.locked { color:var(--text-dim); }
+    /* Entitlement lock optic — consistent across every enterprise feature.
+       The nav badge sits after the label; the page banner explains the lock. */
+    .nav-btn .ent-lock { margin-left:auto; font-size:11px; opacity:.65; flex:0 0 auto; }
+    .nav-btn.ent-locked .nav-label { opacity:.7; }
+    .ent-banner { display:flex; gap:10px; align-items:flex-start; margin:0 0 16px; padding:11px 14px;
+      border:1px solid var(--border); border-left:3px solid var(--accent,#6b8afd);
+      background:var(--surface-2,var(--surface)); border-radius:6px; font-size:var(--fs-sm,13px); }
+    .ent-banner .ent-banner-ico { font-size:15px; line-height:1.3; flex:0 0 auto; }
+    .ent-banner b { color:var(--text); }
+    .ent-banner .ent-banner-body { color:var(--text-2,var(--text)); }
+    .ent-banner code { font-family:var(--mono); font-size:12px; background:var(--bg); padding:1px 5px; border-radius:3px; }
+    .pol-subtab .ent-lock { margin-left:5px; font-size:10px; opacity:.65; }
     /* JSON: two tones only — keys at full strength, scalars muted. */
     .pg-json { white-space:pre-wrap; font-family:var(--mono); font-size:12px; background:var(--bg); padding:12px; border:1px solid var(--border); border-radius:4px; max-height:540px; overflow:auto; margin:0; color:var(--text-3,#8a93a5); }
     .pg-json .k { color:var(--text); }
@@ -2078,6 +2090,10 @@
         </div>
         <div class="ph-actions"><button class="btn btn-primary btn-sm" onclick="entEditNew('rbac')">+ New role</button><button class="btn btn-sm" id="ent-rbac-editbtn" onclick="entEditOpen('rbac')">Edit policy</button></div>
       </div>
+      <div class="ent-banner" data-ent-feature="access-control" style="display:none">
+        <span class="ent-banner-ico">🔒</span>
+        <div class="ent-banner-body"><b>Enterprise feature.</b> Enforcing role-based access control requires an entitlement (<code>access-control</code>). You can review the configuration freely; rules only take effect with a license. <a href="#" onclick="showPage('entitlement');return false;">View entitlement →</a></div>
+      </div>
       <div class="card gov-overview">
         <div class="card-header"><h2>How governance fits together</h2></div>
         <div class="gov-flow">
@@ -2253,6 +2269,10 @@ curl -X PUT http://localhost:3000/api/enterprise/policy \
           <div class="gov-sub">Which tools a credential is <em>offered</em> (packaging). Distinct from <b>Policies</b>, which decide what's <em>permitted</em>.</div>
         </div>
       </div>
+      <div class="ent-banner" data-ent-feature="access-control" style="display:none">
+        <span class="ent-banner-ico">🔒</span>
+        <div class="ent-banner-body"><b>Enterprise feature.</b> Governed context products are enforced with an entitlement (<code>access-control</code>). You can define products here; the binding only filters <code>tools/list</code> with a license. <a href="#" onclick="showPage('entitlement');return false;">View entitlement →</a></div>
+      </div>
 
       <!-- Primary surface: MCP Products via /api/products (RBAC-gated). -->
       <div class="card" id="mcp-products-card">
@@ -2349,6 +2369,10 @@ curl -X PUT http://localhost:3000/api/enterprise/catalog \
           <div class="gov-sub">What a role is <em>allowed</em> to call at all — coarse RBAC (resource × action). Distinct from <b>Inspect</b>, which judges whether a call is <em>normal</em>.</div>
         </div>
         <div class="ph-actions"><span id="pol-engine" class="badge"></span></div>
+      </div>
+      <div class="ent-banner" data-ent-feature="access-control" style="display:none">
+        <span class="ent-banner-ico">🔒</span>
+        <div class="ent-banner-body"><b>Enterprise feature.</b> The policy engine enforces verdicts with an entitlement (<code>access-control</code>). Roles and bindings are editable here; they only gate calls with a license. <a href="#" onclick="showPage('entitlement');return false;">View entitlement →</a></div>
       </div>
 
       <!-- Engine banner — colour + copy distinguishes editable file
@@ -2513,6 +2537,10 @@ curl -X PUT http://localhost:3000/api/enterprise/catalog \
       <!-- Provisioning sub-tab (C2b) — read-only view of the SCIM-provisioned
            Users/Groups an identity provider has pushed via /scim/v2. -->
       <div class="card pol-pane" id="pol-pane-provisioning" role="tabpanel" hidden>
+        <div class="ent-banner" data-ent-feature="scim" style="display:none">
+          <span class="ent-banner-ico">🔒</span>
+          <div class="ent-banner-body"><b>Enterprise feature.</b> SCIM 2.0 provisioning requires an entitlement (<code>scim</code>). With <code>OMCP_SCIM_TOKEN</code> set but unlicensed, the <code>/scim/v2</code> routes are not mounted (fail-closed). <a href="#" onclick="showPage('entitlement');return false;">View entitlement →</a></div>
+        </div>
         <div class="card-header"><h2>Provisioning
           <button class="info" aria-label="About provisioning"
             data-title="SCIM provisioning"
@@ -2580,6 +2608,10 @@ curl -X PUT http://localhost:3000/api/enterprise/catalog \
           <div class="gov-sub">An append-only, tamper-evident record of every mutating action — who did what, when.</div>
         </div>
         <div class="ph-actions"><span id="ent-chain"></span></div>
+      </div>
+      <div class="ent-banner" data-ent-feature="audit" style="display:none">
+        <span class="ent-banner-ico">🔒</span>
+        <div class="ent-banner-body"><b>Enterprise feature.</b> The tamper-evident audit log requires an entitlement (<code>audit</code>). Without it, decisions are not recorded to the hash-chained sink. <a href="#" onclick="showPage('entitlement');return false;">View entitlement →</a></div>
       </div>
       <div class="card">
         <div class="card-header"><h2>Recent decisions
@@ -7526,10 +7558,46 @@ function loadingBlock(label) {
 }
 async function refresh(){await Promise.all([loadSources(),loadServices(),loadDashUsage()]);}
 
+// Entitlement lock optic. /api/info.governance.entitlements is a flat
+// { feature: bool } map; all false on the OSS default. We render a consistent
+// 🔒 badge + explanatory banner on every entitled feature so the enterprise
+// surface reads as "visible but locked" rather than silently inert. Purely
+// informational — the real enforcement is server-side and fail-closed.
+window.__entitlements = window.__entitlements || {};
+function omcpFeatureLocked(feature){ return !window.__entitlements[feature]; }
+// nav-rail page → required feature
+const ENT_NAV_FEATURES = { products:'access-control', access:'access-control', policies:'access-control', audit:'audit' };
+function applyEntitlementLocks(gov){
+  window.__entitlements = (gov && gov.entitlements) || {};
+  // 1. Nav-rail badges.
+  for(const page in ENT_NAV_FEATURES){
+    const btn=document.querySelector(`.nav-btn[data-page="${page}"]`);
+    if(!btn) continue;
+    const locked=omcpFeatureLocked(ENT_NAV_FEATURES[page]);
+    btn.classList.toggle('ent-locked', locked);
+    let lk=btn.querySelector('.ent-lock');
+    if(locked && !lk){ lk=document.createElement('span'); lk.className='ent-lock'; lk.textContent='🔒'; lk.setAttribute('aria-label','Enterprise feature — requires an entitlement'); lk.title='Enterprise feature — requires an entitlement'; btn.appendChild(lk); }
+    else if(!locked && lk){ lk.remove(); }
+  }
+  // 2. Page / sub-tab banners (declarative: any [data-ent-feature]).
+  document.querySelectorAll('.ent-banner[data-ent-feature]').forEach(el=>{
+    el.style.display=omcpFeatureLocked(el.getAttribute('data-ent-feature'))?'flex':'none';
+  });
+  // 3. Provisioning sub-tab badge (SCIM).
+  const provTab=document.querySelector('.pol-subtab[data-pol-tab="provisioning"]');
+  if(provTab){
+    const locked=omcpFeatureLocked('scim');
+    let lk=provTab.querySelector('.ent-lock');
+    if(locked && !lk){ lk=document.createElement('span'); lk.className='ent-lock'; lk.textContent='🔒'; provTab.appendChild(lk); }
+    else if(!locked && lk){ lk.remove(); }
+  }
+}
+
 async function loadInfo(){
   try{
     const r=await fetch('/api/info'); if(!r.ok) return;
     const d=await r.json();
+    try{ applyEntitlementLocks(d.governance); }catch(e){/* lock optic is best-effort */}
     const footer=document.getElementById('info-footer');
     if(!footer) return;
     const plugins=(d.plugins||[]).map(p=>`<span class="footer-pill">${esc(p.name)}<span class="footer-pill-meta">${esc(p.source)}${p.version?` · ${esc(p.version)}`:''}</span></span>`).join('');


### PR DESCRIPTION
## What

Enterprise/entitled features now read as **visible but locked** in the UI when there's no license — instead of silently doing nothing. A consistent 🔒 badge + an explanatory banner appears on each entitled surface, naming the required entitlement.

| Surface | Required entitlement |
|---------|----------------------|
| Access Control, Policies, Products | `access-control` |
| Audit Log | `audit` |
| Provisioning (SCIM) sub-tab | `scim` |
| Inspect → Enforce | `inspect-enforce` (keeps its existing lock) |

`sso` / `tenancy` have no nav surface and fail closed at boot, so there's nothing to lock in the UI.

## How

- **Backend:** `enterprise-gate.ts` gains `entitledFeatures()` — a flat `{feature: bool}` map over the fixed `ENTITLEABLE_FEATURES` vocabulary; default-OFF → all false, never throws. Resolved once at boot and surfaced under `/api/info` → `governance.entitlements`.
- **UI:** `applyEntitlementLocks(gov)` (called from `loadInfo`) toggles a 🔒 nav badge (created via `createElement`+`textContent`), declarative `.ent-banner[data-ent-feature]` banners, and the SCIM sub-tab badge — all driven by the server boolean map. No dynamic data reaches `innerHTML` (XSS-clean). Banners are static copy with a "View entitlement →" link.
- **Fail-safe:** an older server without the field → everything shows locked (informational only; real enforcement is server-side).

## Tests

- Unit: `entitledFeatures` all-false-when-OFF + vocabulary completeness (deep-equal keys) — adding a gate without surfacing it fails CI.
- Playwright `entitlement-locks.spec.mjs`: asserts nav badges, per-page banners (each names its `<code>feature</code>`), and the provisioning badge on the live UI; added to the smoke Dockerfile.
- Verified live against the running demo: 3/3 new + 11/11 adjacent (rail/governance/inspect) Playwright tests pass, zero console errors. Backend 18/18 gate tests, tsc clean.
- Reviewer-agent: SHIP (quality + sensitive-data + XSS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)