### PR TITLE
chore(release): v3.8.2

### DIFF
--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,11 +4,11 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 2.8.1
+version: 2.8.2
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
-appVersion: "3.8.1"
+appVersion: "3.8.2"
 
 home: https://github.com/ThoTischner/observability-mcp
 sources:
@@ -51,7 +51,7 @@ annotations:
     url: https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc
   artifacthub.io/images: |
     - name: observability-mcp
-      image: ghcr.io/thotischner/observability-mcp:3.8.1
+      image: ghcr.io/thotischner/observability-mcp:3.8.2
       platforms:
         - linux/amd64
         - linux/arm64

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@thotischner/observability-mcp",
-      "version": "3.8.1",
+      "version": "3.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^1.4.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Automated weekly release.

- Bumps `mcp-server/package.json` to `v3.8.2`
- Bumps Helm chart: `appVersion` → `v3.8.2`, chart `version` → `2.8.2` (builtin connectors ship in the server image, so the chart is released in lockstep)
- Previous tag: `v3.8.1`
- Auto-merge is enabled — GitHub will squash-merge as soon as all required checks pass. Merging triggers `tag-on-release.yml`, which pushes the tag and fans out to `release.yml`, `docker-publish.yml`, `npm-publish.yml`, and `helm-release.yml`.