### PR TITLE
feat(rbac): per-credential tool allow-list (OMCP_KEY_TOOLS)

### DIFF
--- a/docs/products.md
+++ b/docs/products.md
@@ -149,6 +149,37 @@ Product's `tools` list and re-saving the file takes effect on the
 **next** `/mcp` session, no server restart needed. Live sessions
 keep the snapshot they were created with.
 
+## Per-credential tool allow-list (`OMCP_KEY_TOOLS`)
+
+When you only need to scope one API key to a handful of tools — without
+authoring a whole Product — set `OMCP_KEY_TOOLS`. It is the tool-axis
+counterpart to the per-credential source allow-list `OMCP_KEY_SOURCES`
+and shares its grammar (`name=tool1|tool2;name2=tool3`):
+
+```bash
+OMCP_API_KEYS="agent:tok_a,ci:tok_b"
+# agent may only call these two tools; ci only list_services.
+OMCP_KEY_TOOLS="agent=query_logs|get_service_health;ci=list_services"
+```
+
+The credential's `/mcp` `tools/list` (and dispatch) is scoped to exactly
+the named tools; unknown names are skipped at registration like the
+Product path. A credential not listed in `OMCP_KEY_TOOLS` sees every
+registered tool — the back-compat default.
+
+**Composition with Products.** The per-credential list and a bound
+Product's `tools` list are two **independent** allow-list axes. A tool
+must pass **both** to be registered, so they compose by intersection —
+the more restrictive wins. If the two are disjoint, the credential can
+call *nothing* (each axis denies what the other allows), which is the
+intended fail-closed behaviour for a mis-scoped binding. An unset axis
+imposes no restriction on its own.
+
+`OMCP_KEY_TOOLS` is read at startup (like the rest of the credential
+config); change it and restart. The secret-free `GET /api/subjects`
+admin view surfaces each key's `allowedTools` alongside `allowedSources`
+and `productId`.
+
 ## UI
 
 The Products tab on the Web UI hosts a live table driven by

