### PR TITLE
chore(release): v3.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.8.3] — 2026-06-23
+
+Bug-fix release. No API or configuration changes.
+
+### Fixed
+
+- **`enrich_ips` (RDAP): rate-limited lookups no longer masquerade as true
+  negatives (#523).** A burst of lookups gets throttled by the upstream RIRs;
+  previously every throttled lookup returned `found:false` and was cached as a
+  negative — indistinguishable from "this IP is not in any registry", which made
+  the documented triage recipe silently unreliable at realistic batch sizes.
+  RDAP lookups now resolve to an explicit outcome: `ok`, `not_found` (a genuine,
+  cacheable negative — HTTP 404 or a 2xx with no enrichment), or `transient`
+  (throttle/429-403, 5xx, timeout, network error). Transient failures are
+  **never cached** and are retried with bounded exponential backoff (honoring a
+  capped `Retry-After`). A throttled IP is now reported as `found:false` +
+  `transient:true` + `error` (e.g. `"rate_limited"`), counted in
+  `summary.transient` separately from `summary.unmatched`, with a top-level
+  `note` — so an agent can retry rather than treat the IP as unknown/suspicious.
+
+## [3.8.2] — 2026-06-23
+
+Maintenance release. Dependency bumps only (OpenTelemetry SDK and dev
+dependencies via Dependabot); no API, behavior, or configuration changes.
+
 ## [3.8.1] — 2026-06-18
 
 Security patch release. Dependency-only — no API, behavior, or configuration

--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,11 +4,11 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 2.8.2
+version: 2.8.3
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
-appVersion: "3.8.2"
+appVersion: "3.8.3"
 
 home: https://github.com/ThoTischner/observability-mcp
 sources:
@@ -51,12 +51,12 @@ annotations:
     url: https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc
   artifacthub.io/images: |
     - name: observability-mcp
-      image: ghcr.io/thotischner/observability-mcp:3.8.2
+      image: ghcr.io/thotischner/observability-mcp:3.8.3
       platforms:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
     - kind: changed
-      description: "appVersion → 3.8.1; chart points at the 3.8.1 image"
-    - kind: security
-      description: "Patch transitive dependency CVEs: hono 4.12.26 (CVE-2026-54286/54287/54288/54289/54290), form-data 4.0.6 (CVE-2026-12143), protobufjs 7.6.4 (CVE-2026-54269), @opentelemetry/core 2.8.0 (CVE-2026-54285)"
+      description: "appVersion → 3.8.3; chart points at the 3.8.3 image"
+    - kind: fixed
+      description: "enrich_ips (RDAP): a rate-limited / transient lookup no longer masquerades as a confirmed negative — it is marked transient:true (never cached) and counted separately, with bounded retry + backoff (issue #523)"

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Bug-fix release — v3.8.3

Ships the **#523** fix (`enrich_ips` RDAP rate-limit vs true negative), which landed on `main` after v3.8.2 (a Dependabot dep-bump release) had already been tagged.

### Changes
- Version bump: mcp-server `3.8.2 → 3.8.3`, Helm chart `2.8.2 → 2.8.3` (appVersion `3.8.3`).
- ArtifactHub `changes` block refreshed (was stale at `3.8.1`) → now describes the #523 fix; image tag `3.8.3`.
- CHANGELOG: added `[3.8.3]` (the #523 fix) and backfilled the missing `[3.8.2]` (dependency-bump release).

### Included fix (already merged to main, #524)
`enrich_ips` RDAP lookups now resolve to `ok` / `not_found` (genuine, cached) / `transient` (throttle/5xx/timeout/network — never cached, retried with capped backoff). A throttled IP is surfaced as `found:false` + `transient:true` + `error`, counted in `summary.transient`, with a top-level `note`. Closes #523.

🤖 Generated with [Claude Code](https://claude.com/claude-code)