### PR TITLE
chore(release): v3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.9.0] — 2026-06-23
+
+Feature release. Additive / non-breaking — both new controls are **default-OFF**,
+so an existing deployment behaves exactly as before.
+
+### Added
+
+- **Per-credential tool allow-list (`OMCP_KEY_TOOLS`).** Scope a single MCP API
+  key to specific tools without authoring a Product —
+  `OMCP_KEY_TOOLS="agent=query_logs|get_service_health;ci=list_services"` (same
+  grammar as `OMCP_KEY_SOURCES`). Enforced as a second, independent allow-list
+  axis: a tool must pass **both** the credential list and any bound Product's
+  `tools` list, so the two compose by intersection and disjoint lists deny
+  everything (fail-closed). Covers `tools/list` and dispatch across `/mcp`,
+  `/mcp/ws`, and `/mcp/v/<product>`. `GET /api/subjects` surfaces each key's
+  `allowedTools`. Unlisted credentials see every tool (back-compat).
+- **Strict plugin signatures (`PLUGIN_REQUIRE_SIGNATURE`).** A hard-fail variant
+  of `VERIFY_PLUGINS`: when on, a filesystem plugin that is present but cannot be
+  verified (no manifest, malformed/invalid manifest, name mismatch, missing or
+  invalid signature, integrity mismatch) or a missing/unloadable
+  `PLUGIN_TRUST_ROOT` **aborts startup** instead of being silently skipped — so a
+  high-assurance deployment never quietly runs a reduced connector set. Implies
+  `VERIFY_PLUGINS`; builtins are never gated. Wired in Helm via
+  `plugins.verify.requireSignature`. Default-OFF.
+
 ## [3.8.3] — 2026-06-23
 
 Bug-fix release. No API or configuration changes.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -130,11 +130,11 @@ single deployment is a complete MCP control plane. See
 ## Next
 
 - **Sovereign quickstart.** One-command, fully on-prem demo running next to a local model (no external calls), showing analyzed context vs raw queries end to end.
-- **Per-credential access control (RBAC).** Scope a given MCP connection to specific sources, specific tools, read-only, and optional service/metric allow-lists and look-back caps — replacing today's "every session sees everything". (The tenancy layer already isolates per-tenant; this is finer-grained per-credential scoping. First slice: per-credential gating for `raw_query`, today a global `OMCP_RAW_QUERY` flag.)
+- **Per-credential access control (RBAC).** Scope a given MCP connection to specific sources, specific tools, read-only, and optional service/metric allow-lists and look-back caps — replacing today's "every session sees everything". (The tenancy layer already isolates per-tenant; this is finer-grained per-credential scoping.) Shipped so far: per-credential `raw_query` gating (`OMCP_KEY_RAW_QUERY`), source allow-list (`OMCP_KEY_SOURCES`), and tool allow-list (`OMCP_KEY_TOOLS`, v3.9.0). Still open: read-only mode, service/metric allow-lists, and look-back caps.
 - **More built-in connectors.** Grafana Mimir / Cortex, VictoriaMetrics, OpenSearch / Elasticsearch logs, OpenTelemetry, **Datadog** (read-only). Driven by user demand — see [discussion #97](https://github.com/ThoTischner/observability-mcp/discussions/97).
 - **Framework adapters.** Thin wrappers so users on LangChain / LlamaIndex can register the tools without learning the MCP transport directly.
 - **Claude Skill.** Publish observability-mcp as an [Anthropic Skill](https://docs.anthropic.com/en/docs/build-with-claude/skills).
-- **Plugin signature verification at load.** A `PLUGIN_REQUIRE_SIGNATURE=true` mode rejecting unsigned tarballs at load time (Sigstore keyless OIDC) — building on the default-on signing already shipped.
+- ✅ **Plugin signature verification at load (strict mode).** Shipped in v3.9.0: `PLUGIN_REQUIRE_SIGNATURE=true` (Helm `plugins.verify.requireSignature`) turns the default fail-closed *silent skip* of an unverifiable filesystem plugin into a hard startup failure, against the local offline trust root. (Sigstore keyless OIDC stays out by design — an air-gapped site can't reach a transparency log; see [`docs/plugin-architecture.md`](docs/plugin-architecture.md).)
 
 ## Later
 

--- a/helm/observability-mcp/Chart.yaml
+++ b/helm/observability-mcp/Chart.yaml
@@ -4,11 +4,11 @@ description: Unified observability gateway for AI agents — one MCP server for 
 type: application
 
 # Chart version (this chart). Bumped on chart changes.
-version: 2.8.3
+version: 2.9.0
 
 # App version (the mcp-server image tag the chart defaults to).
 # Update with each release of the mcp-server image.
-appVersion: "3.8.3"
+appVersion: "3.9.0"
 
 home: https://github.com/ThoTischner/observability-mcp
 sources:
@@ -51,12 +51,14 @@ annotations:
     url: https://raw.githubusercontent.com/ThoTischner/observability-mcp/main/docs/helm-signing.pub.asc
   artifacthub.io/images: |
     - name: observability-mcp
-      image: ghcr.io/thotischner/observability-mcp:3.8.3
+      image: ghcr.io/thotischner/observability-mcp:3.9.0
       platforms:
         - linux/amd64
         - linux/arm64
   artifacthub.io/changes: |
     - kind: changed
-      description: "appVersion → 3.8.3; chart points at the 3.8.3 image"
-    - kind: fixed
-      description: "enrich_ips (RDAP): a rate-limited / transient lookup no longer masquerades as a confirmed negative — it is marked transient:true (never cached) and counted separately, with bounded retry + backoff (issue #523)"
+      description: "appVersion → 3.9.0; chart points at the 3.9.0 image"
+    - kind: added
+      description: "Per-credential tool allow-list (OMCP_KEY_TOOLS) — scope an API key to specific MCP tools; composes with Products by intersection. Default-OFF."
+    - kind: added
+      description: "Strict plugin signatures (plugins.verify.requireSignature → PLUGIN_REQUIRE_SIGNATURE): a present-but-unverifiable filesystem plugin or missing trust root aborts startup instead of silently skipping. Default-OFF."

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thotischner/observability-mcp",
-  "version": "3.8.3",
+  "version": "3.9.0",
   "description": "Unified observability gateway for AI agents — one MCP server for Prometheus, Loki, and any backend",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Feature release — v3.9.0

Bundles the two reviewed feature slices merged since v3.8.3. Both **default-OFF / non-breaking**.

### Included
- **Per-credential tool allow-list** (`OMCP_KEY_TOOLS`, #526) — scope an API key to specific MCP tools; second fail-closed allow-list axis that composes with Products by intersection.
- **Strict plugin signatures** (`PLUGIN_REQUIRE_SIGNATURE` / Helm `plugins.verify.requireSignature`, #527) — a present-but-unverifiable filesystem plugin or missing trust root aborts startup instead of silently skipping.

### Bumps
- mcp-server `3.8.3 → 3.9.0`, Helm chart `2.8.3 → 2.9.0` (appVersion `3.9.0`), ArtifactHub `images`/`changes` refreshed.
- CHANGELOG `[3.9.0]`; ROADMAP marks per-credential RBAC progress + plugin-signature-at-load shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)