### PR TITLE
chore(release): v3.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.8.1] — 2026-06-18
+
+Security patch release. Dependency-only — no API, behavior, or configuration
+changes. All affected packages are transitive (pulled via the MCP SDK and the
+OpenTelemetry SDK) and are pinned to patched releases via npm `overrides`.
+
+### Security
+
+- Patch transitive dependency advisories surfaced by code scanning / Dependabot:
+  - **hono** 4.12.23 → 4.12.26 — CVE-2026-54286/54287/54288/54289/54290
+    (serve-static path traversal, CORS credential reflection, Lambda adapter
+    header/cookie handling). Not reachable at runtime — the gateway uses Express,
+    not hono — but the tree is moved onto patched releases to clear the alerts.
+  - **form-data** → 4.0.6 — CVE-2026-12143 (CRLF header injection via unescaped
+    field/filename in `Content-Disposition`).
+  - **protobufjs** → 7.6.4 — CVE-2026-54269 (schema-derived name shadowing,
+    potential DoS on attacker-influenced schemas).
+  - **@opentelemetry/core** → 2.8.0 — CVE-2026-54285 (unbounded memory
+    allocation parsing inbound W3C Baggage headers).
+
 ## [3.8.0] — 2026-06-13
 
 Feature release. Additive / non-breaking — every new control is **default-OFF**,

--- a/examples/agent/package-lock.json
+++ b/examples/agent/package-lock.json
@@ -1082,9 +1082,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/examples/agent/package.json
+++ b/examples/agent/package.json
@@ -18,8 +18,9 @@
   },
   "overrides": {
     "fast-uri": "^3.1.2",
-    "hono": "^4.12.23",
+    "hono": "^4.12.26",
     "ip-address": "^10.2.0",
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "form-data": "^4.0.6"
   }
 }

--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,11 +4,11 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 2.8.0
+version: 2.8.1
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
-appVersion: "3.8.0"
+appVersion: "3.8.1"
 
 home: https://github.com/ThoTischner/observability-mcp
 sources:
@@ -43,7 +43,7 @@ annotations:
       url: https://www.npmjs.com/package/@thotischner/observability-mcp
     - name: Connector Hub
       url: https://thotischner.github.io/observability-mcp/hub/
-  artifacthub.io/containsSecurityUpdates: "false"
+  artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/operator: "false"
   artifacthub.io/prerelease: "false"
   artifacthub.io/signKey: |
@@ -51,14 +51,12 @@ annotations:
     url: https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc
   artifacthub.io/images: |
     - name: observability-mcp
-      image: ghcr.io/thotischner/observability-mcp:3.8.0
+      image: ghcr.io/thotischner/observability-mcp:3.8.1
       platforms:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
     - kind: changed
-      description: "appVersion → 3.8.0 (Inspect — observe/learn/enforce agent behavior); chart points at the 3.8.0 image"
-    - kind: added
-      description: "Inspect: live flow graph + AppArmor-style behavior profile + enforce mode for MCP tool calls. Default observe (zero risk); shapes not payloads; no outbound calls (docs/inspect.md)"
-    - kind: added
-      description: "Entitlement model for enterprise controls (inspect-enforce, sso, scim, tenancy) — all default-OFF=free, fail-closed only when actively configured without the claim"
+      description: "appVersion → 3.8.1; chart points at the 3.8.1 image"
+    - kind: security
+      description: "Patch transitive dependency CVEs: hono 4.12.26 (CVE-2026-54286/54287/54288/54289/54290), form-data 4.0.6 (CVE-2026-12143), protobufjs 7.6.4 (CVE-2026-54269), @opentelemetry/core 2.8.0 (CVE-2026-54285)"

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thotischner/observability-mcp",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",
@@ -771,9 +771,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2052,12 +2052,6 @@
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
@@ -3240,16 +3234,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3508,9 +3502,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3520,9 +3514,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -4111,9 +4105,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
-      "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4123,7 +4117,6 @@
         "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thotischner/observability-mcp",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -86,10 +86,13 @@
   },
   "overrides": {
     "fast-uri": "^3.1.2",
-    "hono": "^4.12.23",
+    "hono": "^4.12.26",
     "ip-address": "^10.2.0",
     "@hono/node-server": "^2.0.2",
     "uuid": "^11.1.1",
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "form-data": "^4.0.6",
+    "protobufjs": "^7.6.4",
+    "@opentelemetry/core": "^2.8.0"
   }
 }

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Security patch release — v3.8.1

Clears the open dependency advisories surfaced by **code scanning (21 alerts)** and **Dependabot (1 alert)**. All affected packages are **transitive** (pulled via the MCP SDK and the OpenTelemetry SDK) and are pinned to patched releases via npm `overrides`. No API, behavior, or configuration changes.

### CVEs patched
| Package | From → To | CVE(s) | Notes |
|---|---|---|---|
| hono | 4.12.23 → 4.12.26 | CVE-2026-54286/54287/54288/54289/54290 | serve-static path traversal, CORS credential reflection, Lambda adapter header/cookie handling. **Not reachable** — gateway uses Express, not hono — but moved onto patched releases to clear the alerts. |
| form-data | → 4.0.6 | CVE-2026-12143 (high) | CRLF header injection via unescaped field/filename in `Content-Disposition`. |
| protobufjs | → 7.6.4 | CVE-2026-54269 | schema-derived name shadowing → DoS on attacker-influenced schemas. |
| @opentelemetry/core | → 2.8.0 | CVE-2026-54285 | unbounded memory allocation parsing inbound W3C Baggage headers. |

The duplicate `app/node_modules/...` findings are the same CVEs seen from the Docker build context (`/app`); regenerating the lockfiles resolves them too.

### Changes
- `mcp-server/package.json` + `examples/agent/package.json`: bumped `overrides`, lockfiles regenerated.
- Version bump: mcp-server `3.8.0 → 3.8.1`, Helm chart `2.8.0 → 2.8.1` (appVersion `3.8.1`), ArtifactHub annotations refreshed (`containsSecurityUpdates: true`, image tag `3.8.1`, security changes block).
- CHANGELOG `[3.8.1]`.

### Verification
- `tsc --noEmit` clean (mcp-server + agent).
- Full unit suite: **972 pass / 0 fail** (45 skipped).
- Lockfiles: single resolved copy of each package at the fixed version, no stale nested copies.
- Reviewer agent: **SHIP** (override↔lock consistency, scope = 4 dep files only, no sensitive data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)