--- a/mcp-server/src/auth/credentials.test.ts
+++ b/mcp-server/src/auth/credentials.test.ts
@@ -20,7 +20,7 @@ describe("single-tenant auth primitive", () => {
     assert.equal(creds.length, 2);
     assert.deepEqual(
       creds[0],
-      { name: "ci", token: "tok_abc", allowedSources: undefined, bypassRedaction: undefined, allowRawQuery: undefined, tenant: undefined, productId: undefined }
+      { name: "ci", token: "tok_abc", allowedSources: undefined, bypassRedaction: undefined, allowRawQuery: undefined, tenant: undefined, productId: undefined, allowedTools: undefined }
     );
     assert.equal(creds[1].name, "key");
     assert.equal(creds[1].token, "tok_bare");
@@ -33,6 +33,17 @@ describe("single-tenant auth primitive", () => {
     });
     assert.deepEqual(creds[0].allowedSources, ["prom-prod", "loki-prod"]);
     assert.deepEqual(creds[1].allowedSources, ["prom-staging"]);
+  });
+
+  it("parses per-key tool allow-list (OMCP_KEY_TOOLS)", () => {
+    const creds = loadCredentials({
+      OMCP_API_KEYS: "agent:tok1,ci:tok2,full:tok3",
+      OMCP_KEY_TOOLS: "agent=query_logs|get_service_health; ci=list_services",
+    });
+    assert.deepEqual(creds.find((c) => c.name === "agent")?.allowedTools, ["query_logs", "get_service_health"]);
+    assert.deepEqual(creds.find((c) => c.name === "ci")?.allowedTools, ["list_services"]);
+    // Unlisted key → undefined (no restriction, back-compat), not [].
+    assert.equal(creds.find((c) => c.name === "full")?.allowedTools, undefined);
   });
 
   it("parses OMCP_KEY_BYPASS_REDACTION → flags only the listed names", () => {

--- a/mcp-server/src/auth/credentials.ts
+++ b/mcp-server/src/auth/credentials.ts
@@ -33,10 +33,21 @@
  *                  # tools list = no restriction). Unlisted keys see
  *                  # every registered tool — back-compat with the
  *                  # pre-Products world. See docs/products.md.
+ *   OMCP_KEY_TOOLS="agent=query_logs|get_service_health;ci=list_services"
+ *                  # optional per-key tool allow-list — same shape as
+ *                  # OMCP_KEY_SOURCES. When set, the credential's /mcp
+ *                  # tools/list (and dispatch) is scoped to exactly these
+ *                  # tool names. Composes with a bound Product by
+ *                  # INTERSECTION (most-restrictive wins). Unlisted keys
+ *                  # see every registered tool — back-compat. This is the
+ *                  # per-credential, source-symmetric counterpart to the
+ *                  # Product bundle: scope one API key to a few tools
+ *                  # without authoring a Product. See docs/products.md
+ *                  # ("Per-credential tool allow-list").
  *
- * Rich role-based access control (tools/services/lookback/read-only, the
- * full governance object) is intentionally NOT here — this is only the
- * authentication + identity + coarse source-scoping primitive.
+ * Rich role-based access control (services/lookback/read-only, the full
+ * governance object) is intentionally NOT here — this is the authentication
+ * + identity + coarse source/tool-scoping primitive.
  */
 
 import { parseKeyTenants } from "../tenancy/context.js";
@@ -61,6 +72,11 @@ export interface Credential {
    *  is filtered to the Product's `tools` allow-list. Resolved against
    *  the credential's tenant so cross-tenant Products don't leak. */
   productId?: string;
+  /** Per-credential tool allow-list (OMCP_KEY_TOOLS). When set, /mcp
+   *  tools/list and dispatch are scoped to these tool names; composes
+   *  with a bound Product by intersection (most-restrictive wins).
+   *  Undefined → no per-credential tool restriction (back-compat). */
+  allowedTools?: string[];
 }
 
 function parseKeySources(raw: string | undefined): Map<string, string[]> {
@@ -107,6 +123,8 @@ export function loadCredentials(env: NodeJS.ProcessEnv = process.env): Credentia
   const rawQueryNames = parseBypassSet(env.OMCP_KEY_RAW_QUERY);
   const keyTenants = parseKeyTenants(env.OMCP_KEY_TENANTS);
   const keyProducts = parseKeyProducts(env.OMCP_KEY_PRODUCTS);
+  // OMCP_KEY_TOOLS shares the OMCP_KEY_SOURCES grammar (`name=a|b;name2=c`).
+  const keyTools = parseKeySources(env.OMCP_KEY_TOOLS);
   const creds: Credential[] = [];
   for (const part of raw.split(",").map((s) => s.trim()).filter(Boolean)) {
     const idx = part.indexOf(":");
@@ -121,6 +139,7 @@ export function loadCredentials(env: NodeJS.ProcessEnv = process.env): Credentia
       allowRawQuery: rawQueryNames.has(name) || undefined,
       tenant: keyTenants.get(name) || undefined,
       productId: keyProducts.get(name) || undefined,
+      allowedTools: keyTools.get(name),
     });
   }
   return creds;

--- a/mcp-server/src/context.test.ts
+++ b/mcp-server/src/context.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { allowsTool, defaultContext, principalContext } from "./context.js";
+import { allowsTool, intersectAllowed, defaultContext, principalContext } from "./context.js";
 
 test("allowsTool — undefined allow-list = no Product binding = every tool allowed", () => {
   assert.equal(allowsTool(undefined, "list_sources"), true);
@@ -18,6 +18,50 @@ test("allowsTool — non-empty allow-list gates by exact match", () => {
   assert.equal(allowsTool(allow, "query_metrics"), true);
   assert.equal(allowsTool(allow, "query_logs"), false);
   assert.equal(allowsTool(allow, "get_topology"), false);
+});
+
+// intersectAllowed folds a per-credential list (OMCP_KEY_TOOLS) with a Product
+// list — most-restrictive wins.
+test("intersectAllowed — either side undefined returns the other (no widening)", () => {
+  assert.equal(intersectAllowed(undefined, undefined), undefined);
+  assert.deepEqual(intersectAllowed(["a", "b"], undefined), ["a", "b"]);
+  assert.deepEqual(intersectAllowed(undefined, ["a", "b"]), ["a", "b"]);
+});
+
+test("intersectAllowed — both set → intersection only", () => {
+  assert.deepEqual(intersectAllowed(["query_logs", "list_services"], ["query_logs", "get_topology"]), ["query_logs"]);
+  // Disjoint → empty list: the credential can call nothing through that binding.
+  assert.deepEqual(intersectAllowed(["query_logs"], ["get_topology"]), []);
+  // Order follows the first (credential) list.
+  assert.deepEqual(intersectAllowed(["b", "a"], ["a", "b"]), ["b", "a"]);
+});
+
+// The registration gate ANDs two independent allowsTool axes (Product +
+// per-credential OMCP_KEY_TOOLS). This is what makes disjoint lists deny
+// everything WITHOUT routing through an overloaded empty intersection — an
+// empty `[]` would be read by allowsTool as "allow all", which is why the two
+// axes are kept separate rather than pre-intersected into one list.
+function passesGate(productTools: string[] | undefined, credTools: string[] | undefined, name: string): boolean {
+  return allowsTool(productTools, name) && allowsTool(credTools, name);
+}
+
+test("two-axis gate — disjoint Product and credential lists deny every tool", () => {
+  // Product allows get_topology; credential allows only query_logs → nothing passes.
+  assert.equal(passesGate(["get_topology"], ["query_logs"], "query_logs"), false);
+  assert.equal(passesGate(["get_topology"], ["query_logs"], "get_topology"), false);
+});
+
+test("two-axis gate — credential list narrows within an unrestricted Product axis", () => {
+  assert.equal(passesGate(undefined, ["query_logs"], "query_logs"), true);
+  assert.equal(passesGate(undefined, ["query_logs"], "get_topology"), false);
+});
+
+test("two-axis gate — overlapping lists allow only the overlap", () => {
+  const product = ["query_logs", "get_topology", "list_services"];
+  const cred = ["query_logs", "list_services"];
+  assert.equal(passesGate(product, cred, "query_logs"), true);
+  assert.equal(passesGate(product, cred, "list_services"), true);
+  assert.equal(passesGate(product, cred, "get_topology"), false); // in Product, not in credential
 });
 
 test("allowsTool — case-sensitive (matches MCP spec)", () => {

--- a/mcp-server/src/context.ts
+++ b/mcp-server/src/context.ts
@@ -43,6 +43,12 @@ export interface RequestContext {
    *  Anonymous + Product-less credentials leave this unset and see
    *  every registered tool. */
   allowedTools?: string[];
+  /** Per-credential tool allow-list (OMCP_KEY_TOOLS) — a SEPARATE axis from
+   *  the Product `allowedTools`. The registration gate requires a tool to
+   *  pass BOTH (each via allowsTool, undefined = no restriction), so the two
+   *  compose by intersection without overloading the empty-list semantics.
+   *  Unset for anonymous + unscoped credentials. */
+  credentialTools?: string[];
   /** Correlates all tool calls within one transport request/session. */
   correlationId: string;
 }
@@ -69,7 +75,7 @@ export function defaultContext(opts: { allowBypassRedaction?: boolean } = {}): R
 export function principalContext(
   principalId: string,
   allowedSources?: string[],
-  opts: { allowBypassRedaction?: boolean; allowRawQuery?: boolean; tenant?: string; allowedTools?: string[] } = {},
+  opts: { allowBypassRedaction?: boolean; allowRawQuery?: boolean; tenant?: string; allowedTools?: string[]; credentialTools?: string[] } = {},
 ): RequestContext {
   return {
     principalId,
@@ -79,6 +85,7 @@ export function principalContext(
     allowRawQuery: opts.allowRawQuery || undefined,
     tenant: normaliseTenant(opts.tenant),
     allowedTools: opts.allowedTools && opts.allowedTools.length > 0 ? opts.allowedTools : undefined,
+    credentialTools: opts.credentialTools && opts.credentialTools.length > 0 ? opts.credentialTools : undefined,
     correlationId: randomUUID(),
   };
 }
@@ -117,4 +124,24 @@ export function sessionContext(
 export function allowsTool(allowedTools: string[] | undefined, toolName: string): boolean {
   if (!allowedTools || allowedTools.length === 0) return true;
   return allowedTools.includes(toolName);
+}
+
+/** Combine two tool allow-lists into the effective (most-restrictive) one.
+ *  Both lists NARROW access, so the result is their intersection:
+ *    - either side undefined → the other side wins (an absent list means
+ *      "no restriction", so it can't tighten the other).
+ *    - both set → only tools present in BOTH survive (so a per-credential
+ *      OMCP_KEY_TOOLS list and a bound Product's `tools` list compose
+ *      without one silently widening the other; an empty intersection
+ *      means the credential can call nothing through that binding).
+ *  Used to fold the per-credential allow-list together with the Product
+ *  allow-list at request entry. */
+export function intersectAllowed(
+  a: string[] | undefined,
+  b: string[] | undefined,
+): string[] | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  const bSet = new Set(b);
+  return a.filter((t) => bSet.has(t));
 }

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { loadConfig, saveConfig, DEFAULT_HEALTH_THRESHOLDS, DEFAULT_SETTINGS } from "./config/loader.js";
 import { ConnectorRegistry, getSupportedTypes } from "./connectors/registry.js";
 import { isTopologyProvider } from "./connectors/interface.js";
-import { defaultContext, principalContext, sessionContext, allowsTool, type RequestContext } from "./context.js";
+import { defaultContext, principalContext, sessionContext, allowsTool, intersectAllowed, type RequestContext } from "./context.js";
 import { parseKeyTenants, isMultiTenantConfigured } from "./tenancy/context.js";
 import {
   enforceEntitledAccess,
@@ -475,7 +475,13 @@ async function main() {
   // reaches the caller. When no hooks are registered (the default in
   // the OSS demo) the wrapper is a thin pass-through.
   const registerTool = ((name: string, ...rest: unknown[]) => {
-    if (!allowsTool(ctx.allowedTools, name)) return undefined as never;
+    // Two independent allow-list axes must BOTH pass: the Product binding
+    // (ctx.allowedTools, OMCP_KEY_PRODUCTS) and the per-credential list
+    // (ctx.credentialTools, OMCP_KEY_TOOLS). Either undefined = no restriction
+    // on that axis; disjoint non-empty lists therefore deny every tool.
+    if (!allowsTool(ctx.allowedTools, name) || !allowsTool(ctx.credentialTools, name)) {
+      return undefined as never;
+    }
     if (rest.length > 0 && typeof rest[rest.length - 1] === "function") {
       const originalHandler = rest[rest.length - 1] as (args: unknown, extra: unknown) => unknown;
       const wrappedHandler = wrapToolHandler(
@@ -2186,6 +2192,7 @@ async function main() {
       productId?: string;
       bypassRedaction: boolean;
       allowedSources?: string[];
+      allowedTools?: string[];
     }> = [];
     for (const c of loadCredentials()) {
       apiKeysOut.push({
@@ -2194,6 +2201,7 @@ async function main() {
         productId: c.productId,
         bypassRedaction: !!c.bypassRedaction,
         allowedSources: c.allowedSources,
+        allowedTools: c.allowedTools,
       });
     }
     // OIDC groups → role mappings.
@@ -4012,6 +4020,11 @@ async function main() {
       allowRawQuery: cred.allowRawQuery,
       tenant: cred.tenant,
       allowedTools,
+      // Per-credential tool allow-list (OMCP_KEY_TOOLS) — a SEPARATE axis from
+      // the Product one. The registration gate requires a tool to pass BOTH,
+      // so disjoint lists deny everything without overloading the empty-list
+      // "allow all" semantics allowsTool uses for the Product axis.
+      credentialTools: cred.allowedTools,
     });
   }
 
@@ -4083,16 +4096,6 @@ async function main() {
   // registerTool gate, so the surface a /mcp/v/<slug> client sees is
   // strictly product.tools (intersected with any pre-existing
   // allowedTools the credential already carries).
-  function intersectAllowed(
-    a: string[] | undefined,
-    b: string[] | undefined,
-  ): string[] | undefined {
-    if (!a) return b;
-    if (!b) return a;
-    const bSet = new Set(b);
-    return a.filter((t) => bSet.has(t));
-  }
-
   async function resolveVirtualProduct(
     req: import("express").Request,
     res: import("express").Response,
@@ -4256,6 +4259,7 @@ async function main() {
         allowRawQuery: cred.allowRawQuery,
         tenant: cred.tenant,
         allowedTools,
+        credentialTools: cred.allowedTools,
       }),
       selectedSubprotocol,
     };


### PR DESCRIPTION
Advances the roadmap **Next → "Per-credential access control (RBAC)"** item. The first slices (`OMCP_KEY_RAW_QUERY`, `OMCP_KEY_SOURCES`) already shipped; this adds the **tool axis**.

## What
Scope a single API key to a few tools **without authoring a Product**:
```bash
OMCP_API_KEYS="agent:tok_a,ci:tok_b"
OMCP_KEY_TOOLS="agent=query_logs|get_service_health;ci=list_services"
```
Same grammar as `OMCP_KEY_SOURCES`. The credential's `/mcp` `tools/list` **and** dispatch are scoped to the named tools.

## Design — two independent allow-list axes (fail-closed)
The per-request registration gate now requires a tool to pass **both**:
```js
allowsTool(ctx.allowedTools, name)   // Product axis (OMCP_KEY_PRODUCTS)
  && allowsTool(ctx.credentialTools, name)  // credential axis (OMCP_KEY_TOOLS)
```
- Either axis `undefined` → no restriction on that axis (an unlisted credential / no Product sees everything — **default-OFF, back-compat**).
- **Disjoint** non-empty lists → every tool denied (**fail-closed**). Kept as two separate checks deliberately: a single pre-intersected `[]` would be read by `allowsTool` as *allow-all* — the trap this avoids.
- The axis can only **narrow**, never widen, beyond the Product binding.
- Applies to `/mcp`, `/mcp/ws`, and `/mcp/v/<product>` (shared registration wrapper); Playground + federation dispatch route through the same gate — no bypass.
- `GET /api/subjects` surfaces each key's `allowedTools` (secret-free).
- `intersectAllowed` promoted from an inline `index.ts` helper to an exported, unit-tested `context.ts` function (still used by the virtual-product path).

## Tests
Credential parsing (unlisted key → `undefined`, not `[]`), `intersectAllowed`, and the two-axis gate (disjoint denies all / credential narrows within unrestricted Product / overlap allows only the overlap). Full suite **985 pass / 0 fail**.

Security reviewer agent: **SHIP** — verified default-OFF, fail-closed-on-disjoint, no fail-open via the empty-intersection trap, propagation across both transports + virtual products, and all three dispatch surfaces gated with no bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)